### PR TITLE
refactor(workflows): add coordinate-based identity check to initialize_nova

### DIFF
--- a/docs/diagrams/workflow-initialize-nova.md
+++ b/docs/diagrams/workflow-initialize-nova.md
@@ -11,21 +11,28 @@ flowchart TD
   H --> I["FinalizeJobRunSuccess (EXISTS_AND_LAUNCHED)"]
 
   G -- No --> J[ResolveCandidateAgainstPublicArchives]
-  J --> K{CandidateIsNova?}
 
+  J --> CC[CheckExistingNovaByCoordinates]
+  CC --> CM{CoordinateMatchClassification?}
+
+  CM -- "< 2&quot;" --> UA[UpsertAliasForExistingNova]
+  UA --> H2[PublishIngestNewNova]
+  H2 --> I2["FinalizeJobRunSuccess (EXISTS_AND_LAUNCHED)"]
+
+  CM -- "2&quot;–10&quot;" --> Q[QuarantineHandler]
+  Q --> R[FinalizeJobRunQuarantined]
+
+  CM -- "No match (&gt; 10&quot;)" --> K{CandidateIsNova?}
   K -- No --> L["FinalizeJobRunSuccess (NOT_FOUND)"]
 
   K -- Yes --> M{CandidateIsClassicalNova?}
   M -- No --> N["FinalizeJobRunSuccess (NOT_A_CLASSICAL_NOVA)"]
 
-  M -- Ambiguous --> Q[QuarantineHandler]
-  Q --> R[FinalizeJobRunQuarantined]
-
+  M -- Ambiguous --> Q
   M -- Yes --> O[CreateNovaId]
   O --> P[UpsertMinimalNovaMetadata]
-  P --> H2[PublishIngestNewNova]
-  H2 --> S["FinalizeJobRunSuccess (CREATED_AND_LAUNCHED)"]
+  P --> H3[PublishIngestNewNova]
+  H3 --> S["FinalizeJobRunSuccess (CREATED_AND_LAUNCHED)"]
 
-  %% Terminal failure path (workflow-level)
-  T[TerminalFailHandler] --> U[FinalizeJobRunFailed]
+  TF[TerminalFailHandler] --> FF[FinalizeJobRunFailed]
 ```

--- a/docs/workflows/initialize-nova.md
+++ b/docs/workflows/initialize-nova.md
@@ -13,11 +13,16 @@ Given a `candidate_name` (public name or alias), this workflow:
 **Invariant:** initialize_nova is the ONLY front door when the system has only a name (no `nova_id`).
 Other workflows may be triggered directly when `nova_id` already exists.
 
+---
+
 ## Triggers
 - Operator / manual trigger with `candidate_name`
 - External trigger from upstream systems that only know a name
 
+---
+
 ## Event Contracts
+
 ### Input Event Schema
 - Schema name: `initialize_nova`
 - Schema path: `schemas/events/initialize_nova/latest.json`
@@ -32,7 +37,10 @@ Other workflows may be triggered directly when `nova_id` already exists.
 - On outcome `NOT_FOUND`:
   - No downstream workflow event published (terminal success outcome)
 
+---
+
 ## State Machine (Explicit State List)
+
 1. **ValidateInput** (Pass)
 2. **EnsureCorrelationId** (Choice + Pass)
    - If `correlation_id` missing: generate new UUID
@@ -44,21 +52,40 @@ Other workflows may be triggered directly when `nova_id` already exists.
    - Yes -> **PublishIngestNewNova** -> **FinalizeJobRunSuccess** (outcome = `EXISTS_AND_LAUNCHED`)
    - No  -> continue
 8. **ResolveCandidateAgainstPublicArchives** (Task)
-9. **CandidateIsNova?** (Choice)
+
+9. **CheckExistingNovaByCoordinates** (Task)
+   - Inputs: resolved coordinates (RA/Dec + epoch if available)
+   - Behavior:
+     - Retrieve existing nova coordinates from persistent store
+     - Compute angular separation to each candidate
+     - Determine minimum separation
+
+10. **CoordinateMatchClassification?** (Choice)
+   - Separation < 2"  -> **UpsertAliasForExistingNova** -> **PublishIngestNewNova**
+     -> **FinalizeJobRunSuccess** (outcome = `EXISTS_AND_LAUNCHED`)
+   - Separation 2"–10" -> **QuarantineHandler** -> **FinalizeJobRunQuarantined**
+   - Separation > 10"  -> continue
+
+11. **CandidateIsNova?** (Choice)
    - No -> **FinalizeJobRunSuccess** (outcome = `NOT_FOUND`)
    - Yes -> continue
-10. **CandidateIsClassicalNova?** (Choice)
+
+12. **CandidateIsClassicalNova?** (Choice)
    - No -> **FinalizeJobRunSuccess** (outcome = `NOT_A_CLASSICAL_NOVA`) *(terminal success; does not launch)*
    - Ambiguous -> **QuarantineHandler** -> **FinalizeJobRunQuarantined**
    - Yes -> continue
-11. **CreateNovaId** (Task)
-12. **UpsertMinimalNovaMetadata** (Task)
-13. **PublishIngestNewNova** (Task)
-14. **FinalizeJobRunSuccess** (Task) (outcome = `CREATED_AND_LAUNCHED`)
-15. **QuarantineHandler** (Task)
-16. **FinalizeJobRunQuarantined** (Task)
-17. **TerminalFailHandler** (Task)
-18. **FinalizeJobRunFailed** (Task)
+
+13. **CreateNovaId** (Task)
+14. **UpsertMinimalNovaMetadata** (Task)
+15. **PublishIngestNewNova** (Task)
+16. **FinalizeJobRunSuccess** (Task) (outcome = `CREATED_AND_LAUNCHED`)
+17. **UpsertAliasForExistingNova** (Task)
+18. **QuarantineHandler** (Task)
+19. **FinalizeJobRunQuarantined** (Task)
+20. **TerminalFailHandler** (Task)
+21. **FinalizeJobRunFailed** (Task)
+
+---
 
 ## Retry / Timeout Policy (per state)
 - BeginJobRun:
@@ -76,6 +103,12 @@ Other workflows may be triggered directly when `nova_id` already exists.
 - ResolveCandidateAgainstPublicArchives:
   - Timeout: 60s
   - Retry: Retryable only; MaxAttempts 3; Backoff 2s, 10s, 30s
+- CheckExistingNovaByCoordinates:
+  - Timeout: 20s
+  - Retry: Retryable only; MaxAttempts 3; Backoff 2s, 10s, 30s
+- UpsertAliasForExistingNova:
+  - Timeout: 20s
+  - Retry: Retryable only; MaxAttempts 3; Backoff 2s, 10s, 30s
 - CreateNovaId:
   - Timeout: 10s
   - Retry: Retryable only; MaxAttempts 3; Backoff 2s, 10s, 30s
@@ -89,27 +122,41 @@ Other workflows may be triggered directly when `nova_id` already exists.
   - Timeout: 10s
   - Retry: Retryable only; MaxAttempts 3; Backoff 2s, 10s, 30s
 
+---
+
 ## Failure Classification Policy
+
 - Retryable:
   - transient network errors, timeouts, throttling, 5xx dependency failures
 - Terminal:
   - schema/version mismatch
   - missing/invalid `candidate_name`
+  - resolver did not return coordinates when required for identity checks
   - internal invariant violations
 - Quarantine:
   - ambiguous resolver results (cannot safely decide nova / classical nova status)
   - conflicting authoritative sources
+  - coordinate match in ambiguous band (2"–10")
 
 **Note:** outcomes `NOT_FOUND` and `NOT_A_CLASSICAL_NOVA` are NOT failures; they are terminal-success outcomes without downstream launch.
 
+---
+
 ## Idempotency Guarantees & Invariants
+
 - Workflow idempotency key (time-bucketed): `InitializeNova:{normalized_candidate_name}:{schema_version}:{time_bucket}`
+
 - Invariant: downstream workflow launches use UUIDs only (`nova_id`).
 - Invariant: `idempotency_key` is INTERNAL ONLY and must not be required in event schemas.
-- Short-circuit behavior:
+
+- Short-circuit behaviors:
   - If name exists -> launch `ingest_new_nova` and do not create a new `nova_id`.
+  - If coordinates match an existing nova within 2" -> upsert alias and launch `ingest_new_nova` with the existing `nova_id`.
+
+---
 
 ## JobRun / Attempt Emissions and Required Log Fields
+
 - JobRun:
   - Emit STARTED at BeginJobRun
   - Emit SUCCEEDED with outcome (`CREATED_AND_LAUNCHED` | `EXISTS_AND_LAUNCHED` | `NOT_FOUND` | `NOT_A_CLASSICAL_NOVA`)
@@ -121,5 +168,8 @@ Other workflows may be triggered directly when `nova_id` already exists.
   - schema_version, correlation_id
   - candidate_name, normalized_candidate_name
   - nova_id (when known)
+  - resolved_ra, resolved_dec, resolved_epoch (when available)
+  - coordinate_match_min_sep_arcsec (when computed)
+  - coordinate_match_outcome (DUPLICATE|AMBIGUOUS|NONE)
   - workflow_idempotency_key (internal), step_dedupe_key (internal, when used)
   - error_classification, error_fingerprint (on failures/quarantine)


### PR DESCRIPTION
# Add coordinate-based duplicate detection to initialize_nova

## Overview

This PR strengthens identity resolution in `initialize_nova` by adding a coordinate-based duplicate check after resolver lookup.

Previously, existence checks relied solely on name/alias matching. This failed to account for newly introduced aliases referencing an already-known nova.

This update adds a secondary coordinate-based identity gate.

---

## What Changed

### New Step: `CheckExistingNovaByCoordinates`

After resolving the candidate against public archives:

- Retrieve existing nova coordinates from persistent store
- Compute angular separation between candidate and stored novae
- Classify result using explicit thresholds:

| Separation | Outcome |
|------------|----------|
| `< 2"`     | Treat as duplicate → upsert alias → launch `ingest_new_nova` |
| `2"–10"`   | Quarantine (ambiguous identity) |
| `> 10"`    | Proceed with new nova creation |

---

## Why This Matters

- Prevents duplicate `nova_id` creation due to new aliases
- Provides deterministic identity resolution
- Adds explicit ambiguity handling for crowded fields
- Keeps UUID-first downstream execution invariant intact

---

## Architectural Notes

- This change documents behavior, not database implementation strategy.
- Coordinate retrieval is described abstractly (“retrieve from persistent store”) to preserve flexibility.
- Threshold policy is explicitly defined in workflow spec and diagram.

---

## Out of Scope

- No changes to DynamoDB schema in this PR
- No spatial index assumptions introduced
- No infrastructure changes

---

This improves correctness of the system’s front-door identity resolution while preserving the existing orchestration model.