### PR TITLE
refactor(workflows): add byte-level dedupe and SNS quarantine notifications

### DIFF
--- a/docs/diagrams/workflow-acquire-and-validate-spectra.md
+++ b/docs/diagrams/workflow-acquire-and-validate-spectra.md
@@ -14,10 +14,16 @@ flowchart TD
 
   I -- No --> K[AcquireArtifact]
   K --> L["ValidateBytes (Profile-Driven)"]
-  L --> M[RecordValidationResult]
+  L --> DBF{DuplicateByFingerprint?}
+
+  DBF -- Yes --> RDL[RecordDuplicateLinkage]
+  RDL --> ND["FinalizeJobRunSuccess (DUPLICATE_OF_EXISTING)"]
+
+  DBF -- No --> M[RecordValidationResult]
   M --> N["FinalizeJobRunSuccess (VALIDATED)"]
 
-  Q[QuarantineHandler] --> R[FinalizeJobRunQuarantined]
+  Q[QuarantineHandler] --> SS["(SNS Notification)"]
+  SS --> R[FinalizeJobRunQuarantined]
   TF[TerminalFailHandler] --> FF[FinalizeJobRunFailed]
 
 ```

--- a/docs/diagrams/workflow-ingest-photometry-dataset.md
+++ b/docs/diagrams/workflow-ingest-photometry-dataset.md
@@ -11,7 +11,8 @@ flowchart TD
   H --> I[IngestMetadataAndProvenance]
   I --> J["FinalizeJobRunSuccess (INGESTED)"]
 
-  Q[QuarantineHandler] --> R[FinalizeJobRunQuarantined]
+  Q[QuarantineHandler] --> SS["(SNS Notification)"]
+  SS --> R[FinalizeJobRunQuarantined]
   TF[TerminalFailHandler] --> FF[FinalizeJobRunFailed]
 
 ```

--- a/docs/diagrams/workflow-name-check-and-reconcile.md
+++ b/docs/diagrams/workflow-name-check-and-reconcile.md
@@ -13,6 +13,7 @@ flowchart TD
   J --> K["PublishNameReconciled (optional)"]
   K --> L["FinalizeJobRunSuccess (UPDATED)"]
 
-  Q[QuarantineHandler] --> R[FinalizeJobRunQuarantined]
+  Q[QuarantineHandler] --> SS["(SNS Notification)"]
+  SS --> R[FinalizeJobRunQuarantined]
   T[TerminalFailHandler] --> U[FinalizeJobRunFailed]
 ```

--- a/docs/workflows/ingest-photometry-dataset.md
+++ b/docs/workflows/ingest-photometry-dataset.md
@@ -60,6 +60,24 @@ Note: This workflow can act as a front door when the system has a photometry fil
   - data readable but invalid columns/units/time formats
   - suspicious timestamps or ambiguous units
 
+### Quarantine Handling
+
+When a workflow transitions to **QuarantineHandler**, it MUST:
+
+1. Persist quarantine status and relevant diagnostic metadata.
+2. Emit a JobRun outcome of `QUARANTINED`.
+3. Publish a notification event to an SNS topic for operational review.
+
+SNS notification requirements:
+- Include workflow name
+- Include primary identifier (e.g., `nova_id` or `data_product_id`)
+- Include `correlation_id`
+- Include `error_fingerprint`
+- Include brief classification reason
+
+The SNS notification is best-effort and MUST NOT cause the workflow to fail if notification delivery fails.
+
+
 ## Idempotency Guarantees & Invariants
 - Workflow idempotency key: `IngestPhotometryDataset:{dataset_id}:{schema_version}`
 - Invariant: `idempotency_key` is internal-only (not in event schemas).

--- a/docs/workflows/initialize-nova.md
+++ b/docs/workflows/initialize-nova.md
@@ -140,6 +140,23 @@ Other workflows may be triggered directly when `nova_id` already exists.
 
 **Note:** outcomes `NOT_FOUND` and `NOT_A_CLASSICAL_NOVA` are NOT failures; they are terminal-success outcomes without downstream launch.
 
+### Quarantine Handling
+
+When a workflow transitions to **QuarantineHandler**, it MUST:
+
+1. Persist quarantine status and relevant diagnostic metadata.
+2. Emit a JobRun outcome of `QUARANTINED`.
+3. Publish a notification event to an SNS topic for operational review.
+
+SNS notification requirements:
+- Include workflow name
+- Include primary identifier (e.g., `nova_id` or `data_product_id`)
+- Include `correlation_id`
+- Include `error_fingerprint`
+- Include brief classification reason
+
+The SNS notification is best-effort and MUST NOT cause the workflow to fail if notification delivery fails.
+
 ---
 
 ## Idempotency Guarantees & Invariants

--- a/docs/workflows/name-check-and-reconcile.md
+++ b/docs/workflows/name-check-and-reconcile.md
@@ -74,6 +74,23 @@ It is designed to run a limited number of times (e.g., during the first ~6 weeks
   - conflicting authorities producing ambiguous canonical designation
   - non-monotonic changes that would imply identity merge/split ambiguity
 
+### Quarantine Handling
+
+When a workflow transitions to **QuarantineHandler**, it MUST:
+
+1. Persist quarantine status and relevant diagnostic metadata.
+2. Emit a JobRun outcome of `QUARANTINED`.
+3. Publish a notification event to an SNS topic for operational review.
+
+SNS notification requirements:
+- Include workflow name
+- Include primary identifier (e.g., `nova_id` or `data_product_id`)
+- Include `correlation_id`
+- Include `error_fingerprint`
+- Include brief classification reason
+
+The SNS notification is best-effort and MUST NOT cause the workflow to fail if notification delivery fails.
+
 ## Idempotency Guarantees & Invariants
 - Workflow idempotency key (time-bucketed): `NameCheckAndReconcile:{nova_id}:{schema_version}:{time_bucket}`
 - Invariant: names are updated only as enrichment; UUID identity remains stable.

--- a/docs/workflows/refresh-references.md
+++ b/docs/workflows/refresh-references.md
@@ -63,6 +63,23 @@ Also computes and sets `discovery_date` metadata using the earliest credible ref
   - item-level reference parse failures (continue Map)
   - discovery date cannot be selected due to irreconcilable conflicts (rare)
 
+### Quarantine Handling
+
+When a workflow transitions to **QuarantineHandler**, it MUST:
+
+1. Persist quarantine status and relevant diagnostic metadata.
+2. Emit a JobRun outcome of `QUARANTINED`.
+3. Publish a notification event to an SNS topic for operational review.
+
+SNS notification requirements:
+- Include workflow name
+- Include primary identifier (e.g., `nova_id` or `data_product_id`)
+- Include `correlation_id`
+- Include `error_fingerprint`
+- Include brief classification reason
+
+The SNS notification is best-effort and MUST NOT cause the workflow to fail if notification delivery fails.
+
 ## Idempotency Guarantees & Invariants
 - Workflow idempotency key (time-bucketed): `RefreshReferences:{nova_id}:{schema_version}:{time_bucket}`
 - Reference upsert dedupe key: `ReferenceUpsert:{source}:{source_key}:{schema_version}`


### PR DESCRIPTION
# Add fingerprint-based dedupe and SNS quarantine notifications

## Overview

This PR strengthens spectra lifecycle correctness and operational visibility by:

1. Introducing byte-level duplicate detection in `acquire_and_validate_spectra`.
2. Formalizing a metadata identity ladder in `discover_spectra_products`.
3. Standardizing quarantine handling to publish SNS notifications.
4. Updating workflow specs and diagrams to reflect these changes.

---

## What Changed

### 1️⃣ Discovery Identity Policy

`discover_spectra_products` now explicitly defines an identity ladder:

- Strong identity via provider-native product ID
- Fallback strong identity via deterministic metadata key
- Weak identity → defer dedupe to acquisition phase

Locator aliases are persisted when new access paths are discovered for an existing data product.

---

### 2️⃣ Post-Acquisition Duplicate Detection

`acquire_and_validate_spectra` now performs fingerprint-based deduplication:

- Compute `content_fingerprint` after acquisition
- If a validated product with the same fingerprint exists:
  - Mark as `DUPLICATE_OF_EXISTING`
  - Link via `duplicate_of_data_product_id`
  - Do not mark as VALIDATED
- Otherwise continue normal validation

This resolves duplicate cases that cannot be detected via metadata alone.

---

### 3️⃣ Persisted Fields Added

Data product operational metadata now includes:

- `content_fingerprint`
- `duplicate_of_data_product_id`

These are internal lifecycle fields (not part of event contracts).

---

### 4️⃣ Quarantine Handling Standardized

All quarantine paths now:

- Persist quarantine status
- Emit JobRun outcome `QUARANTINED`
- Publish an SNS notification for operational review

SNS notification is best-effort and must not cause workflow failure.

---

## Why This Matters

- Prevents duplicate scientific artifacts across providers
- Enables cross-provider equivalence detection
- Improves operational visibility for ambiguous or invalid cases
- Keeps orchestration UUID-first and contract-first
- Preserves MVP simplicity while enabling future scalability

---

## Out of Scope

- No infrastructure changes
- No DynamoDB schema implementation changes in this PR
- No changes to event schema contracts

---

This improves correctness, safety, and maintainability of spectra ingestion while remaining cost-conscious and MVP-aligned.