### PR TITLE
feat(epic-12): implement refresh_references workflow

### DIFF
--- a/docs/compressed/nova-cat-compressed-tests_3_3_26.md
+++ b/docs/compressed/nova-cat-compressed-tests_3_3_26.md
@@ -1,0 +1,312 @@
+# Nova Cat — Compressed Test Suite
+
+---
+
+## SHARED PATTERNS (all service unit tests)
+
+Every service test file follows this identical scaffold — stated once here, not repeated per file:
+
+**`aws_env` fixture** (`autouse=True`): sets `NOVA_CAT_TABLE_NAME`, `NOVA_CAT_QUARANTINE_TOPIC_ARN`, `INGEST_*_STATE_MACHINE_ARN` (where applicable), `AWS_DEFAULT_REGION=us-east-1`, `AWS_ACCESS_KEY_ID=test`, `AWS_SECRET_ACCESS_KEY=test`, `POWERTOOLS_SERVICE_NAME=nova-cat-test`, `LOG_LEVEL=DEBUG`.
+
+**`table` fixture**: `mock_aws()` + `dynamodb.create_table(_TABLE_NAME, PK+SK string, PAY_PER_REQUEST)`. Integration tests also add GSI1.
+
+**`_load_handler()`**: deletes cached module from `sys.modules`, then `importlib.import_module(...)`. All tests re-import fresh inside the moto context.
+
+**`_base_event(**kwargs)`**: minimal valid event with `task_name`, common fields, `**kwargs` override.
+
+**All tests** wrap handler calls in `with mock_aws():` and re-call `_load_handler()` per test.
+
+---
+
+## INFRA TESTS — `test_synth.py`
+
+**Fixture**: `template` (module scope) — synthesizes `NovaCatStack("NovaCatTest", account="000000000000", region="us-east-1")` once for all tests.
+
+### TestDynamoDb
+| Test | Assertion |
+|---|---|
+| single_table_exists | `resource_count_is("AWS::DynamoDB::Table", 1)` |
+| table_name | `TableName: "NovaCat"` |
+| primary_key_schema | `PK=HASH, SK=RANGE` |
+| primary_key_attribute_types | PK/SK/GSI1PK/GSI1SK all `AttributeType: S` |
+| billing_mode | `BillingMode: PAY_PER_REQUEST` |
+| pitr_disabled_by_default | `PointInTimeRecoveryEnabled: false` |
+| eligibility_gsi | `IndexName: EligibilityIndex`, `GSI1PK=HASH, GSI1SK=RANGE`, `Projection: ALL` |
+
+### TestS3
+| Test | Assertion |
+|---|---|
+| private_bucket_versioning | `Status: Enabled`; lifecycle rules `ExpireQuarantineObjects` (prefix=`quarantine/`, 365d) and `ExpireWorkflowPayloadSnapshots` (prefix=`workflow-payloads/`, 30d) |
+| private_bucket_blocks_public | All four `BlockPublic*/IgnorePublic*/Restrict*` = true |
+| public_site_releases_lifecycle | `ExpireOldReleases` (prefix=`releases/`, 730d) |
+| public_site_versioning_disabled | Bucket with `ExpireOldReleases` has no `VersioningConfiguration` |
+| both_buckets_enforce_ssl | Scans all `BucketPolicy` resources; asserts `aws:SecureTransport` condition present on ≥2 |
+
+### TestSns
+| Test | Assertion |
+|---|---|
+| quarantine_topic_exists | `TopicName: nova-cat-quarantine-notifications` |
+
+### TestLambda
+Parameterized against `_EXPECTED_FUNCTIONS` dict (12 entries):
+```
+nova-cat-nova-resolver      256MB  30s
+nova-cat-job-run-manager    256MB  30s
+nova-cat-idempotency-guard  256MB  30s
+nova-cat-archive-resolver   256MB  90s
+nova-cat-workflow-launcher  256MB  30s
+nova-cat-reference-manager  256MB  90s
+nova-cat-spectra-discoverer 256MB  60s
+nova-cat-spectra-acquirer   512MB  900s
+nova-cat-spectra-validator  512MB  300s
+nova-cat-photometry-ingestor 512MB 300s
+nova-cat-quarantine-handler 256MB  30s
+nova-cat-name-reconciler    256MB  90s
+```
+| Test | Assertion |
+|---|---|
+| all_twelve_functions_exist | all 12 names present in template |
+| all_functions_use_python_311 | `Runtime: python3.11` per function |
+| all_functions_have_xray_tracing | `TracingConfig.Mode: Active` per function |
+| all_functions_have_required_env_vars | all 6 standard env vars present per function |
+| function_memory_and_timeout (parametrized) | correct memory + timeout per entry in table above |
+
+**`_REQUIRED_ENV_VARS`**: `NOVA_CAT_TABLE_NAME`, `NOVA_CAT_PRIVATE_BUCKET`, `NOVA_CAT_PUBLIC_SITE_BUCKET`, `NOVA_CAT_QUARANTINE_TOPIC_ARN`, `LOG_LEVEL`, `POWERTOOLS_SERVICE_NAME`
+
+### TestOutputs
+Asserts `has_output("*", {"Export": {"Name": X}})` for each of:
+`NovaCat-TableName`, `NovaCat-PrivateBucketName`, `NovaCat-PublicSiteBucketName`, `NovaCat-QuarantineTopicArn`, `NovaCat-InitializeNovaStateMachineArn`, `NovaCat-IngestNewNovaStateMachineArn`, `NovaCat-RefreshReferencesStateMachineArn`, `NovaCat-DiscoverSpectraProductsStateMachineArn`
+
+### TestStepFunctions
+`_EXPECTED_STATE_MACHINES`: `nova-cat-initialize-nova`, `nova-cat-ingest-new-nova`, `nova-cat-refresh-references`, `nova-cat-discover-spectra-products`
+| Test | Assertion |
+|---|---|
+| all_state_machines_exist | each name present |
+| all_standard_workflow | `StateMachineType: STANDARD` per name |
+| all_have_execution_role | `RoleArn` present on each |
+| initialize_nova_can_invoke_lambdas | ≥1 IAM policy with `lambda:InvokeFunction` |
+| workflow_launcher_can_start_executions | ≥1 IAM policy with `states:StartExecution` |
+
+---
+
+## SERVICE UNIT TESTS
+
+### `test_idempotency_guard.py`
+`_TABLE_NAME = "NovaCat-Test"`. `_base_event()`: `task_name=AcquireIdempotencyLock, workflow_name=initialize_nova, primary_id="v1324 sco", job_run_id="job-001", correlation_id="corr-001"`.
+
+**TestAcquireIdempotencyLock**:
+- `acquires_lock_and_returns_key` → result has `idempotency_key`, `acquired_at`
+- `key_contains_workflow_name_and_primary_id` → key contains `"initialize_nova"` and `"v1324 sco"`
+- `writes_dynamodb_item` → `PK=IDEMPOTENCY#<key>, SK=LOCK`; item has `workflow_name`, `primary_id`, `job_run_id`, `ttl`
+- `lock_already_held_raises_retryable_error` → second call with same inputs raises `RetryableError(match="already held")`
+- `key_is_stable_for_same_inputs` → `_compute_key` deterministic within hour
+- `different_primary_ids_produce_different_keys` → `"v1324 sco"` ≠ `"rs oph"`
+- `works_with_nova_id_as_primary_id` → `workflow_name="ingest_new_nova"`, `primary_id="4e9b0e88-..."` appear in key
+- `different_workflows_produce_different_keys` → `initialize_nova` ≠ `ingest_new_nova`
+
+**TestDispatch**: unknown task → `ValueError(match="Unknown task_name")`
+
+---
+
+### `test_job_run_manager.py`
+`_base_event()`: `task_name=BeginJobRun, workflow_name=initialize_nova, candidate_name="V1324 Sco", correlation_id="corr-001"`.
+`_finalize_event(task_name, job_run, **kwargs)`: adds `job_run` dict.
+
+**TestBeginJobRun**:
+- `returns_job_run_id` → 36-char UUID
+- `uses_supplied_correlation_id` → echoed exactly
+- `generates_correlation_id_when_absent` → 36-char UUID generated
+- `writes_dynamodb_item` → `status=RUNNING, workflow_name=initialize_nova, candidate_name="V1324 Sco"`, `job_run_id` matches
+- `pk_uses_workflow_correlation_prefix` → `PK="WORKFLOW#corr-abc"`
+
+**TestFinalizeJobRunSuccess**:
+- `updates_status_to_succeeded` → `status=SUCCEEDED, outcome=CREATED_AND_LAUNCHED`
+- `all_valid_outcomes` (parametrized): `CREATED_AND_LAUNCHED`, `EXISTS_AND_LAUNCHED`, `NOT_FOUND`, `NOT_A_CLASSICAL_NOVA` — all return correctly
+
+**TestFinalizeJobRunFailed**:
+- `updates_status_to_failed` → `status=FAILED, error_type="TerminalError", error_message="Missing field"`
+- `handles_missing_error_field` → no error, `status=FAILED`
+
+**TestFinalizeJobRunQuarantined**: `status=QUARANTINED`
+
+**TestDispatch**: unknown task → `ValueError`
+
+---
+
+### `test_nova_resolver.py`
+Helpers: `_seed_nova(table, nova_id, ra, dec)` — writes `PK=<nova_id>, SK=NOVA` with `ra_deg/dec_deg` as `Decimal`. `_seed_name_mapping(table, normalized, nova_id)` — writes `PK=NAME#<normalized>, SK=NOVA#<nova_id>`.
+
+**TestNormalizeCandidateName** (parametrized):
+- `"V1324 Sco"` → `"v1324 sco"`
+- `"  RS  Oph  "` → `"rs oph"`
+- `"V407Cyg"` → `"v407cyg"`
+- `"NOVA SCO 2012"` → `"nova sco 2012"`
+- blank/whitespace → `TerminalError`
+
+**TestCheckExistingNovaByName**:
+- found → `{exists: True, nova_id: <uuid>}`
+- not found → `{exists: False}`, no `nova_id` key
+
+**TestCheckExistingNovaByCoordinates** (base coords `_RA=267.56, _DEC=-32.55`):
+- offset `+0.5/3600` in RA → `DUPLICATE`, `matched_nova_id` set
+- offset `+5.0/3600` in RA → `AMBIGUOUS`
+- offset `+30.0/3600` in RA → `NONE`
+- empty DB → `NONE`, no `matched_nova_id`
+
+**TestCreateNovaId**:
+- returns 36-char UUID
+- writes `PK=<nova_id>, SK=NOVA` with `status=PENDING, primary_name="V1324 Sco", entity_type=Nova`
+
+**TestUpsertMinimalNovaMetadata**:
+- promotes nova to `ACTIVE`, sets `ra_deg ≈ 267.56`
+- writes `PK=NAME#v1324 sco, SK=NOVA#<nova_id>` with `name_kind=PRIMARY`
+
+**TestUpsertAliasForExistingNova**:
+- writes `PK=NAME#nova sco 2012, SK=NOVA#<nova_id>` with `name_kind=ALIAS`
+
+**TestAngularSeparation**:
+- same point → `0.0` (abs=1e-6)
+- 1 arcsec dec offset → `≈1.0` (abs=0.001)
+- 10 arcsec dec offset → `≈10.0` (abs=0.01)
+
+**TestDispatch**: unknown task → `ValueError`
+
+---
+
+### `test_quarantine_handler.py`
+**Extra fixtures**: `topic` — moto SNS `create_topic(Name="nova-cat-quarantine-test")`.
+
+Pre-seeded JobRun item: `PK="WORKFLOW#corr-001", SK="JOBRUN#initialize_nova#2026-01-01T00:00:00Z#job-001", status=RUNNING`.
+
+`_base_event()`: `task_name=QuarantineHandler, workflow_name=initialize_nova, quarantine_reason_code=COORDINATE_AMBIGUITY, candidate_name="V1324 Sco", correlation_id=corr-001, job_run={pk, sk, job_run_id, correlation_id}`.
+
+**TestQuarantineHandlerPersistence** (all read back the JobRun item):
+- `writes_quarantine_reason_code` → `COORDINATE_AMBIGUITY`
+- `writes_error_fingerprint` → present, `len==12` (truncated SHA-256)
+- `writes_classification_reason` → present, non-empty
+- `writes_quarantined_at` → present
+- `captures_extra_context_min_sep_arcsec` → `_base_event(min_sep_arcsec=5.3)` → `item["extra_context"] == {"min_sep_arcsec": Decimal("5.3")}`
+- `no_extra_context_when_absent` → `"extra_context"` not in item
+- `unknown_reason_code_uses_fallback_classification` → still writes `error_fingerprint` + non-empty `classification_reason`
+
+**TestQuarantineHandlerReturnValue**:
+- returns `quarantine_reason_code`, `error_fingerprint` (len 12), `quarantined_at`
+- `error_fingerprint_is_stable` → two calls with same inputs → same fingerprint
+
+**TestQuarantineHandlerSns** (patches `handler._sns`):
+- `sns_failure_does_not_raise` → `publish.side_effect = Exception(...)` → no raise, result has `error_fingerprint`
+- `uses_candidate_name_as_primary_id_when_no_nova_id` → SNS payload `primary_id == "V1324 Sco"`
+- `uses_nova_id_as_primary_id_when_present` → `_base_event(nova_id="nova-uuid-001")` → `primary_id == "nova-uuid-001"`
+- `sns_payload_contains_required_fields` → payload has `workflow_name`, `primary_id`, `correlation_id`, `error_fingerprint`, `quarantine_reason_code`, `classification_reason`
+
+**TestDispatch**: unknown task → `ValueError`
+
+---
+
+### `test_workflow_launcher.py`
+`_FAKE_NOVA_ID = "nova-uuid-001"`, `_FAKE_JOB_RUN_ID = "job-run-abcdef12"`, `_EXPECTED_EXECUTION_NAME = f"{_FAKE_NOVA_ID}-{_FAKE_JOB_RUN_ID[:8]}"`.
+
+**`state_machines` fixture**: moto SFN; creates all 3 state machines (`nova-cat-ingest-new-nova`, `nova-cat-refresh-references`, `nova-cat-discover-spectra-products`) with trivial `Succeed` ASL.
+
+**TestLaunchTasks** (parametrized: `PublishIngestNewNova/ingest_new_nova`, `LaunchRefreshReferences/refresh_references`, `LaunchDiscoverSpectraProducts/discover_spectra_products`):
+- `starts_execution_and_returns_arn` → `execution_arn` in result, SM name in ARN
+- `returns_nova_id` → `result["nova_id"] == _FAKE_NOVA_ID`
+- `execution_name_derived_from_nova_id_and_job_run_id` → `result["execution_name"] == _EXPECTED_EXECUTION_NAME`
+- `execution_input_contains_nova_id_and_correlation_id` → fetches execution via `sfn.describe_execution`; verifies `nova_id` and `correlation_id` in parsed input JSON
+- `execution_already_exists_treated_as_success` → patches `_sfn.start_execution` with `ClientError(ExecutionAlreadyExists)` → `result["already_existed"] is True`
+
+**TestThrottling**: `ThrottlingException` ClientError → `RetryableError`
+
+**TestStubTasks**: `PublishAcquireAndValidateSpectraRequests` → `NotImplementedError`
+
+**TestDispatch**: unknown task → `ValueError`
+
+---
+
+### `test_archive_resolver.py`
+No DynamoDB. Patches `astroquery.simbad.Simbad` at import time. Helper `_make_mock_table(otypes, ra, dec)` builds mock astropy Table. `_resolve_event(**kwargs)` → `task_name=ResolveCandidateAgainstPublicArchives, candidate_name="V1324 Sco"`.
+
+**TestSimbadClassification**:
+- `["No*", "V*"]` → `is_nova=True, is_classical_nova="true", resolver_source="SIMBAD"`
+- `["RNe", "V*"]` → `is_nova=True, is_classical_nova="false"`
+- `["Star", "V*"]` → `is_nova=False`
+- nova otype → `resolved_ra/dec` present, `resolved_epoch="J2000"`
+- non-nova otype → no `resolved_ra` in result
+
+**TestNoResult**:
+- `query_object=None`, `TNS_API_KEY=""` → `is_nova=False, resolver_source="NONE"`
+- empty mock table (`len=0`) → `is_nova=False`
+
+**TestErrorHandling**:
+- `query_object` raises `Exception("timeout...")` → `RetryableError`
+- SIMBAD says not-nova + TNS says nova → `_merge_results(simbad_result, tns_result)` raises `QuarantineError`
+
+**TestClassifyOtypes** (parametrized, calls `handler._classify_otypes(otypes)` directly):
+| otypes | is_nova | is_classical |
+|---|---|---|
+| `{"No*", "V*"}` | True | "true" |
+| `{"No?"}` | True | "true" |
+| `{"NL*", "Star"}` | True | "true" |
+| `{"RNe", "V*"}` | True | "false" |
+| `{"RN*"}` | True | "false" |
+| `{"Star", "V*"}` | False | "false" |
+| `set()` | False | "false" |
+
+---
+
+## INTEGRATION TESTS
+
+### Shared infrastructure (both integration test files)
+
+**`table` fixture** (both files): `mock_aws()` + DynamoDB with PK/SK + **GSI1** (`EligibilityIndex`, GSI1PK/GSI1SK, ALL projection).
+
+**Handler loader**: `_load_handlers()` — deletes all relevant module entries from `sys.modules`, re-imports all handlers fresh inside moto context.
+
+**`_run_prefix(h, ...)`**: runs the common state machine prefix shared by all paths.
+
+---
+
+### `test_initialize_nova_integration.py`
+
+**Constants**:
+- `_EXISTING_NOVA_ID = "aaaaaaaa-0000-0000-0000-000000000001"`
+- `_EXISTING_NOVA_RA/DEC = 270.0, -30.0`
+- `_DUPLICATE_RA/DEC = 270.000001, -30.000001` (< 2" away)
+- `_AMBIGUOUS_RA/DEC = 270.0015, -30.0` (~5" away)
+
+**Common prefix**: `BeginJobRun → NormalizeCandidateName → AcquireIdempotencyLock`. Returns `{candidate_name, job_run, normalization}`.
+
+Helpers: `_finalize_success(h, state, outcome, nova_id=None)`, `_finalize_quarantined(h, state)`, `_get_job_run(table, state)`.
+
+All archive resolver calls patch `_query_simbad` and `_query_tns`; all SFN calls patch `_sfn`.
+
+**7 paths tested**:
+
+| Path | Class | Key setup | Key assertions |
+|---|---|---|---|
+| CREATED_AND_LAUNCHED | `TestCreatedAndLaunched` | SIMBAD: `is_classical_nova="true"`, `aliases=["NOVA Test 2026", "Gaia DR3 1234567890"]`; empty DB | JobRun `SUCCEEDED/CREATED_AND_LAUNCHED`; Nova `status=ACTIVE, aliases=[...]`; PRIMARY NameMapping; 2 ALIAS NameMappings (`name_kind=ALIAS, source=SIMBAD`) |
+| EXISTS_AND_LAUNCHED (name) | `TestExistsAndLaunchedByName` | Seed Nova + `NAME#v1324 sco` NameMapping | `CheckExistingNovaByName` returns `exists=True, nova_id=_EXISTING_NOVA_ID`; JobRun `SUCCEEDED/EXISTS_AND_LAUNCHED` |
+| EXISTS_AND_LAUNCHED (coord) | `TestExistsAndLaunchedByCoordinates` | Seed Nova with `ra_deg/dec_deg=Decimal`; SIMBAD returns `_DUPLICATE_RA/DEC` | `CheckExistingNovaByCoordinates` returns `DUPLICATE, matched_nova_id=_EXISTING_NOVA_ID`; alias NameMapping written; JobRun `SUCCEEDED/EXISTS_AND_LAUNCHED` |
+| NOT_FOUND | `TestNotFound` | SIMBAD: `is_nova=False` | `resolution["is_nova"] is False`; JobRun `SUCCEEDED/NOT_FOUND` |
+| NOT_A_CLASSICAL_NOVA | `TestNotAClassicalNova` | SIMBAD: `is_nova=True, is_classical_nova="false"` | coord check returns `NONE`; JobRun `SUCCEEDED/NOT_A_CLASSICAL_NOVA` |
+| QUARANTINE (coord ambiguity) | `TestQuarantineCoordinateAmbiguity` | Seed Nova at `_EXISTING_NOVA_RA/DEC`; SIMBAD returns `_AMBIGUOUS_RA/DEC`; patch `_sns` | coord check `AMBIGUOUS`; quarantine result has `error_fingerprint`; JobRun `QUARANTINED, quarantine_reason_code=COORDINATE_AMBIGUITY` |
+| QUARANTINE (classification) | `TestQuarantineClassificationAmbiguity` | SIMBAD: `is_classical_nova="ambiguous"`; patch `_sns` | coord check `NONE`; quarantine `reason_code=OTHER`; JobRun `QUARANTINED` |
+
+---
+
+### `test_ingest_new_nova_integration.py`
+
+**Constants**: `_NOVA_ID = "aaaaaaaa-0000-0000-0000-000000000001"`, `_CORRELATION_ID = "integ-ingest-corr-001"`.
+
+**Common prefix** (`_run_prefix(h)`): `BeginJobRun(workflow_name=ingest_new_nova, nova_id=_NOVA_ID) → AcquireIdempotencyLock`. Returns `{nova_id, job_run}`.
+
+All SFN calls patch `h["workflow_launcher"]._sfn` with `start_execution.return_value = {"executionArn": _FAKE_EXECUTION_ARN}`.
+
+**3 paths**:
+
+| Path | Class | Test | Key assertion |
+|---|---|---|---|
+| Happy path | `TestHappyPath` | `both_branches_succeed` | Both launches return `execution_arn`; JobRun `SUCCEEDED/LAUNCHED` |
+| | | `sfn_called_twice_for_both_branches` | `mock_sfn.start_execution.call_count == 2` |
+| | | `both_branches_idempotent_on_retry` | `start_execution.side_effect = ClientError(ExecutionAlreadyExists)`; both return `already_existed=True`; JobRun `SUCCEEDED/LAUNCHED` |
+| Failure path | `TestFailurePath` | `terminal_error_routes_to_fail_handler` | First launch succeeds; second raises `ClientError(AccessDeniedException)` → caught by test; `FinalizeJobRunFailed` called manually; JobRun `FAILED, error_type=ClientError` |

--- a/infra/workflows/refresh_references.asl.json
+++ b/infra/workflows/refresh_references.asl.json
@@ -1,11 +1,377 @@
 {
-  "Comment": "refresh_references workflow — placeholder stub pending Epic 12+.",
-  "StartAt": "NotImplemented",
-  "States": {
-    "NotImplemented": {
-      "Type": "Fail",
-      "Error": "NotImplemented",
-      "Cause": "refresh_references workflow not yet implemented"
+    "Comment": "refresh_references workflow — fetches ADS references for a nova, upserts global Reference entities, links them via NovaReference, and computes discovery_date.",
+    "StartAt": "BeginJobRun",
+    "States": {
+        "BeginJobRun": {
+            "Type": "Task",
+            "Resource": "${BeginJobRunFunctionArn}",
+            "Parameters": {
+                "task_name": "BeginJobRun",
+                "workflow_name": "refresh_references",
+                "nova_id.$": "$.nova_id",
+                "correlation_id.$": "$.correlation_id"
+            },
+            "ResultPath": "$.job_run",
+            "TimeoutSeconds": 10,
+            "Retry": [
+                {
+                    "ErrorEquals": [
+                        "RetryableError"
+                    ],
+                    "IntervalSeconds": 2,
+                    "MaxAttempts": 3,
+                    "BackoffRate": 1,
+                    "JitterStrategy": "FULL"
+                }
+            ],
+            "Catch": [
+                {
+                    "ErrorEquals": [
+                        "States.ALL"
+                    ],
+                    "Next": "TerminalFailHandler",
+                    "ResultPath": "$.error"
+                }
+            ],
+            "Next": "AcquireIdempotencyLock"
+        },
+        "AcquireIdempotencyLock": {
+            "Type": "Task",
+            "Comment": "Acquire workflow-level idempotency lock. Key: refresh_references:{nova_id}:{schema_version}:{time_bucket}.",
+            "Resource": "${AcquireIdempotencyLockFunctionArn}",
+            "Parameters": {
+                "task_name": "AcquireIdempotencyLock",
+                "workflow_name": "refresh_references",
+                "primary_id.$": "$.nova_id",
+                "correlation_id.$": "$.job_run.correlation_id",
+                "job_run_id.$": "$.job_run.job_run_id"
+            },
+            "ResultPath": "$.idempotency",
+            "TimeoutSeconds": 10,
+            "Retry": [
+                {
+                    "ErrorEquals": [
+                        "RetryableError"
+                    ],
+                    "IntervalSeconds": 2,
+                    "MaxAttempts": 3,
+                    "BackoffRate": 1,
+                    "JitterStrategy": "FULL"
+                }
+            ],
+            "Catch": [
+                {
+                    "ErrorEquals": [
+                        "States.ALL"
+                    ],
+                    "Next": "TerminalFailHandler",
+                    "ResultPath": "$.error"
+                }
+            ],
+            "Next": "FetchReferenceCandidates"
+        },
+        "FetchReferenceCandidates": {
+            "Type": "Task",
+            "Comment": "Load nova aliases, query ADS by name, return raw candidate docs. Output stored at $.fetch; $.fetch.candidates feeds the ReconcileReferences Map.",
+            "Resource": "${ReferenceManagerFunctionArn}",
+            "Parameters": {
+                "task_name": "FetchReferenceCandidates",
+                "workflow_name": "refresh_references",
+                "nova_id.$": "$.nova_id",
+                "correlation_id.$": "$.job_run.correlation_id",
+                "job_run_id.$": "$.job_run.job_run_id"
+            },
+            "ResultPath": "$.fetch",
+            "TimeoutSeconds": 60,
+            "Retry": [
+                {
+                    "ErrorEquals": [
+                        "RetryableError"
+                    ],
+                    "IntervalSeconds": 2,
+                    "MaxAttempts": 3,
+                    "BackoffRate": 1,
+                    "JitterStrategy": "FULL"
+                }
+            ],
+            "Catch": [
+                {
+                    "ErrorEquals": [
+                        "States.ALL"
+                    ],
+                    "Next": "TerminalFailHandler",
+                    "ResultPath": "$.error"
+                }
+            ],
+            "Next": "ReconcileReferences"
+        },
+        "ReconcileReferences": {
+            "Type": "Map",
+            "Comment": "For each ADS candidate doc: normalize, upsert global Reference entity, link to nova. Item-level failures are quarantined and skipped; they do not fail the Map. All ADS_FIELDS are explicitly requested so all keys are present in each item (null when absent from ADS).",
+            "ItemsPath": "$.fetch.candidates",
+            "ItemSelector": {
+                "nova_id.$": "$$.Execution.Input.nova_id",
+                "correlation_id.$": "$$.Execution.Input.correlation_id",
+                "bibcode.$": "$$.Map.Item.Value.bibcode",
+                "doctype.$": "$$.Map.Item.Value.doctype",
+                "title.$": "$$.Map.Item.Value.title",
+                "date.$": "$$.Map.Item.Value.date",
+                "author.$": "$$.Map.Item.Value.author",
+                "doi.$": "$$.Map.Item.Value.doi",
+                "identifier.$": "$$.Map.Item.Value.identifier"
+            },
+            "MaxConcurrency": 5,
+            "ResultPath": "$.reconcile",
+            "Iterator": {
+                "StartAt": "NormalizeReference",
+                "States": {
+                    "NormalizeReference": {
+                        "Type": "Task",
+                        "Resource": "${ReferenceManagerFunctionArn}",
+                        "Parameters": {
+                            "task_name": "NormalizeReference",
+                            "nova_id.$": "$.nova_id",
+                            "bibcode.$": "$.bibcode",
+                            "doctype.$": "$.doctype",
+                            "title.$": "$.title",
+                            "date.$": "$.date",
+                            "author.$": "$.author",
+                            "doi.$": "$.doi",
+                            "identifier.$": "$.identifier"
+                        },
+                        "TimeoutSeconds": 20,
+                        "Retry": [
+                            {
+                                "ErrorEquals": [
+                                    "RetryableError"
+                                ],
+                                "IntervalSeconds": 2,
+                                "MaxAttempts": 2,
+                                "BackoffRate": 1,
+                                "JitterStrategy": "FULL"
+                            }
+                        ],
+                        "Catch": [
+                            {
+                                "ErrorEquals": [
+                                    "States.ALL"
+                                ],
+                                "Next": "ItemFailureHandler",
+                                "ResultPath": "$.error"
+                            }
+                        ],
+                        "Next": "UpsertReferenceEntity"
+                    },
+                    "UpsertReferenceEntity": {
+                        "Type": "Task",
+                        "Comment": "Write or update global Reference item. PK=REFERENCE#<bibcode>, SK=METADATA. Preserves created_at on update.",
+                        "Resource": "${ReferenceManagerFunctionArn}",
+                        "Parameters": {
+                            "task_name": "UpsertReferenceEntity",
+                            "nova_id.$": "$.nova_id",
+                            "bibcode.$": "$.bibcode",
+                            "reference_type.$": "$.reference_type",
+                            "title.$": "$.title",
+                            "year.$": "$.year",
+                            "publication_date.$": "$.publication_date",
+                            "authors.$": "$.authors",
+                            "doi.$": "$.doi",
+                            "arxiv_id.$": "$.arxiv_id"
+                        },
+                        "TimeoutSeconds": 20,
+                        "Retry": [
+                            {
+                                "ErrorEquals": [
+                                    "RetryableError"
+                                ],
+                                "IntervalSeconds": 2,
+                                "MaxAttempts": 2,
+                                "BackoffRate": 1,
+                                "JitterStrategy": "FULL"
+                            }
+                        ],
+                        "Catch": [
+                            {
+                                "ErrorEquals": [
+                                    "States.ALL"
+                                ],
+                                "Next": "ItemFailureHandler",
+                                "ResultPath": "$.error"
+                            }
+                        ],
+                        "Next": "LinkNovaReference"
+                    },
+                    "LinkNovaReference": {
+                        "Type": "Task",
+                        "Comment": "Idempotent upsert of NOVAREF link. PK=<nova_id>, SK=NOVAREF#<bibcode>. ConditionalCheckFailed is silently swallowed.",
+                        "Resource": "${ReferenceManagerFunctionArn}",
+                        "Parameters": {
+                            "task_name": "LinkNovaReference",
+                            "nova_id.$": "$.nova_id",
+                            "bibcode.$": "$.bibcode",
+                            "publication_date.$": "$.publication_date"
+                        },
+                        "TimeoutSeconds": 20,
+                        "Retry": [
+                            {
+                                "ErrorEquals": [
+                                    "RetryableError"
+                                ],
+                                "IntervalSeconds": 2,
+                                "MaxAttempts": 2,
+                                "BackoffRate": 1,
+                                "JitterStrategy": "FULL"
+                            }
+                        ],
+                        "Catch": [
+                            {
+                                "ErrorEquals": [
+                                    "States.ALL"
+                                ],
+                                "Next": "ItemFailureHandler",
+                                "ResultPath": "$.error"
+                            }
+                        ],
+                        "End": true
+                    },
+                    "ItemFailureHandler": {
+                        "Type": "Pass",
+                        "Comment": "TODO: wire to quarantine_handler Lambda for item-level quarantine tracking and SNS notification. For now, records the error context and continues the Map so one bad reference does not abort the workflow.",
+                        "End": true
+                    }
+                }
+            },
+            "Catch": [
+                {
+                    "ErrorEquals": [
+                        "States.ALL"
+                    ],
+                    "Next": "TerminalFailHandler",
+                    "ResultPath": "$.error"
+                }
+            ],
+            "Next": "ComputeDiscoveryDate"
+        },
+        "ComputeDiscoveryDate": {
+            "Type": "Task",
+            "Comment": "Query all NOVAREF links, batch-fetch publication_dates, return earliest bibcode+date. Tiebreaker: lexicographically smallest bibcode.",
+            "Resource": "${ReferenceManagerFunctionArn}",
+            "Parameters": {
+                "task_name": "ComputeDiscoveryDate",
+                "workflow_name": "refresh_references",
+                "nova_id.$": "$.nova_id",
+                "correlation_id.$": "$.job_run.correlation_id",
+                "job_run_id.$": "$.job_run.job_run_id"
+            },
+            "ResultPath": "$.discovery",
+            "TimeoutSeconds": 20,
+            "Retry": [
+                {
+                    "ErrorEquals": [
+                        "RetryableError"
+                    ],
+                    "IntervalSeconds": 2,
+                    "MaxAttempts": 2,
+                    "BackoffRate": 1,
+                    "JitterStrategy": "FULL"
+                }
+            ],
+            "Catch": [
+                {
+                    "ErrorEquals": [
+                        "States.ALL"
+                    ],
+                    "Next": "TerminalFailHandler",
+                    "ResultPath": "$.error"
+                }
+            ],
+            "Next": "UpsertDiscoveryDateMetadata"
+        },
+        "UpsertDiscoveryDateMetadata": {
+            "Type": "Task",
+            "Comment": "Write discovery_date to Nova item only if strictly earlier than current value (monotonically earlier invariant, ADR-005 §4). No-op if unchanged or no date computed.",
+            "Resource": "${ReferenceManagerFunctionArn}",
+            "Parameters": {
+                "task_name": "UpsertDiscoveryDateMetadata",
+                "workflow_name": "refresh_references",
+                "nova_id.$": "$.nova_id",
+                "correlation_id.$": "$.job_run.correlation_id",
+                "job_run_id.$": "$.job_run.job_run_id",
+                "earliest_bibcode.$": "$.discovery.earliest_bibcode",
+                "earliest_publication_date.$": "$.discovery.earliest_publication_date"
+            },
+            "ResultPath": "$.discovery_upsert",
+            "TimeoutSeconds": 20,
+            "Retry": [
+                {
+                    "ErrorEquals": [
+                        "RetryableError"
+                    ],
+                    "IntervalSeconds": 2,
+                    "MaxAttempts": 3,
+                    "BackoffRate": 1,
+                    "JitterStrategy": "FULL"
+                }
+            ],
+            "Catch": [
+                {
+                    "ErrorEquals": [
+                        "States.ALL"
+                    ],
+                    "Next": "TerminalFailHandler",
+                    "ResultPath": "$.error"
+                }
+            ],
+            "Next": "FinalizeJobRunSuccess"
+        },
+        "FinalizeJobRunSuccess": {
+            "Type": "Task",
+            "Resource": "${FinalizeJobRunSuccessFunctionArn}",
+            "Parameters": {
+                "task_name": "FinalizeJobRunSuccess",
+                "workflow_name": "refresh_references",
+                "outcome": "SUCCEEDED",
+                "nova_id.$": "$.nova_id",
+                "correlation_id.$": "$.job_run.correlation_id",
+                "job_run_id.$": "$.job_run.job_run_id",
+                "job_run.$": "$.job_run"
+            },
+            "ResultPath": "$.finalize",
+            "TimeoutSeconds": 10,
+            "Retry": [
+                {
+                    "ErrorEquals": [
+                        "RetryableError"
+                    ],
+                    "IntervalSeconds": 2,
+                    "MaxAttempts": 3,
+                    "BackoffRate": 1,
+                    "JitterStrategy": "FULL"
+                }
+            ],
+            "Catch": [
+                {
+                    "ErrorEquals": [
+                        "States.ALL"
+                    ],
+                    "Next": "TerminalFailHandler",
+                    "ResultPath": "$.error"
+                }
+            ],
+            "End": true
+        },
+        "TerminalFailHandler": {
+            "Type": "Task",
+            "Resource": "${FinalizeJobRunFailedFunctionArn}",
+            "Parameters": {
+                "task_name": "FinalizeJobRunFailed",
+                "workflow_name": "refresh_references",
+                "error.$": "$.error",
+                "job_run.$": "$.job_run"
+            },
+            "ResultPath": "$.finalize",
+            "TimeoutSeconds": 10,
+            "End": true
+        }
     }
-  }
 }

--- a/services/reference_manager/handler.py
+++ b/services/reference_manager/handler.py
@@ -3,7 +3,8 @@ reference_manager — Lambda handler
 
 Description: ADS reference fetch, upsert, link, and discovery_date computation
 Workflows:   refresh_references
-Tasks:       FetchReferenceCandidates, NormalizeReference, UpsertReferenceEntity, LinkNovaReference, ComputeDiscoveryDate, UpsertDiscoveryDateMetadata
+Tasks:       FetchReferenceCandidates, NormalizeReference, UpsertReferenceEntity,
+             LinkNovaReference, ComputeDiscoveryDate, UpsertDiscoveryDateMetadata
 
 Step Functions passes a `task_name` field in the event payload so this
 single Lambda can serve multiple state machine task states. Each task
@@ -14,32 +15,550 @@ Environment variables (injected by CDK):
     NOVA_CAT_PRIVATE_BUCKET       — private data S3 bucket name
     NOVA_CAT_PUBLIC_SITE_BUCKET   — public site S3 bucket name
     NOVA_CAT_QUARANTINE_TOPIC_ARN — quarantine notifications SNS topic ARN
+    ADS_SECRET_NAME               — Secrets Manager secret name for ADS token
+                                    (default: "ADSQueryToken")
     LOG_LEVEL                     — logging level (default INFO)
     POWERTOOLS_SERVICE_NAME       — AWS Lambda Powertools service name
 """
 
 from __future__ import annotations
 
-import logging
+import contextlib
+import json
 import os
+import re
 from collections.abc import Callable
+from datetime import UTC, datetime
+from urllib.parse import urlencode
 
-logger = logging.getLogger(__name__)
-logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+import boto3
+import requests  # type: ignore[import-untyped]
+from boto3.dynamodb.conditions import Attr, Key
+from botocore.exceptions import ClientError
+from nova_common.errors import RetryableError, TerminalError
+from nova_common.logging import configure_logging, logger
+from nova_common.tracing import tracer
+
+# ---------------------------------------------------------------------------
+# AWS clients — module-level so moto patches them on fresh import in tests
+# ---------------------------------------------------------------------------
+
+_TABLE_NAME = os.environ["NOVA_CAT_TABLE_NAME"]
+_ADS_SECRET_NAME = os.environ.get("ADS_SECRET_NAME", "ADSQueryToken")
+_ADS_API_URL = "https://api.adsabs.harvard.edu/v1/search/query"
+_ADS_FIELDS = ["bibcode", "doctype", "title", "date", "author", "doi", "identifier"]
+
+_dynamodb = boto3.resource("dynamodb")
+_table = _dynamodb.Table(_TABLE_NAME)
+_secretsmanager = boto3.client("secretsmanager")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_ARXIV_RE = re.compile(r"^arXiv:(.+)$", re.IGNORECASE)
+
+_DOCTYPE_TO_REFERENCE_TYPE: dict[str, str] = {
+    "article": "journal_article",
+    "eprint": "arxiv_preprint",
+    "inproceedings": "conference_abstract",
+    "abstract": "conference_abstract",
+    "circular": "cbat_circular",
+    "telegram": "atel",
+    "catalog": "catalog",
+    "software": "software",
+}
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
 
 
+def _utcnow_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _get_ads_token() -> str:
+    """Retrieve ADS Bearer token from Secrets Manager."""
+    resp = _secretsmanager.get_secret_value(SecretId=_ADS_SECRET_NAME)
+    val = resp.get("SecretString") or ""
+    try:
+        obj = json.loads(val)
+        return obj.get("token") or obj.get("ADS_TOKEN") or val
+    except Exception:
+        return val
+
+
+def _quote(name: str) -> str:
+    """Wrap a name in double-quotes for an ADS query; escape internal quotes."""
+    name = (name or "").strip()
+    return '"' + name.replace('"', r"\"") + '"' if name else ""
+
+
+def _build_ads_query(names: list[str]) -> str:
+    """OR-join individually-quoted names into an ADS search query string."""
+    quoted = [_quote(n) for n in names if (n or "").strip()]
+    if not quoted:
+        raise TerminalError("No names available to build ADS query")
+    return " OR ".join(quoted)
+
+
+def _ads_request(query: str, token: str) -> list[dict]:
+    """Execute ADS search query and return raw doc list."""
+    encoded = urlencode({"q": query, "fl": ",".join(_ADS_FIELDS), "rows": 2000, "sort": "date asc"})
+    url = f"{_ADS_API_URL}?{encoded}"
+    headers = {"Authorization": f"Bearer {token}"}
+    try:
+        resp = requests.get(url, headers=headers, timeout=25)
+    except requests.exceptions.Timeout as exc:
+        raise RetryableError(f"ADS request timed out: {exc}") from exc
+    except requests.exceptions.RequestException as exc:
+        raise RetryableError(f"ADS network error: {exc}") from exc
+
+    if resp.status_code == 429:
+        raise RetryableError("ADS rate limit exceeded (HTTP 429)")
+    if resp.status_code == 401:
+        raise TerminalError("ADS authentication failed — check ADSQueryToken secret")
+    if resp.status_code >= 500:
+        raise RetryableError(f"ADS server error (HTTP {resp.status_code})")
+
+    resp.raise_for_status()
+    return resp.json().get("response", {}).get("docs", []) or []
+
+
+def _normalize_publication_date(ads_date: str | None) -> str | None:
+    """
+    Normalize an ADS date string to YYYY-MM-00.
+
+    ADS returns YYYY-MM-01T00:00:00Z when only month precision is available
+    (day is always a placeholder, never meaningful). We discard the day
+    unconditionally and store month-only precision as YYYY-MM-00.
+    """
+    if not ads_date:
+        return None
+    # Strip time component if present: "YYYY-MM-01T00:00:00Z" → "YYYY-MM-01"
+    date_part = ads_date.strip().split("T")[0]
+    parts = date_part.split("-")
+    if len(parts) < 2:
+        return None
+    year, month = parts[0], parts[1].zfill(2)
+    if len(year) != 4 or not year.isdigit():
+        return None
+    if not month.isdigit() or not (1 <= int(month) <= 12):
+        return None
+    return f"{year}-{month}-00"
+
+
+def _extract_arxiv_id(identifiers: list | None) -> str | None:
+    """Return bare arXiv ID (strip 'arXiv:' prefix) from ADS identifier list."""
+    for ident in identifiers or []:
+        m = _ARXIV_RE.match(str(ident))
+        if m:
+            return m.group(1)
+    return None
+
+
+def _map_doctype(doctype: str | None) -> str:
+    if not doctype:
+        return "other"
+    return _DOCTYPE_TO_REFERENCE_TYPE.get(doctype.strip().lower(), "other")
+
+
+# ---------------------------------------------------------------------------
+# Per-task handler implementations
+# ---------------------------------------------------------------------------
+
+
+@tracer.capture_method
+def _handle_fetchReferenceCandidates(event: dict, context: object) -> dict:
+    """
+    Load nova aliases from DDB, build ADS name query, return raw candidate docs.
+
+    The Nova item carries a denormalized `aliases` list so we can retrieve
+    all known names in a single get_item (ADR-005).
+
+    Output shape (feeds into the ReconcileReferences Map state):
+        {
+            "nova_id": "<uuid>",
+            "candidates": [ <raw ADS doc>, ... ],   # ASL ItemsPath
+            "candidate_count": <int>,
+        }
+    """
+    nova_id: str | None = event.get("nova_id")
+    if not nova_id:
+        raise TerminalError("Missing required field: nova_id")
+
+    ads_name_hints: list[str] = (event.get("attributes") or {}).get("ads_name_hints") or []
+
+    nova_item = _table.get_item(Key={"PK": nova_id, "SK": "NOVA"}).get("Item")
+    if not nova_item:
+        raise TerminalError(f"Nova not found in DDB: {nova_id}")
+
+    primary_name: str = str(nova_item.get("primary_name") or "")
+    raw_aliases = nova_item.get("aliases")
+    aliases: list[str] = [str(a) for a in raw_aliases] if isinstance(raw_aliases, list) else []
+
+    # Deduplicate preserving insertion order; case-insensitive
+    seen: set[str] = set()
+    names: list[str] = []
+    for name in [primary_name, *aliases, *ads_name_hints]:
+        key = name.strip().lower()
+        if key and key not in seen:
+            names.append(name.strip())
+            seen.add(key)
+
+    if not names:
+        raise TerminalError(f"No names available for ADS query — nova_id={nova_id}")
+
+    token = _get_ads_token()
+    query = _build_ads_query(names)
+
+    logger.info(
+        "Querying ADS",
+        extra={"query": query, "name_count": len(names), "nova_id": nova_id},
+    )
+
+    docs = _ads_request(query, token)
+
+    logger.info(
+        "ADS returned candidates",
+        extra={"candidate_count": len(docs), "nova_id": nova_id},
+    )
+
+    return {
+        "nova_id": nova_id,
+        "candidates": docs,
+        "candidate_count": len(docs),
+    }
+
+
+@tracer.capture_method
+def _handle_normalizeReference(event: dict, context: object) -> dict:
+    """
+    Map one raw ADS doc to the Reference schema.
+
+    Called once per Map iteration. Step Functions delivers each candidate doc
+    as the Map item; nova_id is injected alongside it via ASL Parameters.
+
+    Input:  raw ADS doc fields + nova_id (from ASL Parameters)
+    Output: normalized reference fields for UpsertReferenceEntity
+    """
+    bibcode: str | None = event.get("bibcode")
+    if not bibcode:
+        raise TerminalError("ADS doc is missing bibcode — cannot normalize")
+
+    publication_date = _normalize_publication_date(event.get("date"))
+
+    year: int | None = None
+    if publication_date:
+        with contextlib.suppress(ValueError, IndexError):
+            year = int(publication_date[:4])
+
+    # ADS title is a list; take the first element
+    raw_title = event.get("title")
+    title: str | None = (
+        raw_title[0] if isinstance(raw_title, list) and raw_title else raw_title or None
+    )
+
+    # ADS doi is sometimes a list too
+    raw_doi = event.get("doi")
+    doi: str | None = raw_doi[0] if isinstance(raw_doi, list) and raw_doi else raw_doi or None
+
+    authors: list[str] = event.get("author") or []
+    arxiv_id = _extract_arxiv_id(event.get("identifier"))
+    reference_type = _map_doctype(event.get("doctype"))
+
+    return {
+        # pass-through for downstream tasks in the Map chain
+        "nova_id": event.get("nova_id"),
+        # normalized reference fields
+        "bibcode": bibcode,
+        "reference_type": reference_type,
+        "title": title,
+        "year": year,
+        "publication_date": publication_date,
+        "authors": authors,
+        "doi": doi,
+        "arxiv_id": arxiv_id,
+    }
+
+
+@tracer.capture_method
+def _handle_upsertReferenceEntity(event: dict, context: object) -> dict:
+    """
+    Write or update the global Reference entity.
+
+    PK = REFERENCE#<bibcode>, SK = METADATA
+    Preserves created_at from the existing item when updating.
+
+    Input:  output of NormalizeReference
+    Output: {nova_id, bibcode, publication_date} for LinkNovaReference
+    """
+    bibcode: str | None = event.get("bibcode")
+    if not bibcode:
+        raise TerminalError("Missing bibcode in UpsertReferenceEntity")
+
+    pk = f"REFERENCE#{bibcode}"
+    now = _utcnow_iso()
+
+    existing = _table.get_item(Key={"PK": pk, "SK": "METADATA"}).get("Item")
+    created_at = existing["created_at"] if existing else now
+
+    # Build item; omit None-valued optional fields (DDB rejects None)
+    item: dict = {
+        "PK": pk,
+        "SK": "METADATA",
+        "entity_type": "Reference",
+        "schema_version": "1.0.0",
+        "bibcode": bibcode,
+        "reference_type": event.get("reference_type") or "other",
+        "authors": event.get("authors") or [],
+        "created_at": created_at,
+        "updated_at": now,
+    }
+    for field in ("title", "year", "publication_date", "doi", "arxiv_id"):
+        val = event.get(field)
+        if val is not None:
+            item[field] = val
+
+    _table.put_item(Item=item)
+
+    logger.info(
+        "Upserted Reference entity",
+        extra={"bibcode": bibcode, "action": "update" if existing else "create"},
+    )
+
+    return {
+        "nova_id": event.get("nova_id"),
+        "bibcode": bibcode,
+        "publication_date": event.get("publication_date"),
+    }
+
+
+@tracer.capture_method
+def _handle_linkNovaReference(event: dict, context: object) -> dict:
+    """
+    Create the NOVAREF link between a nova and a reference.
+
+    PK = <nova_id>, SK = NOVAREF#<bibcode>
+    Idempotent: ConditionalCheckFailedException → link already exists → no-op.
+
+    Input:  output of UpsertReferenceEntity
+    Output: {nova_id, bibcode, publication_date, linked: bool}
+    """
+    nova_id: str | None = event.get("nova_id")
+    bibcode: str | None = event.get("bibcode")
+
+    if not nova_id or not bibcode:
+        raise TerminalError(
+            f"Missing required fields in LinkNovaReference — "
+            f"nova_id={nova_id!r} bibcode={bibcode!r}"
+        )
+
+    now = _utcnow_iso()
+
+    try:
+        _table.put_item(
+            Item={
+                "PK": nova_id,
+                "SK": f"NOVAREF#{bibcode}",
+                "entity_type": "NovaReference",
+                "schema_version": "1.0.0",
+                "nova_id": nova_id,
+                "bibcode": bibcode,
+                "role": "OTHER",
+                "added_by_workflow": "refresh_references",
+                "created_at": now,
+                "updated_at": now,
+            },
+            ConditionExpression=Attr("PK").not_exists(),
+        )
+        logger.info(
+            "Linked NovaReference",
+            extra={"nova_id": nova_id, "bibcode": bibcode},
+        )
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] == "ConditionalCheckFailedException":
+            logger.info(
+                "NovaReference already exists — skipping",
+                extra={"nova_id": nova_id, "bibcode": bibcode},
+            )
+        else:
+            raise RetryableError(f"DDB error in LinkNovaReference: {exc}") from exc
+
+    return {
+        "nova_id": nova_id,
+        "bibcode": bibcode,
+        "publication_date": event.get("publication_date"),
+        "linked": True,
+    }
+
+
+@tracer.capture_method
+def _handle_computeDiscoveryDate(event: dict, context: object) -> dict:
+    """
+    Query all NOVAREF links for the nova, batch-fetch their Reference
+    publication_dates, and return the earliest.
+
+    Tiebreaker: lexicographically smallest bibcode (ADR-005 §4).
+    Lexicographic comparison on YYYY-MM-00 strings is correct by design.
+
+    Output: {nova_id, earliest_bibcode, earliest_publication_date}
+    """
+    nova_id: str | None = event.get("nova_id")
+    if not nova_id:
+        raise TerminalError("Missing required field: nova_id")
+
+    novaref_resp = _table.query(
+        KeyConditionExpression=Key("PK").eq(nova_id) & Key("SK").begins_with("NOVAREF#")
+    )
+    novarefs = novaref_resp.get("Items", [])
+
+    if not novarefs:
+        logger.info("No references linked to nova", extra={"nova_id": nova_id})
+        return {
+            "nova_id": nova_id,
+            "earliest_bibcode": None,
+            "earliest_publication_date": None,
+        }
+
+    bibcodes: list[str] = [str(item["bibcode"]) for item in novarefs if item.get("bibcode")]
+
+    # Batch-get Reference entities; DDB limit is 100 keys per call
+    pub_dates: dict[str, str | None] = {}
+    for i in range(0, len(bibcodes), 100):
+        chunk = bibcodes[i : i + 100]
+        keys = [{"PK": f"REFERENCE#{bib}", "SK": "METADATA"} for bib in chunk]
+        batch_resp = _dynamodb.batch_get_item(RequestItems={_TABLE_NAME: {"Keys": keys}})
+        for ref_item in batch_resp.get("Responses", {}).get(_TABLE_NAME, []):
+            bib = ref_item.get("bibcode")
+            if bib:
+                pub_dates[str(bib)] = (
+                    str(ref_item["publication_date"])
+                    if ref_item.get("publication_date") is not None
+                    else None
+                )
+
+    dated = [(bib, pd) for bib, pd in pub_dates.items() if pd]
+
+    if not dated:
+        logger.info(
+            "No dated references found",
+            extra={"nova_id": nova_id, "bibcode_count": len(bibcodes)},
+        )
+        return {
+            "nova_id": nova_id,
+            "earliest_bibcode": None,
+            "earliest_publication_date": None,
+        }
+
+    # min by (publication_date, bibcode) — lex order is correct for YYYY-MM-00
+    earliest_bibcode, earliest_date = min(dated, key=lambda x: (x[1], x[0]))
+
+    logger.info(
+        "Computed discovery date",
+        extra={
+            "nova_id": nova_id,
+            "earliest_bibcode": earliest_bibcode,
+            "earliest_publication_date": earliest_date,
+        },
+    )
+
+    return {
+        "nova_id": nova_id,
+        "earliest_bibcode": earliest_bibcode,
+        "earliest_publication_date": earliest_date,
+    }
+
+
+@tracer.capture_method
+def _handle_upsertDiscoveryDateMetadata(event: dict, context: object) -> dict:
+    """
+    Update Nova.discovery_date — only if the new date is strictly earlier than
+    the current value (monotonically earlier invariant, ADR-005 §4).
+
+    No-op when: no date was computed, or Nova already has an equal/earlier date.
+
+    Output: {nova_id, updated: bool, discovery_date, discovery_date_old?}
+    """
+    nova_id: str | None = event.get("nova_id")
+    if not nova_id:
+        raise TerminalError("Missing required field: nova_id")
+
+    new_date: str | None = event.get("earliest_publication_date")
+    earliest_bibcode: str | None = event.get("earliest_bibcode")
+
+    if not new_date:
+        logger.info(
+            "No discovery date to upsert — skipping",
+            extra={"nova_id": nova_id},
+        )
+        return {"nova_id": nova_id, "updated": False, "discovery_date": None}
+
+    nova_item = _table.get_item(Key={"PK": nova_id, "SK": "NOVA"}).get("Item")
+    if not nova_item:
+        raise TerminalError(f"Nova not found: {nova_id}")
+
+    raw_date = nova_item.get("discovery_date")
+    current_date: str | None = str(raw_date) if raw_date is not None else None
+
+    # Monotonically earlier invariant: only overwrite with a strictly earlier date
+    if current_date is not None and new_date >= current_date:
+        logger.info(
+            "Discovery date not earlier — no-op",
+            extra={
+                "nova_id": nova_id,
+                "discovery_date_old": current_date,
+                "discovery_date_new": new_date,
+            },
+        )
+        return {"nova_id": nova_id, "updated": False, "discovery_date": current_date}
+
+    now = _utcnow_iso()
+    _table.update_item(
+        Key={"PK": nova_id, "SK": "NOVA"},
+        UpdateExpression="SET discovery_date = :dd, updated_at = :ua",
+        ExpressionAttributeValues={":dd": new_date, ":ua": now},
+    )
+
+    logger.info(
+        "Updated discovery date",
+        extra={
+            "nova_id": nova_id,
+            "discovery_date_old": current_date,
+            "discovery_date_new": new_date,
+            "earliest_bibcode": earliest_bibcode,
+        },
+    )
+
+    return {
+        "nova_id": nova_id,
+        "updated": True,
+        "discovery_date": new_date,
+        "discovery_date_old": current_date,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+@tracer.capture_lambda_handler
 def handle(event: dict, context: object) -> dict:
     """
     Lambda entry point.
 
     Expected event shape (minimum):
         {
-            "task_name": "<StateName>",    # Step Functions state name
+            "task_name": "<StateName>",
             "correlation_id": "<uuid>",
-            "nova_id": "<uuid>",           # present for most tasks
+            "nova_id": "<uuid>",
             ... task-specific fields ...
         }
     """
+    configure_logging(event)
+
     task_name = event.get("task_name")
     if not task_name:
         raise ValueError("Missing required field: task_name")
@@ -48,86 +567,13 @@ def handle(event: dict, context: object) -> dict:
     if handler_fn is None:
         raise ValueError(f"Unknown task_name: {task_name!r}. Known tasks: {list(_TASK_HANDLERS)}")
 
-    logger.info(
-        "Dispatching task",
-        extra={
-            "task_name": task_name,
-            "correlation_id": event.get("correlation_id"),
-            "nova_id": event.get("nova_id"),
-        },
-    )
-
     return handler_fn(event, context)
 
 
-# ------------------------------------------------------------------
-# Per-task handler stubs
-# ------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Dispatch table — defined after implementations to avoid forward references
+# ---------------------------------------------------------------------------
 
-
-def _handle_fetchReferenceCandidates(event: dict, context: object) -> dict:
-    """
-    TODO: implement FetchReferenceCandidates.
-
-    Receives the Step Functions task input event and the Lambda context.
-    Must return a dict that will be used as the task output in the state machine.
-    """
-    raise NotImplementedError("FetchReferenceCandidates not yet implemented")
-
-
-def _handle_normalizeReference(event: dict, context: object) -> dict:
-    """
-    TODO: implement NormalizeReference.
-
-    Receives the Step Functions task input event and the Lambda context.
-    Must return a dict that will be used as the task output in the state machine.
-    """
-    raise NotImplementedError("NormalizeReference not yet implemented")
-
-
-def _handle_upsertReferenceEntity(event: dict, context: object) -> dict:
-    """
-    TODO: implement UpsertReferenceEntity.
-
-    Receives the Step Functions task input event and the Lambda context.
-    Must return a dict that will be used as the task output in the state machine.
-    """
-    raise NotImplementedError("UpsertReferenceEntity not yet implemented")
-
-
-def _handle_linkNovaReference(event: dict, context: object) -> dict:
-    """
-    TODO: implement LinkNovaReference.
-
-    Receives the Step Functions task input event and the Lambda context.
-    Must return a dict that will be used as the task output in the state machine.
-    """
-    raise NotImplementedError("LinkNovaReference not yet implemented")
-
-
-def _handle_computeDiscoveryDate(event: dict, context: object) -> dict:
-    """
-    TODO: implement ComputeDiscoveryDate.
-
-    Receives the Step Functions task input event and the Lambda context.
-    Must return a dict that will be used as the task output in the state machine.
-    """
-    raise NotImplementedError("ComputeDiscoveryDate not yet implemented")
-
-
-def _handle_upsertDiscoveryDateMetadata(event: dict, context: object) -> dict:
-    """
-    TODO: implement UpsertDiscoveryDateMetadata.
-
-    Receives the Step Functions task input event and the Lambda context.
-    Must return a dict that will be used as the task output in the state machine.
-    """
-    raise NotImplementedError("UpsertDiscoveryDateMetadata not yet implemented")
-
-
-# ------------------------------------------------------------------
-# Dispatch table — defined after stubs to avoid forward references
-# ------------------------------------------------------------------
 _TASK_HANDLERS: dict[str, Callable[[dict, object], dict]] = {
     "FetchReferenceCandidates": _handle_fetchReferenceCandidates,
     "NormalizeReference": _handle_normalizeReference,

--- a/tests/services/test_reference_manager.py
+++ b/tests/services/test_reference_manager.py
@@ -1,0 +1,971 @@
+"""
+Unit tests for services/reference_manager/handler.py
+
+Follows the same scaffold as all other NovaCat service unit tests:
+  - aws_env fixture (autouse) sets env vars
+  - table fixture creates the DDB table inside mock_aws()
+  - _load_handler() deletes cached modules then re-imports fresh
+  - All test methods wrap handler calls in `with mock_aws()`
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+from collections.abc import Generator
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from boto3.dynamodb.conditions import Key
+from moto import mock_aws
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_TABLE_NAME = "NovaCat-Test"
+_NOVA_ID = "aaaaaaaa-1111-2222-3333-444444444444"
+_BIBCODE_A = "2013ATel.5073....1S"  # 2013-06-00 — later
+_BIBCODE_B = "1992IAUC.5608....1W"  # 1992-01-00 — earlier
+_BIBCODE_C = "2013ApJ...779..118M"  # no date in some tests
+_ADS_SECRET_VALUE = json.dumps({"token": "test-ads-token-abc123"})
+
+# Minimal raw ADS doc as it arrives from the API (date has time component)
+_RAW_DOC_A = {
+    "bibcode": _BIBCODE_A,
+    "doctype": "telegram",
+    "title": ["Discovery of Nova V1324 Sco"],
+    "date": "2013-06-01T00:00:00Z",
+    "author": ["Stanek, K. Z.", "Kochanek, C. S."],
+    "doi": None,
+    "identifier": ["arXiv:1307.0011"],
+}
+
+_RAW_DOC_B = {
+    "bibcode": _BIBCODE_B,
+    "doctype": "circular",
+    "title": ["Nova V1324 Sco — IAUC notice"],
+    "date": "1992-01-01T00:00:00Z",
+    "author": ["Williams, R."],
+    "doi": None,
+    "identifier": [],
+}
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def aws_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NOVA_CAT_TABLE_NAME", _TABLE_NAME)
+    monkeypatch.setenv("NOVA_CAT_PRIVATE_BUCKET", "nova-cat-private-test")
+    monkeypatch.setenv("NOVA_CAT_PUBLIC_SITE_BUCKET", "nova-cat-public-test")
+    monkeypatch.setenv(
+        "NOVA_CAT_QUARANTINE_TOPIC_ARN", "arn:aws:sns:us-east-1:000000000000:test-topic"
+    )
+    monkeypatch.setenv("ADS_SECRET_NAME", "ADSQueryToken")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+    monkeypatch.setenv("POWERTOOLS_SERVICE_NAME", "nova-cat-test")
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+
+
+@pytest.fixture
+def table(aws_env: None) -> Generator[Any, None, None]:
+    with mock_aws():
+        ddb = boto3.resource("dynamodb", region_name="us-east-1")
+        ddb.create_table(
+            TableName=_TABLE_NAME,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield ddb.Table(_TABLE_NAME)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_ads_secret() -> None:
+    sm = boto3.client("secretsmanager", region_name="us-east-1")
+    sm.create_secret(Name="ADSQueryToken", SecretString=_ADS_SECRET_VALUE)
+
+
+def _load_handler() -> types.ModuleType:
+    if "reference_manager.handler" in sys.modules:
+        del sys.modules["reference_manager.handler"]
+    return importlib.import_module("reference_manager.handler")
+
+
+def _base_event(**kwargs: Any) -> dict[str, Any]:
+    base = {
+        "task_name": "FetchReferenceCandidates",
+        "workflow_name": "refresh_references",
+        "nova_id": _NOVA_ID,
+        "correlation_id": "corr-ref-001",
+    }
+    base.update(kwargs)
+    return base
+
+
+def _seed_nova(table: Any, nova_id: str = _NOVA_ID, aliases: list[str] | None = None) -> None:
+    table.put_item(
+        Item={
+            "PK": nova_id,
+            "SK": "NOVA",
+            "entity_type": "Nova",
+            "schema_version": "1.0.0",
+            "nova_id": nova_id,
+            "primary_name": "V1324 Sco",
+            "primary_name_normalized": "v1324 sco",
+            "status": "ACTIVE",
+            "aliases": aliases if aliases is not None else ["NOVA Sco 2012", "Gaia DR3 1234567890"],
+        }
+    )
+
+
+def _seed_reference(table: Any, bibcode: str, publication_date: str | None = None) -> None:
+    item: dict[str, Any] = {
+        "PK": f"REFERENCE#{bibcode}",
+        "SK": "METADATA",
+        "entity_type": "Reference",
+        "schema_version": "1.0.0",
+        "bibcode": bibcode,
+        "reference_type": "journal_article",
+        "authors": [],
+        "created_at": "2024-01-01T00:00:00+00:00",
+        "updated_at": "2024-01-01T00:00:00+00:00",
+    }
+    if publication_date is not None:
+        item["publication_date"] = publication_date
+    table.put_item(Item=item)
+
+
+def _seed_novaref(table: Any, nova_id: str, bibcode: str) -> None:
+    table.put_item(
+        Item={
+            "PK": nova_id,
+            "SK": f"NOVAREF#{bibcode}",
+            "entity_type": "NovaReference",
+            "schema_version": "1.0.0",
+            "nova_id": nova_id,
+            "bibcode": bibcode,
+            "role": "OTHER",
+            "created_at": "2024-01-01T00:00:00+00:00",
+            "updated_at": "2024-01-01T00:00:00+00:00",
+        }
+    )
+
+
+def _mock_ads_response(docs: list[dict[str, Any]]) -> MagicMock:
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"response": {"docs": docs}}
+    mock_resp.raise_for_status = MagicMock()
+    return mock_resp
+
+
+# ===========================================================================
+# TestFetchReferenceCandidates
+# ===========================================================================
+
+
+class TestFetchReferenceCandidates:
+    def test_returns_candidates_from_ads(self, table: Any) -> None:
+        with mock_aws():
+            _seed_nova(table)
+            _create_ads_secret()
+            h = _load_handler()
+            with patch.object(h, "requests") as mock_requests:
+                mock_requests.get.return_value = _mock_ads_response([_RAW_DOC_A])
+                mock_requests.exceptions.Timeout = Exception
+                mock_requests.exceptions.RequestException = Exception
+                result = h.handle(_base_event(), None)
+            assert result["nova_id"] == _NOVA_ID
+            assert result["candidate_count"] == 1
+            assert result["candidates"][0]["bibcode"] == _BIBCODE_A
+
+    def test_query_includes_primary_name(self, table: Any) -> None:
+        with mock_aws():
+            _seed_nova(table, aliases=[])
+            _create_ads_secret()
+            h = _load_handler()
+            with patch.object(h, "requests") as mock_requests:
+                mock_requests.get.return_value = _mock_ads_response([])
+                mock_requests.exceptions.Timeout = Exception
+                mock_requests.exceptions.RequestException = Exception
+                h.handle(_base_event(), None)
+            url = mock_requests.get.call_args[0][0]
+            assert "V1324" in url and "Sco" in url
+
+    def test_query_includes_aliases(self, table: Any) -> None:
+        with mock_aws():
+            _seed_nova(table, aliases=["NOVA Sco 2012"])
+            _create_ads_secret()
+            h = _load_handler()
+            with patch.object(h, "requests") as mock_requests:
+                mock_requests.get.return_value = _mock_ads_response([])
+                mock_requests.exceptions.Timeout = Exception
+                mock_requests.exceptions.RequestException = Exception
+                h.handle(_base_event(), None)
+            url = mock_requests.get.call_args[0][0]
+            assert "NOVA" in url and "Sco" in url and "2012" in url
+
+    def test_query_includes_ads_name_hints(self, table: Any) -> None:
+        with mock_aws():
+            _seed_nova(table, aliases=[])
+            _create_ads_secret()
+            h = _load_handler()
+            event = _base_event(attributes={"ads_name_hints": ["V1324Sco"]})
+            with patch.object(h, "requests") as mock_requests:
+                mock_requests.get.return_value = _mock_ads_response([])
+                mock_requests.exceptions.Timeout = Exception
+                mock_requests.exceptions.RequestException = Exception
+                h.handle(event, None)
+            url = mock_requests.get.call_args[0][0]
+            assert "V1324Sco" in url
+
+    def test_deduplicates_names_case_insensitively(self, table: Any) -> None:
+        with mock_aws():
+            # primary_name "V1324 Sco" and alias "v1324 sco" are the same normalized
+            _seed_nova(table, aliases=["v1324 sco"])
+            _create_ads_secret()
+            h = _load_handler()
+            with patch.object(h, "requests") as mock_requests:
+                mock_requests.get.return_value = _mock_ads_response([])
+                mock_requests.exceptions.Timeout = Exception
+                mock_requests.exceptions.RequestException = Exception
+                h.handle(_base_event(), None)
+            url = mock_requests.get.call_args[0][0]
+            # urlencode encodes spaces as + and quotes as %22
+            # dedupe means "V1324 Sco" appears exactly once in either casing
+            assert url.count("V1324") + url.count("v1324") == 1
+
+    def test_uses_bearer_token_from_secret(self, table: Any) -> None:
+        with mock_aws():
+            _seed_nova(table)
+            _create_ads_secret()
+            h = _load_handler()
+            with patch.object(h, "requests") as mock_requests:
+                mock_requests.get.return_value = _mock_ads_response([])
+                mock_requests.exceptions.Timeout = Exception
+                mock_requests.exceptions.RequestException = Exception
+                h.handle(_base_event(), None)
+            auth_header = mock_requests.get.call_args[1]["headers"]["Authorization"]
+            assert auth_header == "Bearer test-ads-token-abc123"
+
+    def test_ads_empty_response_returns_zero_candidates(self, table: Any) -> None:
+        with mock_aws():
+            _seed_nova(table)
+            _create_ads_secret()
+            h = _load_handler()
+            with patch.object(h, "requests") as mock_requests:
+                mock_requests.get.return_value = _mock_ads_response([])
+                mock_requests.exceptions.Timeout = Exception
+                mock_requests.exceptions.RequestException = Exception
+                result = h.handle(_base_event(), None)
+            assert result["candidate_count"] == 0
+            assert result["candidates"] == []
+
+    def test_nova_not_found_raises_terminal_error(self, table: Any) -> None:
+        with mock_aws():
+            _create_ads_secret()
+            h = _load_handler()
+            from nova_common.errors import TerminalError
+
+            with pytest.raises(TerminalError, match="Nova not found"):
+                h.handle(_base_event(), None)
+
+    def test_http_429_raises_retryable_error(self, table: Any) -> None:
+        with mock_aws():
+            _seed_nova(table)
+            _create_ads_secret()
+            h = _load_handler()
+            from nova_common.errors import RetryableError
+
+            mock_resp = MagicMock()
+            mock_resp.status_code = 429
+            with patch.object(h, "requests") as mock_requests:
+                mock_requests.get.return_value = mock_resp
+                mock_requests.exceptions.Timeout = Exception
+                mock_requests.exceptions.RequestException = Exception
+                with pytest.raises(RetryableError, match="429"):
+                    h.handle(_base_event(), None)
+
+    def test_http_401_raises_terminal_error(self, table: Any) -> None:
+        with mock_aws():
+            _seed_nova(table)
+            _create_ads_secret()
+            h = _load_handler()
+            from nova_common.errors import TerminalError
+
+            mock_resp = MagicMock()
+            mock_resp.status_code = 401
+            with patch.object(h, "requests") as mock_requests:
+                mock_requests.get.return_value = mock_resp
+                mock_requests.exceptions.Timeout = Exception
+                mock_requests.exceptions.RequestException = Exception
+                with pytest.raises(TerminalError, match="authentication failed"):
+                    h.handle(_base_event(), None)
+
+    def test_http_500_raises_retryable_error(self, table: Any) -> None:
+        with mock_aws():
+            _seed_nova(table)
+            _create_ads_secret()
+            h = _load_handler()
+            from nova_common.errors import RetryableError
+
+            mock_resp = MagicMock()
+            mock_resp.status_code = 500
+            with patch.object(h, "requests") as mock_requests:
+                mock_requests.get.return_value = mock_resp
+                mock_requests.exceptions.Timeout = Exception
+                mock_requests.exceptions.RequestException = Exception
+                with pytest.raises(RetryableError, match="server error"):
+                    h.handle(_base_event(), None)
+
+    def test_missing_nova_id_raises_terminal_error(self, table: Any) -> None:
+        with mock_aws():
+            _create_ads_secret()
+            h = _load_handler()
+            from nova_common.errors import TerminalError
+
+            with pytest.raises(TerminalError, match="nova_id"):
+                h.handle(_base_event(nova_id=None), None)
+
+
+# ===========================================================================
+# TestNormalizeReference
+# ===========================================================================
+
+
+class TestNormalizeReference:
+    def _run(self, table: Any, doc: dict[str, Any]) -> dict[str, Any]:
+        with mock_aws():
+            h = _load_handler()
+            event = {**doc, "task_name": "NormalizeReference", "nova_id": _NOVA_ID}
+            return cast(dict[str, Any], h.handle(event, None))
+
+    def test_maps_telegram_doctype_to_atel(self, table: Any) -> None:
+        result = self._run(table, _RAW_DOC_A)
+        assert result["reference_type"] == "atel"
+
+    def test_maps_circular_doctype_to_cbat(self, table: Any) -> None:
+        result = self._run(table, _RAW_DOC_B)
+        assert result["reference_type"] == "cbat_circular"
+
+    @pytest.mark.parametrize(
+        "doctype,expected",
+        [
+            ("article", "journal_article"),
+            ("eprint", "arxiv_preprint"),
+            ("inproceedings", "conference_abstract"),
+            ("abstract", "conference_abstract"),
+            ("catalog", "catalog"),
+            ("software", "software"),
+            ("unknown_thing", "other"),
+            (None, "other"),
+        ],
+    )
+    def test_doctype_mapping(self, table: Any, doctype: str | None, expected: str) -> None:
+        doc = {**_RAW_DOC_A, "bibcode": "2000Test.0001....A", "doctype": doctype}
+        result = self._run(table, doc)
+        assert result["reference_type"] == expected
+
+    def test_returns_bibcode(self, table: Any) -> None:
+        result = self._run(table, _RAW_DOC_A)
+        assert result["bibcode"] == _BIBCODE_A
+
+    def test_passes_nova_id_through(self, table: Any) -> None:
+        result = self._run(table, _RAW_DOC_A)
+        assert result["nova_id"] == _NOVA_ID
+
+    def test_title_extracted_from_list(self, table: Any) -> None:
+        doc = {**_RAW_DOC_A, "title": ["First Title", "Second Title"]}
+        result = self._run(table, doc)
+        assert result["title"] == "First Title"
+
+    def test_title_from_string(self, table: Any) -> None:
+        doc = {**_RAW_DOC_A, "title": "Plain string title"}
+        result = self._run(table, doc)
+        assert result["title"] == "Plain string title"
+
+    def test_title_none_when_missing(self, table: Any) -> None:
+        doc = {**_RAW_DOC_A, "title": None}
+        result = self._run(table, doc)
+        assert result["title"] is None
+
+    def test_doi_extracted_from_list(self, table: Any) -> None:
+        doc = {**_RAW_DOC_A, "doi": ["10.1234/test.2013"]}
+        result = self._run(table, doc)
+        assert result["doi"] == "10.1234/test.2013"
+
+    def test_doi_from_string(self, table: Any) -> None:
+        doc = {**_RAW_DOC_A, "doi": "10.1234/test.2013"}
+        result = self._run(table, doc)
+        assert result["doi"] == "10.1234/test.2013"
+
+    def test_doi_none_when_absent(self, table: Any) -> None:
+        doc = {**_RAW_DOC_A, "doi": None}
+        result = self._run(table, doc)
+        assert result["doi"] is None
+
+    def test_authors_preserved(self, table: Any) -> None:
+        result = self._run(table, _RAW_DOC_A)
+        assert result["authors"] == ["Stanek, K. Z.", "Kochanek, C. S."]
+
+    def test_authors_empty_list_when_missing(self, table: Any) -> None:
+        doc = {**_RAW_DOC_A, "author": None}
+        result = self._run(table, doc)
+        assert result["authors"] == []
+
+    def test_publication_date_strips_time_and_day(self, table: Any) -> None:
+        """ADS YYYY-MM-01T00:00:00Z → YYYY-MM-00."""
+        doc = {**_RAW_DOC_A, "date": "2013-06-01T00:00:00Z"}
+        result = self._run(table, doc)
+        assert result["publication_date"] == "2013-06-00"
+
+    def test_publication_date_full_date_also_discards_day(self, table: Any) -> None:
+        """Any day value — not just 01 — is discarded."""
+        doc = {**_RAW_DOC_A, "date": "2013-06-14T00:00:00Z"}
+        result = self._run(table, doc)
+        assert result["publication_date"] == "2013-06-00"
+
+    def test_publication_date_bare_yyyy_mm_dd(self, table: Any) -> None:
+        doc = {**_RAW_DOC_A, "date": "2013-06-14"}
+        result = self._run(table, doc)
+        assert result["publication_date"] == "2013-06-00"
+
+    def test_publication_date_none_when_missing(self, table: Any) -> None:
+        doc = {**_RAW_DOC_A, "date": None}
+        result = self._run(table, doc)
+        assert result["publication_date"] is None
+
+    def test_year_derived_from_publication_date(self, table: Any) -> None:
+        result = self._run(table, _RAW_DOC_A)
+        assert result["year"] == 2013
+
+    def test_year_none_when_no_date(self, table: Any) -> None:
+        doc = {**_RAW_DOC_A, "date": None}
+        result = self._run(table, doc)
+        assert result["year"] is None
+
+    def test_arxiv_id_stripped_of_prefix(self, table: Any) -> None:
+        doc = {**_RAW_DOC_A, "identifier": ["arXiv:1307.0011"]}
+        result = self._run(table, doc)
+        assert result["arxiv_id"] == "1307.0011"
+
+    def test_arxiv_id_case_insensitive_strip(self, table: Any) -> None:
+        doc = {**_RAW_DOC_A, "identifier": ["ARXIV:1307.0011"]}
+        result = self._run(table, doc)
+        assert result["arxiv_id"] == "1307.0011"
+
+    def test_arxiv_id_none_when_absent(self, table: Any) -> None:
+        doc = {**_RAW_DOC_A, "identifier": []}
+        result = self._run(table, doc)
+        assert result["arxiv_id"] is None
+
+    def test_missing_bibcode_raises_terminal_error(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            from nova_common.errors import TerminalError
+
+            event = {
+                **_RAW_DOC_A,
+                "bibcode": None,
+                "task_name": "NormalizeReference",
+                "nova_id": _NOVA_ID,
+            }
+            with pytest.raises(TerminalError, match="bibcode"):
+                h.handle(event, None)
+
+
+# ===========================================================================
+# TestUpsertReferenceEntity
+# ===========================================================================
+
+
+class TestUpsertReferenceEntity:
+    def _event(self, **overrides: Any) -> dict[str, Any]:
+        base = {
+            "task_name": "UpsertReferenceEntity",
+            "workflow_name": "refresh_references",
+            "nova_id": _NOVA_ID,
+            "bibcode": _BIBCODE_A,
+            "reference_type": "atel",
+            "title": "Discovery of Nova V1324 Sco",
+            "year": 2013,
+            "publication_date": "2013-06-00",
+            "authors": ["Stanek, K. Z."],
+            "doi": None,
+            "arxiv_id": "1307.0011",
+        }
+        base.update(overrides)
+        return base
+
+    def test_writes_reference_item_to_ddb(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            h.handle(self._event(), None)
+            item = table.get_item(Key={"PK": f"REFERENCE#{_BIBCODE_A}", "SK": "METADATA"})["Item"]
+            assert item["bibcode"] == _BIBCODE_A
+            assert item["reference_type"] == "atel"
+            assert item["publication_date"] == "2013-06-00"
+            assert item["year"] == 2013
+            assert item["arxiv_id"] == "1307.0011"
+
+    def test_sets_entity_type(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            h.handle(self._event(), None)
+            item = table.get_item(Key={"PK": f"REFERENCE#{_BIBCODE_A}", "SK": "METADATA"})["Item"]
+            assert item["entity_type"] == "Reference"
+
+    def test_sets_created_at_and_updated_at(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            h.handle(self._event(), None)
+            item = table.get_item(Key={"PK": f"REFERENCE#{_BIBCODE_A}", "SK": "METADATA"})["Item"]
+            assert "created_at" in item
+            assert "updated_at" in item
+
+    def test_preserves_created_at_on_update(self, table: Any) -> None:
+        with mock_aws():
+            _seed_reference(table, _BIBCODE_A)
+            original_created = table.get_item(
+                Key={"PK": f"REFERENCE#{_BIBCODE_A}", "SK": "METADATA"}
+            )["Item"]["created_at"]
+            h = _load_handler()
+            h.handle(self._event(title="Updated Title"), None)
+            item = table.get_item(Key={"PK": f"REFERENCE#{_BIBCODE_A}", "SK": "METADATA"})["Item"]
+            assert item["created_at"] == original_created
+            assert item["title"] == "Updated Title"
+
+    def test_omits_none_valued_optional_fields(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            h.handle(self._event(doi=None, arxiv_id=None), None)
+            item = table.get_item(Key={"PK": f"REFERENCE#{_BIBCODE_A}", "SK": "METADATA"})["Item"]
+            assert "doi" not in item
+            assert "arxiv_id" not in item
+
+    def test_returns_bibcode_and_publication_date(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            result = h.handle(self._event(), None)
+            assert result["bibcode"] == _BIBCODE_A
+            assert result["publication_date"] == "2013-06-00"
+
+    def test_passes_nova_id_through(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            result = h.handle(self._event(), None)
+            assert result["nova_id"] == _NOVA_ID
+
+    def test_missing_bibcode_raises_terminal_error(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            from nova_common.errors import TerminalError
+
+            with pytest.raises(TerminalError, match="bibcode"):
+                h.handle(self._event(bibcode=None), None)
+
+    def test_idempotent_on_second_call(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            h.handle(self._event(), None)
+            result = h.handle(self._event(), None)
+            assert result["bibcode"] == _BIBCODE_A
+
+
+# ===========================================================================
+# TestLinkNovaReference
+# ===========================================================================
+
+
+class TestLinkNovaReference:
+    def _event(self, **overrides: Any) -> dict[str, Any]:
+        base = {
+            "task_name": "LinkNovaReference",
+            "workflow_name": "refresh_references",
+            "nova_id": _NOVA_ID,
+            "bibcode": _BIBCODE_A,
+            "publication_date": "2013-06-00",
+        }
+        base.update(overrides)
+        return base
+
+    def test_writes_novaref_item(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            h.handle(self._event(), None)
+            item = table.get_item(Key={"PK": _NOVA_ID, "SK": f"NOVAREF#{_BIBCODE_A}"})["Item"]
+            assert item["nova_id"] == _NOVA_ID
+            assert item["bibcode"] == _BIBCODE_A
+            assert item["role"] == "OTHER"
+            assert item["added_by_workflow"] == "refresh_references"
+
+    def test_returns_linked_true(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            result = h.handle(self._event(), None)
+            assert result["linked"] is True
+
+    def test_returns_bibcode_and_publication_date(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            result = h.handle(self._event(), None)
+            assert result["bibcode"] == _BIBCODE_A
+            assert result["publication_date"] == "2013-06-00"
+
+    def test_returns_nova_id(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            result = h.handle(self._event(), None)
+            assert result["nova_id"] == _NOVA_ID
+
+    def test_idempotent_second_call_does_not_raise(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            h.handle(self._event(), None)
+            result = h.handle(self._event(), None)
+            assert result["linked"] is True
+
+    def test_idempotent_second_call_leaves_one_item(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            h.handle(self._event(), None)
+            h.handle(self._event(), None)
+            resp = table.query(
+                KeyConditionExpression=Key("PK").eq(_NOVA_ID) & Key("SK").begins_with("NOVAREF#")
+            )
+            assert len(resp["Items"]) == 1
+
+    def test_missing_nova_id_raises_terminal_error(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            from nova_common.errors import TerminalError
+
+            with pytest.raises(TerminalError, match="Missing required fields"):
+                h.handle(self._event(nova_id=None), None)
+
+    def test_missing_bibcode_raises_terminal_error(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            from nova_common.errors import TerminalError
+
+            with pytest.raises(TerminalError, match="Missing required fields"):
+                h.handle(self._event(bibcode=None), None)
+
+
+# ===========================================================================
+# TestComputeDiscoveryDate
+# ===========================================================================
+
+
+class TestComputeDiscoveryDate:
+    def _event(self, **overrides: Any) -> dict[str, Any]:
+        base = {
+            "task_name": "ComputeDiscoveryDate",
+            "workflow_name": "refresh_references",
+            "nova_id": _NOVA_ID,
+        }
+        base.update(overrides)
+        return base
+
+    def test_returns_none_when_no_references(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            result = h.handle(self._event(), None)
+            assert result["earliest_bibcode"] is None
+            assert result["earliest_publication_date"] is None
+
+    def test_returns_single_reference(self, table: Any) -> None:
+        with mock_aws():
+            _seed_novaref(table, _NOVA_ID, _BIBCODE_A)
+            _seed_reference(table, _BIBCODE_A, "2013-06-00")
+            h = _load_handler()
+            result = h.handle(self._event(), None)
+            assert result["earliest_bibcode"] == _BIBCODE_A
+            assert result["earliest_publication_date"] == "2013-06-00"
+
+    def test_picks_earlier_of_two_references(self, table: Any) -> None:
+        with mock_aws():
+            _seed_novaref(table, _NOVA_ID, _BIBCODE_A)
+            _seed_novaref(table, _NOVA_ID, _BIBCODE_B)
+            _seed_reference(table, _BIBCODE_A, "2013-06-00")
+            _seed_reference(table, _BIBCODE_B, "1992-01-00")
+            h = _load_handler()
+            result = h.handle(self._event(), None)
+            assert result["earliest_bibcode"] == _BIBCODE_B
+            assert result["earliest_publication_date"] == "1992-01-00"
+
+    def test_tiebreaker_uses_lexicographically_smaller_bibcode(self, table: Any) -> None:
+        bib_alpha = "2013ApJ.AAAA"
+        bib_omega = "2013ApJ.ZZZZ"
+        with mock_aws():
+            _seed_novaref(table, _NOVA_ID, bib_alpha)
+            _seed_novaref(table, _NOVA_ID, bib_omega)
+            _seed_reference(table, bib_alpha, "2013-06-00")
+            _seed_reference(table, bib_omega, "2013-06-00")
+            h = _load_handler()
+            result = h.handle(self._event(), None)
+            assert result["earliest_bibcode"] == bib_alpha
+
+    def test_references_without_dates_are_excluded(self, table: Any) -> None:
+        with mock_aws():
+            _seed_novaref(table, _NOVA_ID, _BIBCODE_A)
+            _seed_novaref(table, _NOVA_ID, _BIBCODE_C)
+            _seed_reference(table, _BIBCODE_A, "2013-06-00")
+            _seed_reference(table, _BIBCODE_C, None)  # no date
+            h = _load_handler()
+            result = h.handle(self._event(), None)
+            assert result["earliest_bibcode"] == _BIBCODE_A
+
+    def test_all_undated_returns_none(self, table: Any) -> None:
+        with mock_aws():
+            _seed_novaref(table, _NOVA_ID, _BIBCODE_A)
+            _seed_reference(table, _BIBCODE_A, None)
+            h = _load_handler()
+            result = h.handle(self._event(), None)
+            assert result["earliest_bibcode"] is None
+            assert result["earliest_publication_date"] is None
+
+    def test_returns_nova_id(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            result = h.handle(self._event(), None)
+            assert result["nova_id"] == _NOVA_ID
+
+    def test_missing_nova_id_raises_terminal_error(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            from nova_common.errors import TerminalError
+
+            with pytest.raises(TerminalError, match="nova_id"):
+                h.handle(self._event(nova_id=None), None)
+
+
+# ===========================================================================
+# TestUpsertDiscoveryDateMetadata
+# ===========================================================================
+
+
+class TestUpsertDiscoveryDateMetadata:
+    def _event(self, **overrides: Any) -> dict[str, Any]:
+        base = {
+            "task_name": "UpsertDiscoveryDateMetadata",
+            "workflow_name": "refresh_references",
+            "nova_id": _NOVA_ID,
+            "earliest_bibcode": _BIBCODE_A,
+            "earliest_publication_date": "2013-06-00",
+        }
+        base.update(overrides)
+        return base
+
+    def test_writes_discovery_date_to_nova(self, table: Any) -> None:
+        with mock_aws():
+            _seed_nova(table)
+            h = _load_handler()
+            h.handle(self._event(), None)
+            nova = table.get_item(Key={"PK": _NOVA_ID, "SK": "NOVA"})["Item"]
+            assert nova["discovery_date"] == "2013-06-00"
+
+    def test_returns_updated_true_when_written(self, table: Any) -> None:
+        with mock_aws():
+            _seed_nova(table)
+            h = _load_handler()
+            result = h.handle(self._event(), None)
+            assert result["updated"] is True
+            assert result["discovery_date"] == "2013-06-00"
+
+    def test_updates_when_new_date_is_earlier(self, table: Any) -> None:
+        with mock_aws():
+            _seed_nova(table)
+            table.update_item(
+                Key={"PK": _NOVA_ID, "SK": "NOVA"},
+                UpdateExpression="SET discovery_date = :d",
+                ExpressionAttributeValues={":d": "2014-03-00"},
+            )
+            h = _load_handler()
+            result = h.handle(self._event(earliest_publication_date="2013-06-00"), None)
+            assert result["updated"] is True
+            nova = table.get_item(Key={"PK": _NOVA_ID, "SK": "NOVA"})["Item"]
+            assert nova["discovery_date"] == "2013-06-00"
+
+    def test_noop_when_new_date_is_same(self, table: Any) -> None:
+        with mock_aws():
+            _seed_nova(table)
+            table.update_item(
+                Key={"PK": _NOVA_ID, "SK": "NOVA"},
+                UpdateExpression="SET discovery_date = :d",
+                ExpressionAttributeValues={":d": "2013-06-00"},
+            )
+            h = _load_handler()
+            result = h.handle(self._event(earliest_publication_date="2013-06-00"), None)
+            assert result["updated"] is False
+            assert result["discovery_date"] == "2013-06-00"
+
+    def test_noop_when_new_date_is_later(self, table: Any) -> None:
+        with mock_aws():
+            _seed_nova(table)
+            table.update_item(
+                Key={"PK": _NOVA_ID, "SK": "NOVA"},
+                UpdateExpression="SET discovery_date = :d",
+                ExpressionAttributeValues={":d": "2013-06-00"},
+            )
+            h = _load_handler()
+            result = h.handle(self._event(earliest_publication_date="2015-01-00"), None)
+            assert result["updated"] is False
+            nova = table.get_item(Key={"PK": _NOVA_ID, "SK": "NOVA"})["Item"]
+            assert nova["discovery_date"] == "2013-06-00"  # unchanged
+
+    def test_noop_when_no_date_computed(self, table: Any) -> None:
+        with mock_aws():
+            _seed_nova(table)
+            h = _load_handler()
+            result = h.handle(
+                self._event(earliest_publication_date=None, earliest_bibcode=None),
+                None,
+            )
+            assert result["updated"] is False
+            assert result["discovery_date"] is None
+
+    def test_records_old_date_in_result(self, table: Any) -> None:
+        with mock_aws():
+            _seed_nova(table)
+            table.update_item(
+                Key={"PK": _NOVA_ID, "SK": "NOVA"},
+                UpdateExpression="SET discovery_date = :d",
+                ExpressionAttributeValues={":d": "2014-03-00"},
+            )
+            h = _load_handler()
+            result = h.handle(self._event(earliest_publication_date="2013-06-00"), None)
+            assert result["discovery_date_old"] == "2014-03-00"
+
+    def test_first_write_has_no_old_date_key(self, table: Any) -> None:
+        """When there was no prior discovery_date, discovery_date_old should not appear."""
+        with mock_aws():
+            _seed_nova(table)
+            h = _load_handler()
+            result = h.handle(self._event(), None)
+            # discovery_date_old is only set when overwriting an existing value
+            assert result.get("discovery_date_old") is None
+
+    def test_nova_not_found_raises_terminal_error(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            from nova_common.errors import TerminalError
+
+            with pytest.raises(TerminalError, match="Nova not found"):
+                h.handle(self._event(), None)
+
+    def test_missing_nova_id_raises_terminal_error(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            from nova_common.errors import TerminalError
+
+            with pytest.raises(TerminalError, match="nova_id"):
+                h.handle(self._event(nova_id=None), None)
+
+
+# ===========================================================================
+# TestPublicationDateNormalization
+# ===========================================================================
+
+
+class TestPublicationDateNormalization:
+    @pytest.mark.parametrize(
+        "ads_date,expected",
+        [
+            ("2013-06-01T00:00:00Z", "2013-06-00"),  # standard ADS format
+            ("1992-01-01T00:00:00Z", "1992-01-00"),  # older record
+            ("2013-06-14T00:00:00Z", "2013-06-00"),  # non-01 day still discarded
+            ("2013-06-14", "2013-06-00"),  # bare date, no time component
+            ("2013-06-00", "2013-06-00"),  # already canonical
+            (None, None),
+            ("", None),
+            ("2013-00-01T00:00:00Z", None),  # month 00 is invalid
+            ("bad-date", None),
+        ],
+    )
+    def test_normalize_publication_date(
+        self, table: Any, ads_date: str | None, expected: str | None
+    ) -> None:
+        with mock_aws():
+            h = _load_handler()
+            result = h._normalize_publication_date(ads_date)
+            assert result == expected
+
+
+# ===========================================================================
+# TestArxivIdExtraction
+# ===========================================================================
+
+
+class TestArxivIdExtraction:
+    @pytest.mark.parametrize(
+        "identifiers,expected",
+        [
+            (["arXiv:1307.0011"], "1307.0011"),
+            (["ARXIV:1307.0011v2"], "1307.0011v2"),
+            (["arXiv:2101.12345.6789"], "2101.12345.6789"),
+            (["10.1234/doi", "arXiv:1307.0011"], "1307.0011"),  # arxiv after doi
+            (["10.1234/doi"], None),
+            ([], None),
+            (None, None),
+        ],
+    )
+    def test_extract_arxiv_id(
+        self, table: Any, identifiers: list[str] | None, expected: str | None
+    ) -> None:
+        with mock_aws():
+            h = _load_handler()
+            result = h._extract_arxiv_id(identifiers)
+            assert result == expected
+
+
+# ===========================================================================
+# TestDispatch
+# ===========================================================================
+
+
+class TestDispatch:
+    def test_unknown_task_raises_value_error(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            with pytest.raises(ValueError, match="Unknown task_name"):
+                h.handle(_base_event(task_name="NonExistentTask"), None)
+
+    def test_all_six_task_names_are_registered(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            expected = {
+                "FetchReferenceCandidates",
+                "NormalizeReference",
+                "UpsertReferenceEntity",
+                "LinkNovaReference",
+                "ComputeDiscoveryDate",
+                "UpsertDiscoveryDateMetadata",
+            }
+            assert set(h._TASK_HANDLERS.keys()) == expected
+
+    def test_all_handlers_are_callable(self, table: Any) -> None:
+        with mock_aws():
+            h = _load_handler()
+            for name, fn in h._TASK_HANDLERS.items():
+                assert callable(fn), f"Handler for {name!r} is not callable"


### PR DESCRIPTION
## Epic 12: Implement refresh_references workflow

### Summary

Implements the `refresh_references` workflow, which fetches ADS reference data for a `nova_id`, upserts global `Reference` entities keyed by bibcode, links them to the nova via `NovaReference` items, and derives `discovery_date` from the earliest credible publication date.

---

### Changes

#### `reference_manager` handler

- **`services/reference_manager/handler.py`** — full implementation of all six tasks, replacing stubs with `NotImplementedError`:
  - `FetchReferenceCandidates` — loads nova aliases from DDB, deduplicates case-insensitively, builds OR-joined quoted ADS name query via `urlencode`, retrieves Bearer token from Secrets Manager, returns raw candidate docs
  - `NormalizeReference` — maps raw ADS doc to Reference schema; unconditionally discards day component (`YYYY-MM-01T00:00:00Z` → `YYYY-MM-00`); strips `arXiv:` prefix; maps all eight `doctype` values
  - `UpsertReferenceEntity` — get-then-put pattern preserving `created_at`; omits `None`-valued optional fields
  - `LinkNovaReference` — conditional put with `Attr("PK").not_exists()`; `ConditionalCheckFailedException` swallowed as idempotent success
  - `ComputeDiscoveryDate` — queries all `NOVAREF#` links, batch-gets `Reference` entities in chunks of 100, returns earliest `(publication_date, bibcode)` tuple; tiebreaker is lexicographically smallest bibcode (ADR-005 §4)
  - `UpsertDiscoveryDateMetadata` — monotonically earlier invariant enforced via strict string comparison; no-op if new date ≥ current date or no date computed
- Upgraded from plain `logging` to full `nova_common` patterns: `configure_logging`, `@tracer.capture_lambda_handler`, `@tracer.capture_method`, `nova_common.errors`

#### `refresh_references` workflow

- **`infra/workflows/refresh_references.asl.json`** — full ASL replacing the Epic 11 placeholder `Fail` state:
  `BeginJobRun` → `AcquireIdempotencyLock` → `FetchReferenceCandidates` → `ReconcileReferences` (Map) → `ComputeDiscoveryDate` → `UpsertDiscoveryDateMetadata` → `FinalizeJobRunSuccess` | `TerminalFailHandler`
- Map `ItemSelector` injects `nova_id` from `$$.Execution.Input` alongside each ADS doc; all `ADS_FIELDS` passed explicitly so downstream tasks receive consistent shapes
- `ItemFailureHandler` is a `Pass` state — captures error context and continues the Map; pending `quarantine_handler` wiring in a future epic

---

### Tests

- **`tests/services/test_reference_manager.py`** — 65 unit tests across 8 test classes using moto + `mock_aws()`:
  - `TestFetchReferenceCandidates` — query construction, name deduplication, Bearer token usage, ADS error codes (429/401/500)
  - `TestNormalizeReference` — all 8 doctype mappings, title/DOI list vs string handling, date normalization edge cases, arXiv prefix stripping
  - `TestUpsertReferenceEntity` — write, update, `created_at` preservation, `None`-field omission, idempotency
  - `TestLinkNovaReference` — write, idempotency (single item after two calls), missing field errors
  - `TestComputeDiscoveryDate` — no refs, single ref, earliest of multiple, tiebreaker, undated exclusion
  - `TestUpsertDiscoveryDateMetadata` — write, monotonicity (same/later = no-op), `discovery_date_old` tracking
  - `TestPublicationDateNormalization` / `TestArxivIdExtraction` — parametrized unit tests on helpers directly

---

### Notes

- ADS `/v1/search/query` requires `urlencode` + `requests.get` with the query string appended to the URL directly — `params=` kwarg and `POST` with JSON body both produce `405` responses
- `ItemFailureHandler` in the Map is intentionally a `Pass` state for now; item-level quarantine tracking and SNS notification will be wired once `quarantine_handler` integration is confirmed stable
- CDK wiring for `${ReferenceManagerFunctionArn}` substitution in `refresh_references.asl.json` is not included in this PR — pending the `infra/workflows.py` update that provisions the Lambda and state machine together