### PR TITLE
fix(generators): guard empty wavelength lists in spectra trimming, add reseed tool

### DIFF
--- a/services/artifact_generator/generators/spectra.py
+++ b/services/artifact_generator/generators/spectra.py
@@ -146,14 +146,43 @@ def generate_spectra_json(
                 },
             )
 
-        # Trim outlier spectra to the display range.
+        # Trim outlier spectra to the display range (red side).
         for rec in parsed:
+            if not rec["wavelengths"]:
+                continue
             if rec["wavelengths"][-1] > display_wavelength_max * _TRIM_TOLERANCE:
                 _trim_wavelength_range(rec, display_wavelength_max)
 
+        # Drop records that became empty after red-side trim.
         for rec in parsed:
+            if not rec["wavelengths"]:
+                _logger.warning(
+                    "Spectrum empty after red-side wavelength trim — dropping",
+                    extra={
+                        "nova_id": nova_id,
+                        "data_product_id": rec["product"]["data_product_id"],
+                    },
+                )
+        parsed = [rec for rec in parsed if rec["wavelengths"]]
+
+        # Trim outlier spectra to the display range (blue side).
+        for rec in parsed:
+            if not rec["wavelengths"]:
+                continue
             if rec["wavelengths"][0] < display_wavelength_min / _TRIM_TOLERANCE:
                 _trim_wavelength_range_min(rec, display_wavelength_min)
+
+        # Drop records that became empty after blue-side trim.
+        for rec in parsed:
+            if not rec["wavelengths"]:
+                _logger.warning(
+                    "Spectrum empty after blue-side wavelength trim — dropping",
+                    extra={
+                        "nova_id": nova_id,
+                        "data_product_id": rec["product"]["data_product_id"],
+                    },
+                )
+        parsed = [rec for rec in parsed if rec["wavelengths"]]
 
     # Step 2c — Second pass: LTTB downsampling + normalization.
     spectra: list[dict[str, Any]] = []

--- a/tests/services/test_generators_spectra.py
+++ b/tests/services/test_generators_spectra.py
@@ -541,3 +541,119 @@ class TestDisplayWavelengthFields:
         assert len(artifact["observations"]) == 3
         obs_ids = {o["data_product_id"] for o in artifact["observations"]}
         assert obs_ids == {"dp-a", "dp-b", "dp-c"}
+
+    def test_red_side_trim_empty_wavelengths_no_crash(self) -> None:
+        """Spectrum entirely above display max is dropped, not IndexError."""
+        # 3 normal spectra (400–900) + 1 entirely above the median max (~900).
+        csvs = {
+            "dp-1": self._make_csv(400, 900),
+            "dp-2": self._make_csv(400, 910),
+            "dp-3": self._make_csv(400, 920),
+            "dp-bad": self._make_csv(5000, 6000),
+        }
+        products = [
+            self._make_product("dp-1", mjd="59000"),
+            self._make_product("dp-2", mjd="59001"),
+            self._make_product("dp-3", mjd="59002"),
+            self._make_product("dp-bad", mjd="59003"),
+        ]
+
+        class FakeBody:
+            def __init__(self, content: str) -> None:
+                self._content = content
+
+            def read(self) -> bytes:
+                return self._content.encode()
+
+        class FakeS3:
+            def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:  # noqa: N803
+                dp_id = Key.split("/")[-2]
+                return {"Body": FakeBody(csvs[dp_id])}
+
+        class FakeTable:
+            def query(self, **kwargs: Any) -> dict[str, Any]:
+                return {"Items": products}
+
+        ctx: dict[str, Any] = {"outburst_mjd": 58000.0, "outburst_mjd_is_estimated": False}
+        artifact = generate_spectra_json("nova-test", FakeTable(), FakeS3(), "bucket", ctx)
+
+        # dp-bad should be excluded — its entire range is above display max.
+        spectrum_ids = [s["spectrum_id"] for s in artifact["spectra"]]
+        assert "dp-bad" not in spectrum_ids
+
+    def test_blue_side_trim_empty_wavelengths_no_crash(self) -> None:
+        """Spectrum entirely below display min is dropped, not IndexError."""
+        # 3 normal spectra (400–900) + 1 entirely below the median min (~400).
+        csvs = {
+            "dp-1": self._make_csv(400, 900),
+            "dp-2": self._make_csv(410, 900),
+            "dp-3": self._make_csv(390, 900),
+            "dp-bad": self._make_csv(100, 200),
+        }
+        products = [
+            self._make_product("dp-1", mjd="59000"),
+            self._make_product("dp-2", mjd="59001"),
+            self._make_product("dp-3", mjd="59002"),
+            self._make_product("dp-bad", mjd="59003"),
+        ]
+
+        class FakeBody:
+            def __init__(self, content: str) -> None:
+                self._content = content
+
+            def read(self) -> bytes:
+                return self._content.encode()
+
+        class FakeS3:
+            def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:  # noqa: N803
+                dp_id = Key.split("/")[-2]
+                return {"Body": FakeBody(csvs[dp_id])}
+
+        class FakeTable:
+            def query(self, **kwargs: Any) -> dict[str, Any]:
+                return {"Items": products}
+
+        ctx: dict[str, Any] = {"outburst_mjd": 58000.0, "outburst_mjd_is_estimated": False}
+        artifact = generate_spectra_json("nova-test", FakeTable(), FakeS3(), "bucket", ctx)
+
+        # dp-bad should be excluded — its entire range is below display min.
+        spectrum_ids = [s["spectrum_id"] for s in artifact["spectra"]]
+        assert "dp-bad" not in spectrum_ids
+
+    def test_single_bad_spectrum_does_not_block_others(self) -> None:
+        """One fully-trimmed spectrum doesn't prevent other spectra from appearing."""
+        csvs = {
+            "dp-good-1": self._make_csv(400, 900),
+            "dp-good-2": self._make_csv(410, 920),
+            "dp-bad": self._make_csv(5000, 6000),
+        }
+        products = [
+            self._make_product("dp-good-1", mjd="59000"),
+            self._make_product("dp-good-2", mjd="59001"),
+            self._make_product("dp-bad", mjd="59002"),
+        ]
+
+        class FakeBody:
+            def __init__(self, content: str) -> None:
+                self._content = content
+
+            def read(self) -> bytes:
+                return self._content.encode()
+
+        class FakeS3:
+            def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:  # noqa: N803
+                dp_id = Key.split("/")[-2]
+                return {"Body": FakeBody(csvs[dp_id])}
+
+        class FakeTable:
+            def query(self, **kwargs: Any) -> dict[str, Any]:
+                return {"Items": products}
+
+        ctx: dict[str, Any] = {"outburst_mjd": 58000.0, "outburst_mjd_is_estimated": False}
+        artifact = generate_spectra_json("nova-test", FakeTable(), FakeS3(), "bucket", ctx)
+
+        spectrum_ids = {s["spectrum_id"] for s in artifact["spectra"]}
+        assert "dp-good-1" in spectrum_ids
+        assert "dp-good-2" in spectrum_ids
+        assert "dp-bad" not in spectrum_ids
+        assert len(artifact["spectra"]) == 2

--- a/tools/reseed_work_items.py
+++ b/tools/reseed_work_items.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""reseed_work_items.py — Reseed WorkItems for a nova.
+
+Writes WorkItem(s) to the WORKQUEUE partition so that the next
+artifact regeneration sweep picks up the nova and regenerates its
+artifacts.
+
+Usage:
+    # Reseed spectra WorkItem for V906 Car (by nova_id)
+    python reseed_work_items.py --nova-id 64c5c516-d0fb-4cb8-ab99-e4b87c978474 --dirty spectra
+
+    # Reseed both spectra and photometry
+    python reseed_work_items.py --nova-id 64c5c516-d0fb-4cb8-ab99-e4b87c978474 --dirty spectra photometry
+
+    # Reseed all dirty types
+    python reseed_work_items.py --nova-id 64c5c516-d0fb-4cb8-ab99-e4b87c978474 --dirty all
+
+    # Resolve by name instead of nova_id
+    python reseed_work_items.py --name "V906 Car" --dirty spectra
+
+    # Dry run — show what would be written
+    python reseed_work_items.py --name "V906 Car" --dirty all --dry-run
+
+    # Use a specific table (default: reads NOVACAT_TABLE_NAME from env)
+    python reseed_work_items.py --nova-id abc123 --dirty spectra --table NovaCat
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import uuid
+from datetime import UTC, datetime
+
+import boto3
+from boto3.dynamodb.conditions import Key
+
+_WORKQUEUE_PK = "WORKQUEUE"
+_TTL_DAYS = 30
+_ALL_DIRTY_TYPES = ["spectra", "photometry", "references"]
+
+
+def _resolve_name(table_resource, name: str) -> str | None:
+    """Resolve a nova name to a nova_id via NameMapping."""
+    normalized = name.strip().lower().replace("_", " ")
+    pk = f"NAME#{normalized}"
+    resp = table_resource.query(
+        KeyConditionExpression=Key("PK").eq(pk),
+        Limit=1,
+    )
+    items = resp.get("Items", [])
+    if not items:
+        return None
+    return items[0].get("nova_id")
+
+
+def _write_work_item(
+    table_resource,
+    nova_id: str,
+    dirty_type: str,
+    dry_run: bool = False,
+) -> dict:
+    now = datetime.now(UTC)
+    created_at = now.isoformat(timespec="seconds").replace("+00:00", "Z")
+    sk = f"{nova_id}#{dirty_type}#{created_at}"
+    ttl = int(now.timestamp()) + (_TTL_DAYS * 86_400)
+    correlation_id = f"manual-reseed-{uuid.uuid4().hex[:12]}"
+
+    item = {
+        "PK": _WORKQUEUE_PK,
+        "SK": sk,
+        "entity_type": "WorkItem",
+        "schema_version": "1.0.0",
+        "nova_id": nova_id,
+        "dirty_type": dirty_type,
+        "source_workflow": "manual_reseed",
+        "job_run_id": "00000000-0000-0000-0000-000000000000",
+        "correlation_id": correlation_id,
+        "created_at": created_at,
+        "ttl": ttl,
+    }
+
+    if dry_run:
+        print(f"  [DRY RUN] Would write: PK={_WORKQUEUE_PK}  SK={sk}")
+    else:
+        table_resource.put_item(Item=item)
+        print(f"  Written: PK={_WORKQUEUE_PK}  SK={sk}")
+
+    return item
+
+
+def main() -> None:
+    import os
+
+    parser = argparse.ArgumentParser(
+        description="Reseed WorkItems for a nova so the regeneration sweep picks it up.",
+    )
+    id_group = parser.add_mutually_exclusive_group(required=True)
+    id_group.add_argument("--nova-id", help="Nova UUID")
+    id_group.add_argument("--name", help="Nova name (resolved via NameMapping)")
+
+    parser.add_argument(
+        "--dirty",
+        nargs="+",
+        required=True,
+        choices=_ALL_DIRTY_TYPES + ["all"],
+        help="Dirty type(s) to seed. Use 'all' for spectra + photometry + references.",
+    )
+    parser.add_argument(
+        "--table",
+        default=os.environ.get("NOVACAT_TABLE_NAME", "NovaCat"),
+        help="DynamoDB table name (default: $NOVACAT_TABLE_NAME or 'NovaCat')",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be written")
+
+    args = parser.parse_args()
+
+    dynamodb = boto3.resource("dynamodb")
+    table = dynamodb.Table(args.table)
+
+    # Resolve nova_id
+    if args.name:
+        nova_id = _resolve_name(table, args.name)
+        if not nova_id:
+            print(f"ERROR: Could not resolve name '{args.name}' to a nova_id.", file=sys.stderr)
+            sys.exit(1)
+        print(f"Resolved '{args.name}' → {nova_id}")
+    else:
+        nova_id = args.nova_id
+
+    # Expand dirty types
+    dirty_types = _ALL_DIRTY_TYPES if "all" in args.dirty else args.dirty
+
+    print(f"Nova:        {nova_id}")
+    print(f"Table:       {args.table}")
+    print(f"Dirty types: {', '.join(dirty_types)}")
+    if args.dry_run:
+        print("Mode:        DRY RUN")
+    print()
+
+    for dt in dirty_types:
+        _write_work_item(table, nova_id, dt, dry_run=args.dry_run)
+
+    print()
+    print("Done. Run sweep.py to trigger regeneration.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Fixed IndexError crash in `generate_spectra_json` when display range trimming produces empty wavelength lists
- Added empty-list guards and post-trim filtering with warning logs for dropped spectra
- Added regression tests covering red-side, blue-side, and mixed trim scenarios
- Added `tools/reseed_work_items.py` operator tool for manually seeding WorkItems

## Why
- V906 Car has 402 valid spectra but produced no `spectra.json` — a single spectrum whose wavelength range fell entirely outside the display bounds caused an `IndexError` on `rec["wavelengths"][0]`, which killed the entire generator
- The generator's success path deletes WorkItems before checking whether all artifacts actually succeeded, so after the crash there was no way to re-trigger regeneration without manually writing WorkItems
- The reseed tool generalizes this recovery pattern for any nova and any dirty type (spectra, photometry, references)

## Testing
- `pytest tests/services/test_generators_spectra.py -v` — all existing and new tests pass
- `mypy --strict` and `ruff check` pass on all modified and new files
- Reseed tool tested manually against production table for V906 Car

## Notes
- The reseed tool is operator tooling — no mypy strict or CI enforcement
- The underlying issue of WorkItems being deleted before confirming all generators succeeded is a broader design concern tracked in the bugs list but not addressed here