### PR TITLE
SIMBAD alias collection during initialize_nova

### DIFF
--- a/contracts/models/entities.py
+++ b/contracts/models/entities.py
@@ -144,6 +144,16 @@ class Nova(PersistentBase):
 
     discovery_date: datetime | None = None
 
+    aliases: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Raw alias strings from SIMBAD ids field, e.g. 'NOVA Sco 2012', "
+            "'Gaia DR3 4043499439062100096'. Denormalized on the Nova item so "
+            "refresh_references can retrieve all known names in a single get_item "
+            "call. Empty list if no SIMBAD aliases were returned at ingestion time."
+        ),
+    )
+
     # Optional quarantine context (only meaningful when status == QUARANTINED)
     quarantine_reason_code: NovaQuarantineReasonCode | None = None
     manual_review_status: str | None = Field(default=None, max_length=64)

--- a/docs/storage/dynamodb-access-patterns.md
+++ b/docs/storage/dynamodb-access-patterns.md
@@ -96,6 +96,9 @@ Purpose: Resolve a candidate name to a stable `nova_id`, or create a new `Nova`.
 - Insert primary `NameMapping`:
   `PK = "NAME#<normalized_primary_name>"`, `SK = "NOVA#<nova_id>"`
 
+- Update `Nova.aliases` with the raw alias list from archive resolution:
+  `PK = "<nova_id>"`, `SK = "NOVA"` (same item, SET aliases = :aliases)
+
 **Side effects**
 - Publish `ingest_new_nova`
 - Finalize (`CREATED_AND_LAUNCHED`)

--- a/docs/storage/dynamodb-item-model.md
+++ b/docs/storage/dynamodb-item-model.md
@@ -67,6 +67,7 @@ Canonical nova record.
 - `coord_frame` (string; e.g., `"ICRS"`; optional but recommended for explicitness)
 - `coord_epoch` (string; e.g., `"J2000"`; optional but recommended for explicitness)
 - `discovery_date` (optional, derived from references)
+- `aliases` (string list; raw alias strings
 - `status` (ACTIVE | MERGED | DEPRECATED)
 - `created_at`, `updated_at` (ISO-8601 UTC)
 
@@ -81,6 +82,12 @@ Canonical nova record.
   "primary_name": "V1324 Sco",
   "primary_name_normalized": "v1324 sco",
   "status": "ACTIVE",
+  "ra_deg": 271.0822,
+  "dec_deg": -32.4617,
+  "coord_frame": "ICRS",
+  "coord_epoch": "J2000",
+  "resolver_source": "SIMBAD",
+  "aliases": ["NOVA Sco 2012", "Gaia DR3 4043499439062100096", "MOA 2012-BLG-320"],
   "discovery_date": "2012-06-01",
   "created_at": "2026-02-21T20:00:00Z",
   "updated_at": "2026-02-23T18:10:00Z"

--- a/docs/workflows/initialize-nova.md
+++ b/docs/workflows/initialize-nova.md
@@ -37,6 +37,12 @@ Other workflows may be triggered directly when `nova_id` already exists.
 - On outcome `NOT_FOUND`:
   - No downstream workflow event published (terminal success outcome)
 
+### Internal data flow note
+- `ResolveCandidateAgainstPublicArchives` returns an `aliases` list
+  (empty list when resolver_source is TNS or NONE).
+- The ASL threads `aliases.$: $.resolution.aliases` into the
+  `UpsertMinimalNovaMetadata` Parameters block.
+
 ---
 
 ## State Machine (Explicit State List)
@@ -77,6 +83,19 @@ Other workflows may be triggered directly when `nova_id` already exists.
 
 13. **CreateNovaId** (Task)
 14. **UpsertMinimalNovaMetadata** (Task)
+    - In addition to coordinates and PRIMARY NameMapping, writes an ALIAS
+      NameMapping item for each entry in `aliases` returned by
+      ResolveCandidateAgainstPublicArchives.
+    - Aliases are sourced from the SIMBAD `ids` field (pipe-delimited catalogue
+      identifiers, e.g. "NOVA Sco 2012", "Gaia DR3 4043499439062100096").
+    - Each alias is normalized (lowercase, collapse whitespace) for the DDB PK
+      so that CheckExistingNovaByName can find it; the raw string is preserved
+      in `name_raw` for display and ADS bibliography lookups.
+    - The `V* ` prefix is stripped before storage (SIMBAD variable star
+      annotation — not a searchable identifier).
+    - Aliases whose normalized form matches `normalized_candidate_name` are
+      skipped to avoid duplicating the PRIMARY mapping.
+    - `name_kind = ALIAS`, `source = SIMBAD`.
 15. **PublishIngestNewNova** (Task)
 16. **FinalizeJobRunSuccess** (Task) (outcome = `CREATED_AND_LAUNCHED`)
 17. **UpsertAliasForExistingNova** (Task)

--- a/infra/workflows/initialize_nova.asl.json
+++ b/infra/workflows/initialize_nova.asl.json
@@ -637,6 +637,7 @@
                 "resolved_dec.$": "$.resolution.resolved_dec",
                 "resolved_epoch.$": "$.resolution.resolved_epoch",
                 "resolver_source.$": "$.resolution.resolver_source",
+                "aliases.$": "$.resolution.aliases",
                 "correlation_id.$": "$.job_run.correlation_id",
                 "job_run_id.$": "$.job_run.job_run_id"
             },

--- a/services/archive_resolver/handler.py
+++ b/services/archive_resolver/handler.py
@@ -10,26 +10,41 @@ dependencies. See infra/nova_constructs/compute.py for container config.
 Task dispatch table:
   ResolveCandidateAgainstPublicArchives — query SIMBAD (and TNS if needed);
                                           return coordinates + nova classification
+                                          + SIMBAD aliases
 
 Resolution strategy:
   1. Query SIMBAD via astroquery — authoritative for named objects
   2. If SIMBAD returns no result, query TNS REST API (plain HTTP)
   3. Merge results; raise QuarantineError if sources conflict
 
-Output contract (consumed by CheckExistingNovaByCoordinates and
-CandidateIsNova?/CandidateIsClassicalNova? choice states):
+Output contract (consumed by CheckExistingNovaByCoordinates,
+CandidateIsNova?/CandidateIsClassicalNova? choice states, and
+UpsertMinimalNovaMetadata for alias persistence):
   is_nova           — bool
   is_classical_nova — "true" | "false"
   resolved_ra       — ICRS RA in degrees (present when is_nova=True)
   resolved_dec      — ICRS Dec in degrees (present when is_nova=True)
   resolved_epoch    — always "J2000" for SIMBAD
   resolver_source   — "SIMBAD" | "TNS" | "SIMBAD+TNS" | "NONE"
+  aliases           — list of raw alias strings from SIMBAD ids field
+                      (present when resolver_source includes "SIMBAD";
+                      empty list otherwise). Used by UpsertMinimalNovaMetadata
+                      to persist NameMapping items for each alias, and by
+                      refresh_references for ADS bibliography lookups.
 
 SIMBAD otypes.otype_txt → nova classification:
   No*, No?, NL*  → is_nova=True, is_classical_nova="true"
   RNe, RN*       → is_nova=True, is_classical_nova="false" (recurrent)
   Anything else  → is_nova=False
   Conflicting    → QuarantineError
+
+SIMBAD alias extraction:
+  The ids field is a pipe-delimited string of catalogue identifiers,
+  e.g. "V* V1324 Sco|NOVA Sco 2012|Gaia DR3 4043499439062100096".
+  Each token is trimmed of whitespace. The "V* " prefix is stripped
+  (SIMBAD variable star annotation — not part of the searchable name).
+  All other prefixes (Gaia DR3, 2MASS J, NOVA, MOA, etc.) are kept
+  verbatim as they are genuine searchable catalogue identifiers.
 
 astropy/astroquery cache:
   Redirected to /tmp at module load — Lambda filesystem is read-only
@@ -135,6 +150,7 @@ def _resolve_candidate_against_public_archives(
             "is_nova": False,
             "is_classical_nova": "false",
             "resolver_source": "NONE",
+            "aliases": [],
         }
 
     if simbad_result is not None and tns_result is not None:
@@ -146,6 +162,7 @@ def _resolve_candidate_against_public_archives(
     else:
         result = cast(dict[str, Any], tns_result)
         result["resolver_source"] = "TNS"
+        result.setdefault("aliases", [])
 
     logger.info(
         "Archive resolution complete",
@@ -153,6 +170,7 @@ def _resolve_candidate_against_public_archives(
             "is_nova": result.get("is_nova"),
             "is_classical_nova": result.get("is_classical_nova"),
             "resolver_source": result.get("resolver_source"),
+            "alias_count": len(result.get("aliases", [])),
         },
     )
 
@@ -170,7 +188,7 @@ def _query_simbad(candidate_name: str) -> dict[str, Any] | None:
     Query SIMBAD via astroquery.
 
     SIMBAD returns one row per object type. We collect all otype_txt values
-    across rows and take coordinates from the first row.
+    across rows and take coordinates and ids from the first row.
 
     Returns None if no object found. Raises RetryableError on transient
     network failures.
@@ -202,6 +220,7 @@ def _query_simbad(candidate_name: str) -> dict[str, Any] | None:
 
     ra = _raw("ra")
     dec = _raw("dec")
+    ids_raw = _raw("ids")
 
     is_nova, is_classical_nova = _classify_otypes(all_otypes)
 
@@ -209,6 +228,7 @@ def _query_simbad(candidate_name: str) -> dict[str, Any] | None:
         "is_nova": is_nova,
         "is_classical_nova": is_classical_nova,
         "resolved_epoch": "J2000",
+        "aliases": _parse_simbad_ids(ids_raw),
     }
 
     if is_nova and ra is not None and dec is not None:
@@ -279,7 +299,7 @@ def _query_tns(candidate_name: str) -> dict[str, Any] | None:
 
 
 # ---------------------------------------------------------------------------
-# Classification helpers
+# Classification and alias helpers
 # ---------------------------------------------------------------------------
 
 
@@ -304,13 +324,45 @@ def _classify_otypes(otypes: set[str]) -> tuple[bool, str]:
     return True, "true"
 
 
+def _parse_simbad_ids(ids_raw: str | None) -> list[str]:
+    """
+    Parse the SIMBAD ids pipe-delimited string into a clean alias list.
+
+    Rules:
+      - Split on "|"
+      - Strip leading/trailing whitespace from each token
+      - Strip leading "V* " prefix (SIMBAD variable star annotation —
+        not part of the searchable name)
+      - Drop empty strings
+
+    All other catalogue prefixes (Gaia DR3, 2MASS J, NOVA, MOA, etc.)
+    are kept verbatim — they are genuine searchable identifiers.
+
+    Example input:  "V* V1324 Sco|NOVA Sco 2012|Gaia DR3 4043499439062100096"
+    Example output: ["V1324 Sco", "NOVA Sco 2012", "Gaia DR3 4043499439062100096"]
+    """
+    if not ids_raw:
+        return []
+
+    aliases = []
+    for token in ids_raw.split("|"):
+        token = token.strip()
+        if token.startswith("V* "):
+            token = token[3:]
+        token = token.strip()
+        if token:
+            aliases.append(token)
+
+    return aliases
+
+
 def _merge_results(
     simbad: dict[str, Any],
     tns: dict[str, Any],
 ) -> dict[str, Any]:
     """
     Merge SIMBAD and TNS results, raising QuarantineError on conflict.
-    When both agree, prefer SIMBAD coordinates.
+    When both agree, prefer SIMBAD coordinates and aliases.
     """
     if simbad["is_nova"] != tns["is_nova"]:
         raise QuarantineError(

--- a/services/nova_resolver/handler.py
+++ b/services/nova_resolver/handler.py
@@ -9,7 +9,7 @@ Task dispatch table:
   CheckExistingNovaByName         — query NameMapping for normalized name
   CheckExistingNovaByCoordinates  — compute angular separation against all novae
   CreateNovaId                    — generate stable nova_id, write Nova stub
-  UpsertMinimalNovaMetadata       — persist coordinates and NameMapping
+  UpsertMinimalNovaMetadata       — persist coordinates, aliases, and NameMapping
   UpsertAliasForExistingNova      — add candidate name as alias to existing nova
 
 Angular separation:
@@ -175,7 +175,6 @@ def _check_existing_nova_by_coordinates(event: dict[str, Any], context: object) 
             matched_nova_id = cast(str, item["nova_id"])
 
     if min_sep == float("inf"):
-        # No novae with coordinates in DB yet
         logger.info("No novae with coordinates in database — no coordinate match")
         return {
             "match_outcome": "NONE",
@@ -248,11 +247,24 @@ def _create_nova_id(event: dict[str, Any], context: object) -> dict[str, Any]:
 @tracer.capture_method
 def _upsert_minimal_nova_metadata(event: dict[str, Any], context: object) -> dict[str, Any]:
     """
-    Persist resolved coordinates and NameMapping for a newly created nova.
+    Persist resolved coordinates, aliases, and NameMapping for a newly created nova.
 
     Writes:
-      1. Updates the Nova item with coordinates and ACTIVE status
+      1. Updates the Nova item with coordinates, ACTIVE status, and aliases list
       2. Writes a PRIMARY NameMapping item
+      3. Writes an ALIAS NameMapping item for each SIMBAD alias, if provided
+
+    The `aliases` field on the Nova item is a denormalized list of raw alias
+    strings (e.g. ["NOVA Sco 2012", "Gaia DR3 4043499439062100096"]).
+    It exists so that refresh_references can retrieve all known names for a
+    nova in a single get_item call without querying NameMapping partitions.
+
+    SIMBAD aliases are supplied via the optional `aliases` field in the event
+    (list of raw strings from archive_resolver). Each alias is:
+      - Stored raw in the Nova.aliases list and in name_raw on NameMapping
+      - Normalized (lowercase, collapse whitespace) for the NameMapping PK
+        so that CheckExistingNovaByName can find it
+      - Skipped if its normalized form matches normalized_candidate_name
 
     Returns:
         nova_id — echoed from input
@@ -264,15 +276,16 @@ def _upsert_minimal_nova_metadata(event: dict[str, Any], context: object) -> dic
     resolved_dec: float = float(event["resolved_dec"])
     resolved_epoch: str = event.get("resolved_epoch") or "J2000"
     resolver_source: str = event.get("resolver_source") or "UNKNOWN"
+    aliases: list[str] = event.get("aliases") or []
     now = _now()
 
-    # Update Nova item with coordinates and promote to ACTIVE
+    # Update Nova item with coordinates, ACTIVE status, and aliases list
     _table.update_item(
         Key={"PK": nova_id, "SK": "NOVA"},
         UpdateExpression=(
             "SET ra_deg = :ra, dec_deg = :dec, coord_epoch = :epoch, "
             "coord_frame = :frame, resolver_source = :source, "
-            "#status = :status, updated_at = :now"
+            "#status = :status, aliases = :aliases, updated_at = :now"
         ),
         ExpressionAttributeNames={"#status": "status"},
         ExpressionAttributeValues={
@@ -282,6 +295,7 @@ def _upsert_minimal_nova_metadata(event: dict[str, Any], context: object) -> dic
             ":frame": "ICRS",
             ":source": resolver_source,
             ":status": "ACTIVE",
+            ":aliases": aliases,
             ":now": now,
         },
     )
@@ -303,7 +317,35 @@ def _upsert_minimal_nova_metadata(event: dict[str, Any], context: object) -> dic
         }
     )
 
-    logger.info("Minimal nova metadata upserted", extra={"nova_id": nova_id})
+    # Write ALIAS NameMapping items for each SIMBAD alias
+    alias_count = 0
+    for alias_raw in aliases:
+        normalized_alias = re.sub(r"\s+", " ", alias_raw.strip().lower())
+        if not normalized_alias:
+            continue
+        if normalized_alias == normalized_candidate_name:
+            continue
+        _table.put_item(
+            Item={
+                "PK": f"NAME#{normalized_alias}",
+                "SK": f"NOVA#{nova_id}",
+                "entity_type": "NameMapping",
+                "schema_version": _SCHEMA_VERSION,
+                "name_raw": alias_raw,
+                "name_normalized": normalized_alias,
+                "name_kind": "ALIAS",
+                "nova_id": nova_id,
+                "source": "SIMBAD",
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
+        alias_count += 1
+
+    logger.info(
+        "Minimal nova metadata upserted",
+        extra={"nova_id": nova_id, "alias_count": alias_count},
+    )
     return {"nova_id": nova_id}
 
 

--- a/tests/integration/test_initialize_nova_integration.py
+++ b/tests/integration/test_initialize_nova_integration.py
@@ -31,6 +31,7 @@ from unittest.mock import patch
 
 import boto3
 import pytest
+from boto3.dynamodb.conditions import Key
 from moto import mock_aws
 
 # ---------------------------------------------------------------------------
@@ -271,6 +272,7 @@ class TestCreatedAndLaunched:
                 "resolved_dec": -30.5,
                 "resolved_epoch": "J2000",
                 "resolver_source": "SIMBAD",
+                "aliases": ["NOVA Test 2026", "Gaia DR3 1234567890"],
             }
 
             with (
@@ -358,6 +360,7 @@ class TestCreatedAndLaunched:
                         "resolved_dec": resolution["resolved_dec"],
                         "resolved_epoch": resolution["resolved_epoch"],
                         "resolver_source": resolution["resolver_source"],
+                        "aliases": resolution.get("aliases", []),
                         "correlation_id": state["job_run"]["correlation_id"],
                         "job_run_id": state["job_run"]["job_run_id"],
                     },
@@ -388,13 +391,31 @@ class TestCreatedAndLaunched:
             nova_item = table.get_item(Key={"PK": nova_id, "SK": "NOVA"}).get("Item")
             assert nova_item is not None
             assert nova_item["status"] == "ACTIVE"
+            assert nova_item["aliases"] == ["NOVA Test 2026", "Gaia DR3 1234567890"]
 
-            # NameMapping exists
+            # NameMapping — primary
             normalized = state["normalization"]["normalized_candidate_name"]
             name_item = table.get_item(
                 Key={"PK": f"NAME#{normalized}", "SK": f"NOVA#{nova_id}"}
             ).get("Item")
             assert name_item is not None
+            assert name_item["name_kind"] == "PRIMARY"
+
+            # NameMapping — SIMBAD aliases written for CREATED_AND_LAUNCHED path
+            alias1 = table.query(KeyConditionExpression=Key("PK").eq("NAME#nova test 2026"))[
+                "Items"
+            ]
+            assert len(alias1) == 1
+            assert alias1[0]["name_kind"] == "ALIAS"
+            assert alias1[0]["name_raw"] == "NOVA Test 2026"
+            assert alias1[0]["source"] == "SIMBAD"
+
+            alias2 = table.query(KeyConditionExpression=Key("PK").eq("NAME#gaia dr3 1234567890"))[
+                "Items"
+            ]
+            assert len(alias2) == 1
+            assert alias2[0]["name_kind"] == "ALIAS"
+            assert alias2[0]["name_raw"] == "Gaia DR3 1234567890"
 
 
 # ---------------------------------------------------------------------------
@@ -505,6 +526,7 @@ class TestExistsAndLaunchedByCoordinates:
                 "resolved_dec": _DUPLICATE_DEC,
                 "resolved_epoch": "J2000",
                 "resolver_source": "SIMBAD",
+                "aliases": [],
             }
 
             with (
@@ -617,6 +639,7 @@ class TestNotFound:
                 "is_nova": False,
                 "is_classical_nova": "false",
                 "resolver_source": "SIMBAD",
+                "aliases": [],
             }
 
             with (
@@ -678,6 +701,7 @@ class TestNotAClassicalNova:
                 "resolved_dec": -30.5,
                 "resolved_epoch": "J2000",
                 "resolver_source": "SIMBAD",
+                "aliases": [],
             }
 
             with (
@@ -770,6 +794,7 @@ class TestQuarantineCoordinateAmbiguity:
                 "resolved_dec": _AMBIGUOUS_DEC,
                 "resolved_epoch": "J2000",
                 "resolver_source": "SIMBAD",
+                "aliases": [],
             }
 
             with (
@@ -866,6 +891,7 @@ class TestQuarantineClassificationAmbiguity:
                 "resolved_dec": -30.5,
                 "resolved_epoch": "J2000",
                 "resolver_source": "SIMBAD",
+                "aliases": [],
             }
 
             with (


### PR DESCRIPTION
## SIMBAD alias collection during initialize_nova

### Summary
During `initialize_nova`, SIMBAD returns a pipe-delimited `ids` field
containing all known catalogue identifiers for an object (e.g. `"NOVA Sco
2012|Gaia DR3 4043499439062100096|MOA 2012-BLG-320"`). Previously this
field was ignored. This PR collects those aliases and persists them in two
ways:

1. **NameMapping items** — one per alias, normalized for PK so
   `CheckExistingNovaByName` can resolve any known alias to a `nova_id`
2. **`Nova.aliases`** — denormalized raw string list on the Nova item itself,
   so `refresh_references` can retrieve all known names in a single
   `get_item` call for ADS bibliography lookups

### Changes

#### `archive_resolver`
- Extract `ids` field from SIMBAD VOTable response
- `_parse_simbad_ids()` helper: splits on `|`, strips whitespace, strips
  leading `V* ` prefix (variable star annotation, not a searchable name)
- All return paths include `aliases` field (empty list for TNS-only and NONE)

#### `nova_resolver`
- `UpsertMinimalNovaMetadata` writes `aliases` onto the Nova item via
  `update_item`
- Writes one ALIAS NameMapping per alias; skips any whose normalized form
  matches `normalized_candidate_name`

#### `initialize_nova.asl.json`
- `UpsertMinimalNovaMetadata` Parameters block adds
  `"aliases.$": "$.resolution.aliases"`

#### Tests
- `test_initialize_nova_integration.py` — happy path asserts
  `nova_item["aliases"]` equals the expected list and both alias NameMapping
  items land in DynamoDB with correct `name_kind`, `name_raw`, and `source`

#### Docs
- `dynamodb-item-model.md` — `aliases` field added to Nova; example updated
- `dynamodb-access-patterns.md` — Section E notes the `Nova.aliases` write
- `contracts/models/entities.py` — `aliases: list[str]` added to `Nova`

### Breaking change
`Nova` DDB items created before this change will not have an `aliases` field.
`refresh_references` must handle its absence gracefully (treat as empty list).
Existing novae can be backfilled by re-running `initialize_nova` for each.