### PR TITLE
fix(infra): non-deterministic deploys, discover→acquire pipeline, and observability

### DIFF
--- a/infra/nova_constructs/compute.py
+++ b/infra/nova_constructs/compute.py
@@ -475,7 +475,7 @@ class NovaCatCompute(Construct):
                 handler="handler.handle",
                 code=lambda_.Code.from_asset(
                     service_path,
-                    asset_hash_type=cdk.AssetHashType.OUTPUT,
+                    asset_hash_type=cdk.AssetHashType.SOURCE,
                     bundling=cdk.BundlingOptions(
                         image=_PYTHON_RUNTIME.bundling_image,
                         command=["bash", "-c", docker_cmd],

--- a/infra/nova_constructs/workflows.py
+++ b/infra/nova_constructs/workflows.py
@@ -38,6 +38,7 @@ import aws_cdk.aws_events as events
 import aws_cdk.aws_events_targets as events_targets
 import aws_cdk.aws_iam as iam
 import aws_cdk.aws_lambda as lambda_
+import aws_cdk.aws_logs as logs
 import aws_cdk.aws_s3 as s3
 import aws_cdk.aws_sns as sns
 import aws_cdk.aws_stepfunctions as sfn
@@ -77,11 +78,13 @@ class NovaCatWorkflows(Construct):
         sweep_schedule_hours: int = 6,
         env_prefix: str = "nova-cat",
         cf_prefix: str = "NovaCat",
+        removal_policy: cdk.RemovalPolicy = cdk.RemovalPolicy.DESTROY,
     ) -> None:
         super().__init__(scope, construct_id)
 
         self._env_prefix = env_prefix
         self._cf_prefix = cf_prefix
+        self._removal_policy = removal_policy
 
         self._workflows_dir = os.path.join(os.path.dirname(__file__), "../workflows")
 
@@ -103,6 +106,7 @@ class NovaCatWorkflows(Construct):
                 compute.spectra_validator,
                 compute.spectra_acquirer,
             ],
+            removal_policy=self._removal_policy,
         )
 
         # ------------------------------------------------------------------
@@ -123,6 +127,7 @@ class NovaCatWorkflows(Construct):
                 compute.spectra_discoverer,
                 compute.workflow_launcher,
             ],
+            removal_policy=self._removal_policy,
         )
 
         # ------------------------------------------------------------------
@@ -148,6 +153,7 @@ class NovaCatWorkflows(Construct):
                 compute.quarantine_handler,
                 compute.reference_manager,
             ],
+            removal_policy=self._removal_policy,
         )
         # ------------------------------------------------------------------
         # ingest_new_nova state machine
@@ -171,6 +177,7 @@ class NovaCatWorkflows(Construct):
                 compute.idempotency_guard,
                 compute.workflow_launcher,
             ],
+            removal_policy=self._removal_policy,
         )
 
         # Grant workflow_launcher permission to start executions and inject ARNs.
@@ -248,6 +255,7 @@ class NovaCatWorkflows(Construct):
                 compute.workflow_launcher,
                 compute.quarantine_handler,
             ],
+            removal_policy=self._removal_policy,
         )
 
         # ------------------------------------------------------------------
@@ -275,6 +283,7 @@ class NovaCatWorkflows(Construct):
                 compute.ticket_ingestor,
                 compute.quarantine_handler,
             ],
+            removal_policy=self._removal_policy,
         )
 
         # ------------------------------------------------------------------
@@ -629,6 +638,7 @@ class NovaCatWorkflows(Construct):
         asl_file: str,
         substitutions: dict[str, str],
         invokable_functions: list[lambda_.Function],
+        removal_policy: cdk.RemovalPolicy = cdk.RemovalPolicy.DESTROY,
     ) -> sfn.CfnStateMachine:
         """
         Create a Standard Workflow state machine from an ASL file.
@@ -642,6 +652,7 @@ class NovaCatWorkflows(Construct):
             asl_file:            Filename under infra/workflows/
             substitutions:       Mapping of token name → Lambda ARN (CDK token)
             invokable_functions: Lambda functions this state machine may invoke
+            removal_policy:      CDK removal policy for the log group
         """
         asl_path = os.path.join(self._workflows_dir, asl_file)
         with open(asl_path) as f:
@@ -677,6 +688,15 @@ class NovaCatWorkflows(Construct):
             )
         )
 
+        # CloudWatch log group for Express Workflow execution logging
+        log_group = logs.LogGroup(
+            self,
+            f"{_to_pascal(name)}LogGroup",
+            log_group_name=f"/aws/states/{self._env_prefix}-{name}",
+            retention=logs.RetentionDays.ONE_MONTH,
+            removal_policy=removal_policy,
+        )
+
         # CfnStateMachine (L1) rather than StateMachine (L2) because the L2
         # doesn't cleanly support loading ASL from a file with CloudFormation
         # token substitution. definition_string + definition_substitutions
@@ -694,6 +714,17 @@ class NovaCatWorkflows(Construct):
             )
             if substitutions
             else json.dumps(asl_body, separators=(",", ":")),
+            logging_configuration=sfn.CfnStateMachine.LoggingConfigurationProperty(
+                destinations=[
+                    sfn.CfnStateMachine.LogDestinationProperty(
+                        cloud_watch_logs_log_group=sfn.CfnStateMachine.CloudWatchLogsLogGroupProperty(
+                            log_group_arn=log_group.log_group_arn,
+                        ),
+                    ),
+                ],
+                include_execution_data=True,
+                level="ALL",
+            ),
         )
 
 

--- a/infra/workflows/discover_spectra_products.asl.json
+++ b/infra/workflows/discover_spectra_products.asl.json
@@ -176,7 +176,7 @@
                             "provider.$": "$.provider",
                             "nova_id.$": "$.nova_id",
                             "correlation_id.$": "$.correlation_id",
-                            "job_run_id.$": "$$.Execution.Input.job_run.job_run_id"
+                            "job_run_id.$": "$.job_run.job_run_id"
                         },
                         "ResultPath": null,
                         "TimeoutSeconds": 60,
@@ -198,7 +198,7 @@
                     },
                     "SuppressDownstreamCheck": {
                         "Type": "Choice",
-                        "Comment": "Skip downstream launch if suppress_downstream=true (smoke tests / dry-runs) or if DiscoverAndPersistProducts found zero new products to acquire.",
+                        "Comment": "Skip downstream launch only if suppress_downstream=true (smoke tests / dry-runs). Otherwise always proceed — the launcher queries DDB for eligible products and handles the empty case gracefully.",
                         "Choices": [
                             {
                                 "And": [
@@ -212,14 +212,9 @@
                                     }
                                 ],
                                 "Next": "DownstreamSuppressed"
-                            },
-                            {
-                                "Variable": "$.discover_result.total_new",
-                                "NumericGreaterThan": 0,
-                                "Next": "PublishAcquireAndValidateSpectraRequests"
                             }
                         ],
-                        "Default": "DownstreamSuppressed"
+                        "Default": "PublishAcquireAndValidateSpectraRequests"
                     },
                     "DownstreamSuppressed": {
                         "Type": "Pass",

--- a/services/artifact_generator/Dockerfile
+++ b/services/artifact_generator/Dockerfile
@@ -32,6 +32,7 @@ COPY contracts/ /app/contracts/
 COPY artifact_generator/main.py .
 COPY artifact_generator/release_publisher.py .
 COPY artifact_generator/generators/ ./generators/
+COPY artifact_generator/structured_logging.py .
 
 # Band registry — loaded once per Fargate execution (§8.2).
 # Sourced from the photometry_ingestor package where it is maintained.


### PR DESCRIPTION
## Summary
- Fixed non-deterministic CDK deploys that produced a 19-item changeset on every deploy even with no source changes
- Added synth determinism regression test
- Fixed discover_spectra_products → acquire_and_validate_spectra pipeline: existing unacquired stubs now correctly trigger acquisition
- Fixed JSONPath reference error that crashed PublishAcquireAndValidateSpectraRequests at runtime
- Enabled CloudWatch logging on all Express state machines
- Fixed missing structured_logging.py in artifact_generator Dockerfile

## Why
- Every deploy was producing a full changeset due to `AssetHashType.OUTPUT` hashing non-deterministic pip output — wasting deploy time and making it impossible to tell if real changes were present
- V906 Car had unacquired spectra stubs that could never progress: the ASL gated acquisition launch on `total_new > 0`, but re-discovery correctly identified the stubs as existing (not new), so the gate was never satisfied
- Even after fixing the gate, the launcher crashed because the ASL referenced `job_run_id` via `$$` (execution input) instead of `$` (accumulated state)
- Express Workflows don't store execution history, so debugging these issues required manually enabling logging in the console each time
- `sweep.py` failed on startup because the Dockerfile never copied `structured_logging.py` into the container

## Testing
- `pytest tests/infra/test_synth.py` — all existing tests pass, new determinism test passes
- `pytest tests/integration/test_discover_spectra_products_integration.py` — passes
- `mypy --strict` and `ruff check` pass on all modified files
- ASL validated with `python3 -m json.tool`
- Deployed to production and verified via CloudWatch logs that discover_spectra_products now reaches PublishAcquireAndValidateSpectraRequests

## Notes
- `_create_state_machine` docstring still says "Standard Workflow" but the type is intentionally EXPRESS — docstring cleanup deferred
- `regenerate_artifacts` is built outside the helper and does not get logging from this change