### PR TITLE
Epic-13: fix: resolve doc drift and ASL/CDK wiring bugs

### DIFF
--- a/docs/architecture/current-architecture.md
+++ b/docs/architecture/current-architecture.md
@@ -1,6 +1,6 @@
 # Nova Cat — Current Architecture Snapshot
 
-_Last Updated: 2026-03-06_
+_Last Updated: 2026-03-07_
 
 This document captures the **authoritative architectural baseline** of Nova Cat at this point in time.
 
@@ -85,13 +85,6 @@ Minted during `discover_spectra_products`. Derived as follows:
 
 Immutable once assigned; never reused across distinct products. See ADR-003 for full specification.
 
-Each spectra product identity is deterministic:
-
-```
-identity_key = hash(provider + provider_product_key + canonical_locator)
-data_product_id = UUID(identity_key)
-```
-
 `LOCATOR#<provider>#<locator_identity>` ensures stable deduplication.
 
 ---
@@ -121,12 +114,12 @@ Atomic unit of ingestion and validation.
 
 Each product has independent:
 
-- acquisition_state
-- validation_state
+- acquisition_status
+- validation_status
 - cooldown metadata
 - fingerprint (sha256)
 - header signature hash
-- selected_profile
+- fits_profile_id
 - quarantine_reason_code (if applicable)
 
 No dataset abstraction exists.
@@ -278,6 +271,17 @@ Eligibility index removed immediately after validation.
 - If schema version changes (future capability), snapshots prior table before overwrite
 
 No dataset abstraction exists.
+
+---
+
+## 4.7 name_check_and_reconcile
+
+- Accepts `nova_id`
+- Performs name normalization and reconciliation checks against the global `NameMapping` index
+- Proposed naming inputs (`proposed_public_name`, `proposed_aliases`) are passed via
+  `attributes` rather than typed fields, consistent with the minimal stable contract pattern
+- Operates entirely within the UUID-first execution model; no name-based downstream
+  operations are performed beyond the resolution boundary
 
 ---
 

--- a/docs/execution/execution-governance.md
+++ b/docs/execution/execution-governance.md
@@ -1,7 +1,7 @@
 # Execution Governance
 
 This document defines Step Functions execution conventions for Nova Cat workflows.
-It is intentionally “code-adjacent” and designed to be translated into definitions later.
+It is intentionally "code-adjacent" and designed to be translated into definitions later.
 
 ---
 
@@ -54,7 +54,7 @@ Operational metadata:
 
 Before acquisition:
 
-1. If `validation_status == VALIDATED`
+1. If `validation_status == VALID`
    → short-circuit success (`SKIPPED_DUPLICATE`)
 2. If `now < next_eligible_attempt_at`
    → short-circuit success (`SKIPPED_BACKOFF`)

--- a/docs/storage/dynamodb-access-patterns.md
+++ b/docs/storage/dynamodb-access-patterns.md
@@ -11,7 +11,7 @@ Field definitions and item structure are defined in `dynamodb-item-model.md`.
 
 The table is heterogeneous and uses namespaced `PK` values.
 
-Two primary partition types exist:
+Three primary partition types exist:
 
 1) Per-nova partitions
 - `PK = "<nova_id>"`
@@ -20,6 +20,8 @@ Two primary partition types exist:
 - `PK = "NAME#<normalized_name>"`
 - `PK = "LOCATOR#<provider>#<locator_identity>"`
 - `PK = "REFERENCE#<bibcode>"`
+- `PK = "WORKFLOW#<correlation_id>"` — pre-nova workflow artifacts written before a
+  `nova_id` exists (e.g. `FileObject` records during `initialize_nova` quarantine)
 
 Within per-nova partitions, item types are distinguished by `SK` prefixes such as:
 - `NOVA`
@@ -28,6 +30,22 @@ Within per-nova partitions, item types are distinguished by `SK` prefixes such a
 - `NOVAREF#...`
 - `JOBRUN#...`
 - `ATTEMPT#...`
+
+### Global Secondary Index: EligibilityIndex (GSI1)
+
+The table has one GSI used to identify spectra products that are ready to acquire:
+
+- **GSI1PK** = `<nova_id>` — scopes the query to a single nova
+- **GSI1SK** = `ELIG#<eligibility>#SPECTRA#<provider>#<data_product_id>`
+
+Key values:
+- `eligibility = ACQUIRE` → GSI1 attributes are **present** on the item; product appears in the index
+- `eligibility = NONE` → GSI1 attributes are **absent** (removed); product drops off the index
+
+This is the core signal that controls whether a spectra product is eligible for
+`acquire_and_validate_spectra`. It is set by `discover_spectra_products` on stub creation
+and cleared by `acquire_and_validate_spectra` on any terminal outcome (VALID, QUARANTINED,
+TERMINAL_INVALID, or SKIPPED_*). See dynamodb-item-model.md §3.2 for the full field spec.
 
 > **`data_product_id` — stable, deterministic UUID (SPECTRA products)**
 >
@@ -90,6 +108,12 @@ Purpose: Resolve a candidate name to a stable `nova_id`, or create a new `Nova`.
     - status = QUARANTINED
     - quarantine_reason_code = COORDINATE_AMBIGUITY
     - `PK = "<new_nova_id>"`, `SK = "NOVA"`
+
+- Write `FileObject` quarantine context record (before `nova_id` is confirmed):
+  `PK = "WORKFLOW#<correlation_id>"`
+  `SK = "FILE#WORKFLOW_QUARANTINE_CONTEXT#ID#<file_id>"`
+  *(Uses `correlation_id` as partition key because no stable `nova_id` exists at write time.
+  See dynamodb-item-model.md §5 for the full FileObject key table.)*
 
 **Side effects**
 - Finalize (`QUARANTINED`)
@@ -177,12 +201,18 @@ Purpose: Discover spectra products across providers, assign stable `data_product
   Stub state includes:
   - `acquisition_status = STUB`
   - `validation_status = UNVALIDATED`
-  - `eligibility = ACQUIRE`
-  - cooldown fields initialized (attempt_count = 0, etc.)
-  - eligibility index attributes present (so it can appear in the eligibility index)
+  - `eligibility = ACQUIRE` ← marks this product as ready to acquire
+  - cooldown fields initialized (`attempt_count = 0`, `next_eligible_attempt_at = null`, etc.)
+  - GSI1 attributes written so the product appears in the EligibilityIndex:
+    - `GSI1PK = "<nova_id>"`
+    - `GSI1SK = "ELIG#ACQUIRE#SPECTRA#<provider>#<data_product_id>"`
+
+  A product that resolves to an existing `data_product_id` that is already
+  `VALID` must **not** have a new acquisition request published for it, and its
+  `eligibility` must remain `NONE` (GSI1 attributes absent).
 
 ### Side effects
-- Publish one `acquire_and_validate_spectra` request per `data_product_id`
+- Publish one `acquire_and_validate_spectra` event per newly eligible `data_product_id`
 
 ---
 
@@ -214,14 +244,26 @@ Purpose: Acquire bytes for a single spectra product, validate via profile select
   - Persist fingerprints/checksums and profile selection outputs as applicable
   - Update lifecycle state (`validation_status`, `acquisition_status`, etc.)
   - Set `eligibility = NONE`
-  - Remove eligibility index attributes so the product no longer appears in the eligibility index
+  - **Remove GSI1 attributes** (`GSI1PK`, `GSI1SK`) so the product drops off the
+    EligibilityIndex and cannot be re-acquired by a future sweep
 
-### Optional query pattern (admin/repair)
-- List eligible spectra products for a nova via eligibility index:
-  - Query `GSI1PK = "<nova_id>"`
-  - `GSI1SK begins_with "ELIG#ACQUIRE#SPECTRA#"`
+### EligibilityIndex query (core acquisition trigger pattern)
 
-Note: In MVP, executions are normally launched from discovery output; this query supports repair/sweeps.
+In MVP, `acquire_and_validate_spectra` executions are launched directly from
+`discover_spectra_products` output events — the GSI is not used for normal dispatch.
+
+The GSI exists to support:
+- **Repair / retry sweeps**: re-queue all eligible products for a nova after an outage
+- **Operator-triggered re-ingestion**: list what still needs acquiring without scanning all products
+
+```
+Query GSI1PK = "<nova_id>"
+      GSI1SK begins_with "ELIG#ACQUIRE#SPECTRA#"
+```
+
+Returns all spectra products for the nova with `eligibility = ACQUIRE`, ordered by
+`<provider>#<data_product_id>`. An empty result means all products are either
+validated, quarantined, or terminal — nothing left to acquire.
 
 ---
 
@@ -246,11 +288,14 @@ SK = "PRODUCT#PHOTOMETRY_TABLE"
 
 Update photometry table `DataProduct` in place:
 
-- `current_s3_key`
-- `photometry_schema_version`
+- `s3_bucket`
+- `s3_key`
 - `last_ingestion_at`
 - `last_ingestion_source`
 - `ingestion_count`
+
+Note: `photometry_schema_version` is not a persisted field on `DataProduct`. If schema
+versioning is ever required, a typed field must be added to the contract first.
 
 ### Canonical Overwrite Behavior
 
@@ -279,6 +324,32 @@ Insert `FileObject` entries for:
 - Raw uploaded file
 - Split per-nova file (if applicable)
 - Derived artifacts
+
+---
+
+## name_check_and_reconcile
+
+Purpose: Validate and reconcile the canonical name and aliases for an existing nova.
+
+### Reads
+- Read nova metadata:
+  `PK = "<nova_id>"`, `SK = "NOVA"`
+
+- Query existing `NameMapping` entries for this nova:
+  *(via GSI or scan of known aliases on the Nova item)*
+
+### Writes
+- Upsert `NameMapping` items for any new or corrected aliases:
+  `PK = "NAME#<normalized_alias>"`, `SK = "NOVA#<nova_id>"`
+
+- Update `Nova.primary_name` / `Nova.primary_name_normalized` if a canonical name
+  change is approved
+
+### Notes
+- `proposed_public_name` and `proposed_aliases` are passed via `attributes` on the
+  boundary event, not as typed fields. See `NameCheckAndReconcileEvent` in `events.py`.
+- This workflow operates entirely downstream of `initialize_nova`; it does not perform
+  coordinate-based identity resolution.
 
 ---
 

--- a/docs/storage/dynamodb-item-model.md
+++ b/docs/storage/dynamodb-item-model.md
@@ -750,9 +750,18 @@ condition_expression=attribute_not_exists(PK).
 - `execution_arn`
 - `status`
   (`QUEUED` | `RUNNING` | `SUCCEEDED` | `FAILED` | `QUARANTINED` | `CANCELLED`)
+- `correlation_id` (UUID; required; propagated across all workflow chains and
+  downstream events; see execution-governance.md Correlation ID Rules)
 - `started_at`
 - `ended_at`
 - `initiated_by` (optional; actor or service that initiated the run)
+- `error_classification` (optional; `RETRYABLE` | `TERMINAL` — written by `TerminalFailHandler`
+  before `FinalizeJobRunFailed`; absent on SUCCEEDED/QUARANTINED runs)
+- `error_fingerprint` (optional; 12-char hex SHA-256 digest of
+  `error_type + job_run_id + cause[:100]`; stable across retries of the same logical
+  failure; cross-referenceable with CloudWatch logs; written alongside
+  `error_classification`; distinct from `last_error_fingerprint` on `DataProduct`,
+  which drives cooldown/backoff logic)
 
 #### Example:
 ```json
@@ -762,13 +771,16 @@ condition_expression=attribute_not_exists(PK).
   "entity_type": "JobRun",
   "schema_version": "1",
   "job_run_id": "5a4fce02-3b02-4b5c-8d06-541d9f2d4f60",
+  "correlation_id": "a1b2c3d4-9e8f-7a6b-5c4d-3e2f1a0b9c8d",
   "workflow_name": "acquire_and_validate_spectra",
   "execution_arn": "arn:aws:states:us-east-1:123456789012:execution:AcquireAndValidateSpectra:...",
   "status": "SUCCEEDED",
   "started_at": "2026-02-23T18:10:00Z",
   "ended_at": "2026-02-23T18:12:00Z",
   "created_at": "2026-02-23T18:10:00Z",
-  "updated_at": "2026-02-23T18:12:00Z"
+  "updated_at": "2026-02-23T18:12:00Z",
+  "error_classification": null,
+  "error_fingerprint": null
 }
 ```
 

--- a/docs/workflows/acquire-and-validate-spectra.md
+++ b/docs/workflows/acquire-and-validate-spectra.md
@@ -63,32 +63,34 @@ Terminology:
 9. **AcquireArtifact** (Task)
 10. **ValidateBytes (Profile-Driven)** (Task)
 11. **DuplicateByFingerprint?** (Choice)
-   - Yes -> **RecordDuplicateLinkage** -> **FinalizeJobRunSuccess** (outcome = `DUPLICATE_OF_EXISTING`)
-   - No  -> continue
-12. **RecordDuplicateLinkage** (Task)
-13. **RecordValidationResult** (Task)
-14. **FinalizeJobRunSuccess** (Task) (outcome = `VALIDATED`)
-15. **QuarantineHandler** (Task)
-16. **FinalizeJobRunQuarantined** (Task)
-17. **TerminalFailHandler** (Task)
-18. **FinalizeJobRunFailed** (Task)
+    - Yes -> **RecordDuplicateLinkage** -> **FinalizeJobRunSuccess** (outcome = `DUPLICATE_OF_EXISTING`)
+    - No  -> continue
+12. **RecordValidationResult** (Task)
+13. **FinalizeJobRunSuccess** (Task) (outcome = `VALIDATED`)
+14. **QuarantineHandler** (Task)
+15. **FinalizeJobRunQuarantined** (Task)
+16. **TerminalFailHandler** (Task)
+17. **FinalizeJobRunFailed** (Task)
 
 ---
 
 ## Persisted Operational Fields (Data Product)
 
-To control retry frequency and prevent hammering providers, the data product (or its operational sub-record) SHOULD persist:
+To control retry frequency and prevent hammering providers, the data product SHOULD persist:
 
 Minimum viable fields:
-- `validation_status` (e.g., `DISCOVERED | VALIDATED | QUARANTINED | FAILED`)
-- `attempt_count_total`
+- `eligibility` (`ACQUIRE | NONE`) — controls EligibilityIndex (GSI1) visibility;
+  set to `ACQUIRE` on stub creation by `discover_spectra_products`; cleared to
+  `NONE` (with GSI1 attributes removed) on any terminal outcome
+- `validation_status` (`UNVALIDATED | VALID | QUARANTINED | TERMINAL_INVALID`)
+- `acquisition_status` (`STUB | ACQUIRED | FAILED_RETRYABLE | SKIPPED_DUPLICATE | SKIPPED_BACKOFF`)
+- `attempt_count`
 - `last_attempt_at`
 - `last_attempt_outcome` (`SUCCESS | RETRYABLE_FAILURE | TERMINAL_FAILURE | QUARANTINE`)
 - `last_error_fingerprint`
 - `next_eligible_attempt_at`  ← primary anti-ping control
-- `last_successful_fingerprint` (when validated)
-- `content_fingerprint` (when acquired)
-- `duplicate_of_data_product_id` (when duplicate detected)
+- `sha256` (when acquired; stable content fingerprint)
+- `duplicate_of_data_product_id` (when a byte-level duplicate of an existing VALID product is detected)
 
 Rich attempt details belong in JobRun/Attempt records and logs.
 
@@ -136,15 +138,15 @@ Discovery attempts metadata-level dedupe, but definitive dedupe may require acqu
 
 After acquisition (and once bytes are available), the workflow MUST:
 
-1. Compute a stable `content_fingerprint` (e.g., SHA-256 of canonical bytes or a deterministic normalization).
-2. Check whether an existing **VALIDATED** data product already has the same fingerprint.
+1. Compute a stable content fingerprint (`sha256` of canonical bytes or a deterministic normalization).
+2. Check whether an existing **VALID** data product already has the same fingerprint.
 3. If a match exists:
-   - Mark the current data product as a duplicate of the canonical product (e.g., `duplicate_of_data_product_id = <canonical>`).
+   - Mark the current data product as a duplicate of the canonical product (`duplicate_of_data_product_id = <canonical>`).
    - Optionally append this product's locator(s) as aliases to the canonical product.
    - Finalize the JobRun successfully with outcome `DUPLICATE_OF_EXISTING`.
-   - The current data product MUST NOT be marked `VALIDATED`.
+   - The current data product MUST NOT be marked `VALID`.
 4. If no match exists:
-   - Continue normal validation result recording and mark `VALIDATED`.
+   - Continue normal validation result recording and mark `VALID`.
 
 This preserves stable UUIDs while avoiding duplicate scientific products downstream.
 
@@ -215,7 +217,7 @@ Workflow idempotency key:
 
 Step dedupe keys (internal):
 - Acquire: `Acquire:{data_product_id}:{expected_identity_or_locator}`
-- Validate: `Validate:{data_product_id}:{content_fingerprint}`
+- Validate: `Validate:{data_product_id}:{sha256}`
 
 Invariants:
 - Exactly one `data_product_id` per execution (MVP Mode 1)

--- a/docs/workflows/ingest-new-nova.md
+++ b/docs/workflows/ingest-new-nova.md
@@ -23,18 +23,26 @@ It assumes the nova exists (created earlier by initialize_nova or other establis
 - It MAY publish an internal “launched” event for auditing, but downstream consumers are optional.
   - If present: `schemas/events/ingest_new_nova_launched/latest.json` (optional, if such a schema exists)
 
+## Input Validation
+
+`ValidateInput` and `EnsureCorrelationId` Pass/Choice states are **not present** in
+this workflow's ASL. Input is published by `initialize_nova` (and any other internal
+publisher) whose outbound Pydantic event model enforces the contract at the publishing
+boundary. Workflow-entry validation would be redundant and is omitted by design.
+See `initialize_nova_asl.json` for the pattern used at the API-facing boundary.
+
+---
+
 ## State Machine (Explicit State List)
-1. **ValidateInput** (Pass)
-2. **EnsureCorrelationId** (Choice + Pass)
-3. **BeginJobRun** (Task)
-4. **AcquireIdempotencyLock** (Task)
-5. **LaunchDownstream** (Parallel)
+1. **BeginJobRun** (Task)
+2. **AcquireIdempotencyLock** (Task)
+3. **LaunchDownstream** (Parallel)
    - **LaunchRefreshReferences** (Task) -> publishes `schemas/events/refresh_references/latest.json`
    - **LaunchDiscoverSpectraProducts** (Task) -> publishes `schemas/events/discover_spectra_products/latest.json`
    - (Optional future) launch other workflows
-6. **FinalizeJobRunSuccess** (Task)
-7. **TerminalFailHandler** (Task)
-8. **FinalizeJobRunFailed** (Task)
+4. **FinalizeJobRunSuccess** (Task)
+5. **TerminalFailHandler** (Task)
+6. **FinalizeJobRunFailed** (Task)
 
 ## Retry / Timeout Policy (per state)
 - BeginJobRun:

--- a/docs/workflows/refresh-references.md
+++ b/docs/workflows/refresh-references.md
@@ -94,23 +94,37 @@ treat HTTP 429 responses as retryable.
 
 ---
 
+## Input Validation
+
+`ValidateInput` and `EnsureCorrelationId` Pass/Choice states are **not present** in
+this workflow's ASL. In MVP, `refresh_references` is only triggered internally — by
+`ingest_new_nova` and by the scheduled refresh — whose outbound Pydantic event models
+enforce the contract at the publishing boundary. Workflow-entry validation is therefore
+redundant and omitted by design.
+
+**Post-MVP:** When a standalone API entrypoint for `refresh_references` is introduced
+(e.g. operator-triggered re-run or ad-hoc refresh), `ValidateInput` and
+`EnsureCorrelationId` should be added as the first two states, consistent with the
+pattern in `initialize_nova_asl.json`. This will be a non-breaking ASL change as long
+as the input event schema is a strict superset of the internally-published schema.
+
+---
+
 ## State Machine (Explicit State List)
 
-1. **ValidateInput** (Pass)
-2. **EnsureCorrelationId** (Choice + Pass)
-3. **BeginJobRun** (Task)
-4. **AcquireIdempotencyLock** (Task)
-5. **FetchReferenceCandidates** (Task)
-6. **ReconcileReferences** (Map)
+1. **BeginJobRun** (Task)
+2. **AcquireIdempotencyLock** (Task)
+3. **FetchReferenceCandidates** (Task)
+4. **ReconcileReferences** (Map)
    - NormalizeReference (Task)
    - UpsertReferenceEntity (Task) → yields `bibcode`
    - LinkNovaReference (Task)
    - ItemFailureHandler (Catch → QuarantineItem + Continue)
-7. **ComputeDiscoveryDate** (Task)
-8. **UpsertDiscoveryDateMetadata** (Task) (no-op if unchanged)
-9. **FinalizeJobRunSuccess** (Task)
-10. **TerminalFailHandler** (Task)
-11. **FinalizeJobRunFailed** (Task)
+5. **ComputeDiscoveryDate** (Task)
+6. **UpsertDiscoveryDateMetadata** (Task) (no-op if unchanged)
+7. **FinalizeJobRunSuccess** (Task)
+8. **TerminalFailHandler** (Task)
+9. **FinalizeJobRunFailed** (Task)
 
 ---
 

--- a/infra/nova_constructs/compute.py
+++ b/infra/nova_constructs/compute.py
@@ -71,7 +71,8 @@ _FUNCTION_SPECS: dict[str, _FunctionSpec] = {
         service_dir="job_run_manager",
         description=(
             "Writes JobRun and Attempt operational records. "
-            "Handles BeginJobRun, FinalizeJobRunSuccess, FinalizeJobRunFailed, "
+            "Handles BeginJobRun, TerminalFailHandler (error classification + fingerprint), "
+            "FinalizeJobRunSuccess, FinalizeJobRunFailed, "
             "FinalizeJobRunQuarantined. Used by: all workflows (shared)."
         ),
     ),

--- a/infra/nova_constructs/workflows.py
+++ b/infra/nova_constructs/workflows.py
@@ -47,7 +47,7 @@ class NovaCatWorkflows(Construct):
     Exposes:
       initialize_nova          — the initialize_nova state machine
       ingest_new_nova          — the ingest_new_nova state machine
-      refresh_references       — the refresh_references state machine (placeholder stub)
+      refresh_references       — the refresh_references state machine
       discover_spectra_products — the discover_spectra_products state machine (placeholder stub)
     """
 
@@ -63,18 +63,34 @@ class NovaCatWorkflows(Construct):
         self._workflows_dir = os.path.join(os.path.dirname(__file__), "../workflows")
 
         # ------------------------------------------------------------------
-        # Downstream placeholder state machines
+        # discover_spectra_products state machine (placeholder stub)
         #
-        # Provisioned before ingest_new_nova and initialize_nova so their ARNs
-        # can be injected into workflow_launcher as environment variables.
-        # Placeholder ASLs contain a single Fail state — they will be replaced
-        # in their respective epics.
+        # Placeholder ASL contains a single Fail state — will be replaced
+        # in its respective epic.
+        # ------------------------------------------------------------------
+        # ------------------------------------------------------------------
+        # refresh_references state machine
         # ------------------------------------------------------------------
         self.refresh_references = self._create_state_machine(
             name="refresh-references",
             asl_file="refresh_references.asl.json",
-            substitutions={},
-            invokable_functions=[],
+            substitutions={
+                "BeginJobRunFunctionArn": compute.job_run_manager.function_arn,
+                "FinalizeJobRunSuccessFunctionArn": compute.job_run_manager.function_arn,
+                "FinalizeJobRunFailedFunctionArn": compute.job_run_manager.function_arn,
+                # TerminalFailHandler state also routes through job_run_manager
+                # (task_name: TerminalFailHandler — classifies error before FinalizeJobRunFailed)
+                "JobRunManagerFunctionArn": compute.job_run_manager.function_arn,
+                "AcquireIdempotencyLockFunctionArn": compute.idempotency_guard.function_arn,
+                "QuarantineHandlerFunctionArn": compute.quarantine_handler.function_arn,
+                "ReferenceManagerFunctionArn": compute.reference_manager.function_arn,
+            },
+            invokable_functions=[
+                compute.job_run_manager,
+                compute.idempotency_guard,
+                compute.quarantine_handler,
+                compute.reference_manager,
+            ],
         )
         self.discover_spectra_products = self._create_state_machine(
             name="discover-spectra-products",
@@ -93,6 +109,9 @@ class NovaCatWorkflows(Construct):
                 "BeginJobRunFunctionArn": compute.job_run_manager.function_arn,
                 "FinalizeJobRunSuccessFunctionArn": compute.job_run_manager.function_arn,
                 "FinalizeJobRunFailedFunctionArn": compute.job_run_manager.function_arn,
+                # TerminalFailHandler state also routes through job_run_manager
+                # (task_name: TerminalFailHandler — classifies error before FinalizeJobRunFailed)
+                "JobRunManagerFunctionArn": compute.job_run_manager.function_arn,
                 "AcquireIdempotencyLockFunctionArn": compute.idempotency_guard.function_arn,
                 "LaunchRefreshReferencesFunctionArn": compute.workflow_launcher.function_arn,
                 "LaunchDiscoverSpectraProductsFunctionArn": compute.workflow_launcher.function_arn,
@@ -151,6 +170,9 @@ class NovaCatWorkflows(Construct):
                 "FinalizeJobRunSuccessFunctionArn": compute.job_run_manager.function_arn,
                 "FinalizeJobRunFailedFunctionArn": compute.job_run_manager.function_arn,
                 "FinalizeJobRunQuarantinedFunctionArn": compute.job_run_manager.function_arn,
+                # TerminalFailHandler state also routes through job_run_manager
+                # (task_name: TerminalFailHandler — classifies error before FinalizeJobRunFailed)
+                "JobRunManagerFunctionArn": compute.job_run_manager.function_arn,
                 "AcquireIdempotencyLockFunctionArn": compute.idempotency_guard.function_arn,
                 "NormalizeCandidateNameFunctionArn": compute.nova_resolver.function_arn,
                 "CheckExistingNovaByNameFunctionArn": compute.nova_resolver.function_arn,
@@ -161,7 +183,6 @@ class NovaCatWorkflows(Construct):
                 "ResolveCandidateAgainstPublicArchivesFunctionArn": compute.archive_resolver.function_arn,
                 "PublishIngestNewNovaFunctionArn": compute.workflow_launcher.function_arn,
                 "QuarantineHandlerFunctionArn": compute.quarantine_handler.function_arn,
-                "TerminalFailHandlerFunctionArn": compute.quarantine_handler.function_arn,
             },
             invokable_functions=[
                 compute.job_run_manager,

--- a/infra/workflows/ingest_new_nova.asl.json
+++ b/infra/workflows/ingest_new_nova.asl.json
@@ -20,7 +20,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -55,7 +55,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -94,7 +94,7 @@
                                     ],
                                     "IntervalSeconds": 2,
                                     "MaxAttempts": 3,
-                                    "BackoffRate": 1,
+                                    "BackoffRate": 4,
                                     "JitterStrategy": "FULL"
                                 }
                             ],
@@ -122,7 +122,7 @@
                                     ],
                                     "IntervalSeconds": 2,
                                     "MaxAttempts": 3,
-                                    "BackoffRate": 1,
+                                    "BackoffRate": 4,
                                     "JitterStrategy": "FULL"
                                 }
                             ],
@@ -164,7 +164,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -180,6 +180,42 @@
             "End": true
         },
         "TerminalFailHandler": {
+            "Type": "Task",
+            "Comment": "Classifies the error and persists error_classification + error_fingerprint onto the JobRun before the final FAILED status is written. Implemented as a task in job_run_manager (task_name: TerminalFailHandler).",
+            "Resource": "${JobRunManagerFunctionArn}",
+            "Parameters": {
+                "task_name": "TerminalFailHandler",
+                "workflow_name": "ingest_new_nova",
+                "error.$": "$.error",
+                "correlation_id.$": "$.job_run.correlation_id",
+                "job_run_id.$": "$.job_run.job_run_id",
+                "job_run.$": "$.job_run"
+            },
+            "ResultPath": "$.terminal_fail",
+            "TimeoutSeconds": 10,
+            "Retry": [
+                {
+                    "ErrorEquals": [
+                        "RetryableError"
+                    ],
+                    "IntervalSeconds": 2,
+                    "MaxAttempts": 3,
+                    "BackoffRate": 4,
+                    "JitterStrategy": "FULL"
+                }
+            ],
+            "Catch": [
+                {
+                    "ErrorEquals": [
+                        "States.ALL"
+                    ],
+                    "Next": "FinalizeJobRunFailed",
+                    "ResultPath": "$.error"
+                }
+            ],
+            "Next": "FinalizeJobRunFailed"
+        },
+        "FinalizeJobRunFailed": {
             "Type": "Task",
             "Resource": "${FinalizeJobRunFailedFunctionArn}",
             "Parameters": {

--- a/infra/workflows/initialize_nova.asl.json
+++ b/infra/workflows/initialize_nova.asl.json
@@ -21,7 +21,9 @@
         },
         "GenerateCorrelationId": {
             "Type": "Pass",
-            "Comment": "Placeholder: actual UUID generation happens inside BeginJobRun Lambda, which returns the generated correlation_id in its output and merges it into the execution context.",
+            "Comment": "Inject null placeholder so $.correlation_id is always defined when BeginJobRun Parameters are evaluated. BeginJobRun Lambda replaces null with a fresh UUID via event.get('correlation_id') or str(uuid.uuid4()).",
+            "Result": null,
+            "ResultPath": "$.correlation_id",
             "Next": "BeginJobRun"
         },
         "BeginJobRun": {
@@ -44,7 +46,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -58,41 +60,6 @@
                 }
             ],
             "Next": "NormalizeCandidateName"
-        },
-        "AcquireIdempotencyLock": {
-            "Type": "Task",
-            "Comment": "Acquire workflow-level idempotency lock. Key: InitializeNova:{normalized_candidate_name}:{schema_version}:{time_bucket}. If lock already held by a concurrent execution, raises RetryableError.",
-            "Resource": "${AcquireIdempotencyLockFunctionArn}",
-            "Parameters": {
-                "task_name": "AcquireIdempotencyLock",
-                "workflow_name": "initialize_nova",
-                "primary_id.$": "$.normalization.normalized_candidate_name",
-                "correlation_id.$": "$.job_run.correlation_id",
-                "job_run_id.$": "$.job_run.job_run_id"
-            },
-            "ResultPath": "$.idempotency",
-            "TimeoutSeconds": 10,
-            "Retry": [
-                {
-                    "ErrorEquals": [
-                        "RetryableError"
-                    ],
-                    "IntervalSeconds": 2,
-                    "MaxAttempts": 3,
-                    "BackoffRate": 1,
-                    "JitterStrategy": "FULL"
-                }
-            ],
-            "Catch": [
-                {
-                    "ErrorEquals": [
-                        "States.ALL"
-                    ],
-                    "Next": "TerminalFailHandler",
-                    "ResultPath": "$.error"
-                }
-            ],
-            "Next": "CheckExistingNovaByName"
         },
         "NormalizeCandidateName": {
             "Type": "Task",
@@ -114,7 +81,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 2,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -128,6 +95,41 @@
                 }
             ],
             "Next": "AcquireIdempotencyLock"
+        },
+        "AcquireIdempotencyLock": {
+            "Type": "Task",
+            "Comment": "Acquire workflow-level idempotency lock. Key: InitializeNova:{normalized_candidate_name}:{schema_version}:{time_bucket}. If lock already held by a concurrent execution, raises RetryableError.",
+            "Resource": "${AcquireIdempotencyLockFunctionArn}",
+            "Parameters": {
+                "task_name": "AcquireIdempotencyLock",
+                "workflow_name": "initialize_nova",
+                "primary_id.$": "$.normalization.normalized_candidate_name",
+                "correlation_id.$": "$.job_run.correlation_id",
+                "job_run_id.$": "$.job_run.job_run_id"
+            },
+            "ResultPath": "$.idempotency",
+            "TimeoutSeconds": 10,
+            "Retry": [
+                {
+                    "ErrorEquals": [
+                        "RetryableError"
+                    ],
+                    "IntervalSeconds": 2,
+                    "MaxAttempts": 3,
+                    "BackoffRate": 4,
+                    "JitterStrategy": "FULL"
+                }
+            ],
+            "Catch": [
+                {
+                    "ErrorEquals": [
+                        "States.ALL"
+                    ],
+                    "Next": "TerminalFailHandler",
+                    "ResultPath": "$.error"
+                }
+            ],
+            "Next": "CheckExistingNovaByName"
         },
         "CheckExistingNovaByName": {
             "Type": "Task",
@@ -149,7 +151,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -197,7 +199,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 2,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -222,7 +224,8 @@
                 "outcome": "EXISTS_AND_LAUNCHED",
                 "nova_id.$": "$.name_check.nova_id",
                 "correlation_id.$": "$.job_run.correlation_id",
-                "job_run_id.$": "$.job_run.job_run_id"
+                "job_run_id.$": "$.job_run.job_run_id",
+                "job_run.$": "$.job_run"
             },
             "ResultPath": "$.finalize",
             "TimeoutSeconds": 10,
@@ -233,7 +236,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -260,7 +263,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -297,7 +300,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -351,7 +354,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -387,7 +390,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 2,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -412,7 +415,8 @@
                 "outcome": "EXISTS_AND_LAUNCHED",
                 "nova_id.$": "$.coordinate_check.matched_nova_id",
                 "correlation_id.$": "$.job_run.correlation_id",
-                "job_run_id.$": "$.job_run.job_run_id"
+                "job_run_id.$": "$.job_run.job_run_id",
+                "job_run.$": "$.job_run"
             },
             "ResultPath": "$.finalize",
             "TimeoutSeconds": 10,
@@ -423,7 +427,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -441,7 +445,8 @@
                 "normalized_candidate_name.$": "$.normalization.normalized_candidate_name",
                 "min_sep_arcsec.$": "$.coordinate_check.min_sep_arcsec",
                 "correlation_id.$": "$.job_run.correlation_id",
-                "job_run_id.$": "$.job_run.job_run_id"
+                "job_run_id.$": "$.job_run.job_run_id",
+                "job_run.$": "$.job_run"
             },
             "ResultPath": "$.quarantine",
             "TimeoutSeconds": 10,
@@ -452,7 +457,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -489,7 +494,8 @@
                 "outcome": "NOT_FOUND",
                 "candidate_name.$": "$.candidate_name",
                 "correlation_id.$": "$.job_run.correlation_id",
-                "job_run_id.$": "$.job_run.job_run_id"
+                "job_run_id.$": "$.job_run.job_run_id",
+                "job_run.$": "$.job_run"
             },
             "ResultPath": "$.finalize",
             "TimeoutSeconds": 10,
@@ -500,7 +506,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -533,7 +539,8 @@
                 "outcome": "NOT_A_CLASSICAL_NOVA",
                 "candidate_name.$": "$.candidate_name",
                 "correlation_id.$": "$.job_run.correlation_id",
-                "job_run_id.$": "$.job_run.job_run_id"
+                "job_run_id.$": "$.job_run.job_run_id",
+                "job_run.$": "$.job_run"
             },
             "ResultPath": "$.finalize",
             "TimeoutSeconds": 10,
@@ -544,7 +551,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -561,7 +568,8 @@
                 "candidate_name.$": "$.candidate_name",
                 "normalized_candidate_name.$": "$.normalization.normalized_candidate_name",
                 "correlation_id.$": "$.job_run.correlation_id",
-                "job_run_id.$": "$.job_run.job_run_id"
+                "job_run_id.$": "$.job_run.job_run_id",
+                "job_run.$": "$.job_run"
             },
             "ResultPath": "$.quarantine",
             "TimeoutSeconds": 10,
@@ -572,7 +580,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -608,7 +616,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -650,7 +658,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -686,7 +694,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 2,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -711,7 +719,8 @@
                 "outcome": "CREATED_AND_LAUNCHED",
                 "nova_id.$": "$.nova_creation.nova_id",
                 "correlation_id.$": "$.job_run.correlation_id",
-                "job_run_id.$": "$.job_run.job_run_id"
+                "job_run_id.$": "$.job_run.job_run_id",
+                "job_run.$": "$.job_run"
             },
             "ResultPath": "$.finalize",
             "TimeoutSeconds": 10,
@@ -722,7 +731,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -730,15 +739,16 @@
         },
         "TerminalFailHandler": {
             "Type": "Task",
-            "Comment": "Handles unrecoverable terminal failures. Classifies the error, persists diagnostic metadata, and routes to FinalizeJobRunFailed.",
-            "Resource": "${TerminalFailHandlerFunctionArn}",
+            "Comment": "Classifies the error and persists error_classification + error_fingerprint onto the JobRun before the final FAILED status is written. Implemented as a task in job_run_manager (task_name: TerminalFailHandler). ResultPath $.terminal_fail preserves $.job_run and $.error for the subsequent FinalizeJobRunFailed state.",
+            "Resource": "${JobRunManagerFunctionArn}",
             "Parameters": {
-                "task_name": "QuarantineHandler",
+                "task_name": "TerminalFailHandler",
                 "workflow_name": "initialize_nova",
                 "error.$": "$.error",
                 "candidate_name.$": "$.candidate_name",
                 "correlation_id.$": "$.job_run.correlation_id",
-                "job_run_id.$": "$.job_run.job_run_id"
+                "job_run_id.$": "$.job_run.job_run_id",
+                "job_run.$": "$.job_run"
             },
             "ResultPath": "$.terminal_fail",
             "TimeoutSeconds": 10,
@@ -749,7 +759,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -773,7 +783,8 @@
                 "workflow_name": "initialize_nova",
                 "candidate_name.$": "$.candidate_name",
                 "correlation_id.$": "$.job_run.correlation_id",
-                "job_run_id.$": "$.job_run.job_run_id"
+                "job_run_id.$": "$.job_run.job_run_id",
+                "job_run.$": "$.job_run"
             },
             "ResultPath": "$.finalize",
             "TimeoutSeconds": 10,
@@ -784,7 +795,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -799,7 +810,8 @@
                 "workflow_name": "initialize_nova",
                 "candidate_name.$": "$.candidate_name",
                 "correlation_id.$": "$.job_run.correlation_id",
-                "job_run_id.$": "$.job_run.job_run_id"
+                "job_run_id.$": "$.job_run.job_run_id",
+                "job_run.$": "$.job_run"
             },
             "ResultPath": "$.finalize",
             "TimeoutSeconds": 10,
@@ -810,7 +822,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],

--- a/infra/workflows/refresh_references.asl.json
+++ b/infra/workflows/refresh_references.asl.json
@@ -20,7 +20,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -55,7 +55,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -90,7 +90,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -147,7 +147,7 @@
                                 ],
                                 "IntervalSeconds": 2,
                                 "MaxAttempts": 2,
-                                "BackoffRate": 1,
+                                "BackoffRate": 4,
                                 "JitterStrategy": "FULL"
                             }
                         ],
@@ -186,7 +186,7 @@
                                 ],
                                 "IntervalSeconds": 2,
                                 "MaxAttempts": 2,
-                                "BackoffRate": 1,
+                                "BackoffRate": 4,
                                 "JitterStrategy": "FULL"
                             }
                         ],
@@ -219,7 +219,7 @@
                                 ],
                                 "IntervalSeconds": 2,
                                 "MaxAttempts": 2,
-                                "BackoffRate": 1,
+                                "BackoffRate": 4,
                                 "JitterStrategy": "FULL"
                             }
                         ],
@@ -236,7 +236,7 @@
                     },
                     "ItemFailureHandler": {
                         "Type": "Pass",
-                        "Comment": "TODO: wire to quarantine_handler Lambda for item-level quarantine tracking and SNS notification. For now, records the error context and continues the Map so one bad reference does not abort the workflow.",
+                        "Comment": "TODO: wire to ${QuarantineHandlerFunctionArn} for item-level quarantine tracking and SNS notification per execution-governance.md quarantine requirements. Handler should receive: workflow_name, nova_id, bibcode, correlation_id, error_fingerprint. For now, records the error context and continues the Map so one bad reference does not abort the workflow.",
                         "End": true
                     }
                 }
@@ -272,7 +272,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 2,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -309,7 +309,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -345,7 +345,7 @@
                     ],
                     "IntervalSeconds": 2,
                     "MaxAttempts": 3,
-                    "BackoffRate": 1,
+                    "BackoffRate": 4,
                     "JitterStrategy": "FULL"
                 }
             ],
@@ -361,6 +361,42 @@
             "End": true
         },
         "TerminalFailHandler": {
+            "Type": "Task",
+            "Comment": "Classifies the error and persists error_classification + error_fingerprint onto the JobRun before the final FAILED status is written. Implemented as a task in job_run_manager (task_name: TerminalFailHandler).",
+            "Resource": "${JobRunManagerFunctionArn}",
+            "Parameters": {
+                "task_name": "TerminalFailHandler",
+                "workflow_name": "refresh_references",
+                "error.$": "$.error",
+                "correlation_id.$": "$.job_run.correlation_id",
+                "job_run_id.$": "$.job_run.job_run_id",
+                "job_run.$": "$.job_run"
+            },
+            "ResultPath": "$.terminal_fail",
+            "TimeoutSeconds": 10,
+            "Retry": [
+                {
+                    "ErrorEquals": [
+                        "RetryableError"
+                    ],
+                    "IntervalSeconds": 2,
+                    "MaxAttempts": 3,
+                    "BackoffRate": 4,
+                    "JitterStrategy": "FULL"
+                }
+            ],
+            "Catch": [
+                {
+                    "ErrorEquals": [
+                        "States.ALL"
+                    ],
+                    "Next": "FinalizeJobRunFailed",
+                    "ResultPath": "$.error"
+                }
+            ],
+            "Next": "FinalizeJobRunFailed"
+        },
+        "FinalizeJobRunFailed": {
             "Type": "Task",
             "Resource": "${FinalizeJobRunFailedFunctionArn}",
             "Parameters": {

--- a/services/job_run_manager/handler.py
+++ b/services/job_run_manager/handler.py
@@ -28,6 +28,7 @@ Note on candidate_name vs nova_id:
 
 from __future__ import annotations
 
+import hashlib
 import os
 import uuid
 from collections.abc import Callable
@@ -221,6 +222,77 @@ def _finalize_job_run_quarantined(event: dict[str, Any], context: object) -> dic
     return {"status": "QUARANTINED", "ended_at": ended_at}
 
 
+@tracer.capture_method
+def _terminal_fail_handler(event: dict[str, Any], context: object) -> dict[str, Any]:
+    """
+    Classify a terminal error and persist diagnostic metadata onto the JobRun.
+
+    This is a distinct step from FinalizeJobRunFailed. It runs *before* the
+    final status update so that error_classification and error_fingerprint are
+    persisted on the JobRun record for operator diagnosis before the item is
+    marked FAILED.
+
+    Called by initialize_nova (and any workflow that needs richer error context
+    than FinalizeJobRunFailed alone provides). ingest_new_nova and
+    refresh_references collapse straight to FinalizeJobRunFailed because their
+    terminal failure paths are simpler and don't require pre-classification.
+
+    Classification heuristic (extend as the error taxonomy grows):
+      - Error name contains "RetryableError"  → RETRYABLE  (shouldn't reach here
+        normally, but defensive)
+      - Error name contains "TerminalError"   → TERMINAL
+      - Anything else                         → TERMINAL
+
+    The error_fingerprint is a 12-hex-char SHA-256 digest of
+    (error_type + job_run_id + first 100 chars of cause). Stable across retries
+    of the same logical failure; cross-referenceable with CloudWatch logs.
+
+    Returns:
+        error_classification — "RETRYABLE" | "TERMINAL"
+        error_fingerprint    — 12-char hex digest
+    The ASL ResultPath is "$.terminal_fail"; $.job_run and $.error remain
+    accessible for the subsequent FinalizeJobRunFailed state.
+    """
+    job_run: dict[str, Any] = event["job_run"]
+    error: dict[str, Any] = event.get("error") or {}
+
+    error_type: str = error.get("Error") or "UnknownError"
+    error_cause: str = (error.get("Cause") or "")[:500]
+
+    error_classification = "RETRYABLE" if "RetryableError" in error_type else "TERMINAL"
+
+    raw = f"{error_type}:{job_run.get('job_run_id', '')}:{error_cause[:100]}"
+    error_fingerprint = hashlib.sha256(raw.encode()).hexdigest()[:12]
+
+    now = _now()
+
+    _table.update_item(
+        Key={"PK": job_run["pk"], "SK": job_run["sk"]},
+        UpdateExpression=(
+            "SET error_classification = :ec, error_fingerprint = :ef, updated_at = :updated_at"
+        ),
+        ExpressionAttributeValues={
+            ":ec": error_classification,
+            ":ef": error_fingerprint,
+            ":updated_at": now,
+        },
+    )
+
+    logger.error(
+        "Terminal failure classified",
+        extra={
+            "error_type": error_type,
+            "error_classification": error_classification,
+            "error_fingerprint": error_fingerprint,
+        },
+    )
+
+    return {
+        "error_classification": error_classification,
+        "error_fingerprint": error_fingerprint,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -236,6 +308,7 @@ def _now() -> str:
 
 _TASK_HANDLERS: dict[str, Callable[[dict[str, Any], object], dict[str, Any]]] = {
     "BeginJobRun": _begin_job_run,
+    "TerminalFailHandler": _terminal_fail_handler,
     "FinalizeJobRunSuccess": _finalize_job_run_success,
     "FinalizeJobRunFailed": _finalize_job_run_failed,
     "FinalizeJobRunQuarantined": _finalize_job_run_quarantined,

--- a/services/nova_common_layer/python/nova_common/errors.py
+++ b/services/nova_common_layer/python/nova_common/errors.py
@@ -60,5 +60,5 @@ class QuarantineError(Exception):
     Raise when the data is not clearly wrong but cannot be safely processed:
       - Ambiguous archive resolver results
       - Conflicting authoritative sources
-      - Coordinate match in the ambiguous 2"–10" band
+      - Coordinate match in the ambiguous 2"-10" band
     """


### PR DESCRIPTION
## Summary

Two categories of change: documentation drift corrections from the housekeeping audit, and runtime bugs found while cross-referencing Lambda handlers against ASL files.

## Runtime bugs fixed

- `initialize_nova.asl.json` — `job_run.$` parameter missing from all 9 finalize/quarantine states; every finalize path would have raised a `KeyError` at runtime
- `initialize_nova.asl.json` — `GenerateCorrelationId` Pass state had no `Result`/`ResultPath`, leaving `$.correlation_id` undefined on the no-correlation-id path
- All three ASLs — `TerminalFailHandler` either pointed to the wrong Lambda (`quarantine_handler`) or didn't exist at all; now a real two-step classification pass in `job_run_manager` before `FinalizeJobRunFailed`
- `workflows.py` — `refresh_references` was still provisioned as a placeholder stub (`substitutions={}`) despite having a fully implemented ASL; all six tokens would have been unresolved at deploy time

## Supporting generalizations

- `job_run_manager` — add `_terminal_fail_handler` task: classifies error (`RETRYABLE | TERMINAL`), computes stable 12-char `error_fingerprint` (SHA-256 of `error_type + job_run_id + cause[:100]`), persists both onto the JobRun record before `FinalizeJobRunFailed` writes terminal status

## Documentation drift corrected

- `dynamodb-access-patterns` — document GSI1/EligibilityIndex; expand `discover_spectra_products` write spec with explicit GSI1 key values; promote eligibility query from "Optional" to a named pattern
- `dynamodb-item-model` — add `error_classification` and `error_fingerprint` to JobRun §8; note distinction from `last_error_fingerprint` on DataProduct
- `ingest-new-nova`, `refresh-references` — remove phantom `ValidateInput`/`EnsureCorrelationId` states; add Input Validation section explaining boundary validation model; `refresh-references` notes standalone API entrypoint as post-MVP
- `acquire-and-validate-spectra` — add `eligibility` to Persisted Operational Fields

## Notes

- `TerminalFailHandler` is intentionally absent from `ingest_new_nova` and `refresh_references` workflow specs in previous epics — those ASLs collapsed directly to `FinalizeJobRunFailed`. The two-step pattern is now consistent across all three workflows.
- `refresh_references` CDK wiring fix is a deploy-time correctness fix only — no change to the ASL or Lambda behavior.