### PR TITLE
Update S3 Layout (Epic 3 — V2)

### DIFF
--- a/docs/storage/s3-layout.md
+++ b/docs/storage/s3-layout.md
@@ -1,126 +1,272 @@
-# S3 Layout (Epic 3)
+# S3 Layout (Epic 3 — V2)
 
 This document defines Nova Cat's S3 bucket strategy and object prefixes.
+
 Goals:
+
 - Separate **private scientific data** from **public site assets**
-- Keep raw bytes immutable; track derived artifacts and bundles
-- Enable deterministic rebuilds of "full dataset" bundles when new data arrives
-- Provide stable object keys that align with `nova_id` and `dataset_id`
+- Keep raw bytes immutable
+- Track derived artifacts and quarantine context
+- Enable deterministic rebuilds of per-nova bundles
+- Align object keys with `nova_id` and `data_product_id`
+- Reflect atomic spectra product model (no dataset abstraction)
 
 ---
 
-## Buckets
+# Buckets
 
-### 1) Private data bucket (default)
-Bucket: `nova-cat-private-data` (name illustrative)
+## 1. Private Data Bucket (default)
+
+Bucket (illustrative): `nova-cat-private-data`
 
 Contains:
-- Raw downloaded bytes (FITS, zips, expanded members)
-- Quarantine objects (bytes + metadata snapshots)
-- Derived artifacts (plots, normalized representations)
-- Bundle artifacts (per-nova full zip + manifest)
-- Optional: large workflow payload snapshots (if needed)
 
-### 2) Public site bucket
-Bucket: `nova-cat-public-site` (name illustrative)
+- Raw downloaded bytes (FITS, archives, expanded members)
+- Photometry ingest uploads
+- Quarantine objects (bytes + context snapshot)
+- Derived artifacts (normalized representations, plots)
+- Per-nova bundle artifacts
+- Optional workflow payload snapshots
+
+This bucket is private and never directly exposed.
+
+---
+
+## 2. Public Site Bucket
+
+Bucket (illustrative): `nova-cat-public-site`
 
 Contains:
-- Static site releases (versioned)
-- Publicly published derived assets (already curated/redacted)
+
+- Static site releases (immutable)
+- Public derived assets that are curated and approved
 
 ---
 
-## Prefix Conventions (Private Bucket)
+# Private Bucket Prefix Conventions
 
-All keys are deterministic and **UUID-first**.
-
-### Raw spectra
-- `raw/spectra/<nova_id>/<dataset_id>/primary.fits`
-- `raw/spectra/<nova_id>/<dataset_id>/source.json` (small provenance snapshot)
-- If downloaded as archive:
-  - `raw/spectra/<nova_id>/<dataset_id>/archive.zip`
-  - `raw/spectra/<nova_id>/<dataset_id>/unzipped/<relative_path_inside_zip>`
-
-### Quarantine (bytes and context kept together)
-- `quarantine/spectra/<nova_id>/<dataset_id>/<quarantine_timestamp>/primary.fits`
-- `quarantine/spectra/<nova_id>/<dataset_id>/<quarantine_timestamp>/context.json`
-  - include validation status, reason_code, header signature, chosen_profile (if any), and pointers to logs
-
-### Normalized / canonical-ish representations (internal)
-- `derived/spectra/<nova_id>/<dataset_id>/normalized/`
-  - `spectrum.parquet` (or `spectrum.ecsv`, `spectrum.fits`, etc.)
-  - `metadata.json` (axis units, mapping notes, lossy decisions)
-- `derived/spectra/<nova_id>/<dataset_id>/plots/preview.png`
-
-### Photometry uploads (user or upstream ingestion)
-- `raw/photometry/<nova_id>/<dataset_id>/upload/<original_filename>`
-- Optional preprocessed outputs:
-  - `derived/photometry/<nova_id>/<dataset_id>/table.parquet`
-  - `derived/photometry/<nova_id>/<dataset_id>/plots/lightcurve.png`
-
-### Per-nova "full dataset" bundle (rebuilt only when new data arrives)
-- `bundles/<nova_id>/full.zip`
-- `bundles/<nova_id>/manifest.json`
-  - includes bundle_build_id, created_at, list of included dataset_ids and file keys, checksums
-
-### Optional: workflow payload snapshots (only if boundary payloads get too big)
-- `workflow-payloads/<workflow_name>/<job_run_id>/input.json`
-- `workflow-payloads/<workflow_name>/<job_run_id>/output.json`
+All keys are deterministic and UUID-first.
 
 ---
 
-## FITS Profile Assets
+## 1. Raw Spectra (Atomic Products)
 
-Profiles are primarily **code/repo artifacts** (recommended):
-- `docs/specs/spectra-fits-profiles.md` is the “Rosetta stone”
-- Actual profile logic lives in code alongside provider adapters
+Each spectra product is identified by `data_product_id`.
 
-If you later need runtime-managed profile assets (e.g., YAML profile definitions), store in private bucket:
-- `profiles/fits/<profile_id>/<version>/profile.yaml`
-- `profiles/fits/<profile_id>/<version>/tests/<sample>.fits`
+```
+raw/spectra/<nova_id>/<data_product_id>/primary.fits
+raw/spectra/<nova_id>/<data_product_id>/source.json
+```
 
-But default is: **keep profiles in repo** for deterministic deployments and change control.
+If acquired as archive:
 
----
+```
+raw/spectra/<nova_id>/<data_product_id>/archive.zip
+raw/spectra/<nova_id>/<data_product_id>/unzipped/<relative_path>
+```
 
-## Prefix Conventions (Public Site Bucket)
+Rules:
 
-### Release-based publishing (immutable releases)
-- `releases/<release_id>/index.html`
-- `releases/<release_id>/assets/...`
-- `releases/<release_id>/nova/<nova_id>/...`
-
-### Current pointer (optional, via copy or redirect config)
-- `current/...` mirrors latest release
+- Raw bytes are immutable.
+- Re-acquisition overwrites only if validation has not succeeded.
+- `source.json` contains small provenance snapshot (provider, locator, timestamp).
 
 ---
 
-## Examples
+## 2. Spectra Quarantine
 
-Spectra FITS:
-- `raw/spectra/4e9b0e88-.../2c7d1f4d-.../primary.fits`
+Quarantine stores bytes + validation context together.
 
-Quarantine context:
-- `quarantine/spectra/4e9b0e88-.../2c7d1f4d-.../2026-02-21T20:45:10Z/context.json`
+```
+quarantine/spectra/<nova_id>/<data_product_id>/<timestamp>/primary.fits
+quarantine/spectra/<nova_id>/<data_product_id>/<timestamp>/context.json
+```
+
+`context.json` should include:
+
+- validation_status
+- quarantine_reason_code
+- header_signature_hash (if available)
+- fits_profile_id (if selected)
+- locator_identity
+- log references (CloudWatch pointers)
+
+Multiple quarantine attempts may exist for the same product.
+
+---
+
+## 3. Derived Spectra Artifacts
+
+Internal canonical/normalized outputs.
+
+```
+derived/spectra/<nova_id>/<data_product_id>/normalized/spectrum.parquet
+derived/spectra/<nova_id>/<data_product_id>/normalized/metadata.json
+derived/spectra/<nova_id>/<data_product_id>/plots/preview.png
+```
+
+Rules:
+
+- Derived artifacts are reproducible from raw bytes.
+- Metadata documents unit conversions and normalization decisions.
+
+---
+
+## 4. Photometry Ingestion
+
+Photometry differs from spectra:
+
+- There is exactly **one** `PHOTOMETRY_TABLE` data product per nova.
+- Individual ingest files are transient inputs.
+
+### 4A. Photometry Uploads (API-driven)
+
+```
+raw/photometry/uploads/<ingest_file_id>/original/<filename>
+```
+
+If the uploaded file contains multiple novae:
+
+```
+raw/photometry/uploads/<ingest_file_id>/split/<nova_id>/<filename>
+```
+
+Optional manifest:
+
+```
+raw/photometry/uploads/<ingest_file_id>/manifest.json
+```
+
+---
+
+### 4B. Canonical Photometry Table (Per Nova)
+
+Stable location for the current photometry table:
+
+```
+derived/photometry/<nova_id>/photometry_table.parquet
+derived/photometry/<nova_id>/metadata.json
+derived/photometry/<nova_id>/plots/lightcurve.png
+```
+
+Rules:
+
+- This is the authoritative table for the nova.
+- Updated in-place when new ingestion occurs.
+- Versioning (if needed) can rely on S3 object versioning.
+
+---
+
+## 5. Per-Nova Bundle Artifacts
+
+Bundles are rebuilt only when new data arrives.
+
+```
+bundles/<nova_id>/full.zip
+bundles/<nova_id>/manifest.json
+```
+
+`manifest.json` should include:
+
+- bundle_build_id
+- created_at
+- included `data_product_id`s (spectra)
+- photometry table key
+- checksums of included files
+
+---
+
+## 6. Optional Workflow Payload Snapshots
+
+Only used if boundary payloads exceed safe Step Functions size.
+
+```
+workflow-payloads/<workflow_name>/<job_run_id>/input.json
+workflow-payloads/<workflow_name>/<job_run_id>/output.json
+```
+
+---
+
+# FITS Profile Assets
+
+Profiles remain **code artifacts by default**:
+
+- `docs/specs/spectra-fits-profiles.md`
+- Provider adapter + validation logic in code
+
+If runtime-managed profile definitions are later required:
+
+```
+profiles/fits/<profile_id>/<version>/profile.yaml
+profiles/fits/<profile_id>/<version>/tests/<sample>.fits
+```
+
+Default: keep profiles in repo for deterministic deployments.
+
+---
+
+# Public Site Bucket Layout
+
+## Release-Based Publishing (Immutable)
+
+```
+releases/<release_id>/index.html
+releases/<release_id>/assets/...
+releases/<release_id>/nova/<nova_id>/...
+```
+
+Optional "current" pointer:
+
+```
+current/...
+```
+
+This may be implemented via redirect or object copy.
+
+---
+
+# Examples
+
+Spectra raw FITS:
+
+```
+raw/spectra/4e9b0e88-.../2c7d1f4d-.../primary.fits
+```
+
+Spectra quarantine context:
+
+```
+quarantine/spectra/4e9b0e88-.../2c7d1f4d-.../2026-02-21T20:45:10Z/context.json
+```
+
+Photometry table:
+
+```
+derived/photometry/4e9b0e88-.../photometry_table.parquet
+```
 
 Bundle:
-- `bundles/4e9b0e88-.../full.zip`
-- `bundles/4e9b0e88-.../manifest.json`
+
+```
+bundles/4e9b0e88-.../full.zip
+bundles/4e9b0e88-.../manifest.json
+```
 
 ---
 
-## Mermaid Diagrams
+# Mermaid Diagram
 
-### Bucket overview
+## Bucket Overview
+
 ```mermaid
 flowchart TB
   subgraph PRIVATE["S3: nova-cat-private-data (private)"]
-    R1["raw/"]
-    Q1["quarantine/"]
-    D1["derived/"]
-    B1["bundles/"]
-    P1["profiles/ (optional)"]
-    W1["workflow-payloads/ (optional)"]
+    RAW["raw/"]
+    QUAR["quarantine/"]
+    DER["derived/"]
+    BUN["bundles/"]
+    WF["workflow-payloads/ (optional)"]
+    PROF["profiles/ (optional)"]
   end
 
   subgraph PUBLIC["S3: nova-cat-public-site (public)"]
@@ -128,8 +274,20 @@ flowchart TB
     CUR["current/ (optional)"]
   end
 
-  R1 --> D1
-  R1 --> Q1
-  D1 --> B1
+  RAW --> DER
+  RAW --> QUAR
+  DER --> BUN
   REL --> CUR
-  ```
+```
+
+---
+
+# Key Design Principles
+
+- Spectra are atomic (`data_product_id`-scoped).
+- Photometry is singleton-per-nova.
+- Raw bytes are immutable.
+- Quarantine preserves full diagnostic context.
+- Derived artifacts are reproducible.
+- Bundles are deterministic.
+- UUID-first layout ensures stable rebuild logic.


### PR DESCRIPTION
## Update S3 Layout (Epic 3 — V2)

This PR rewrites the S3 layout documentation to align with the finalized atomic `data_product_id` model introduced in Epic 3.

### Key Changes

- Replace legacy `dataset_id` usage with `data_product_id` for spectra.
- Clarify that photometry is a singleton `PHOTOMETRY_TABLE` per nova.
- Introduce `raw/photometry/uploads/` prefix for ingest inputs.
- Tighten quarantine layout to preserve full validation context.
- Update bundle manifest semantics to reference `data_product_id`s.
- Retitle document to “Epic 3 — V2” to reflect iterative architecture.

No bucket structure changes are implemented yet; this PR updates documentation only.