### PR TITLE
docs(frontend, repo): populate public-facing profile pages and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
 # Nova Cat — The Open Nova Catalog
 
-Nova Cat is a serverless platform for aggregating, validating, and publishing classical
-nova observational data. It serves professional astronomers with a curated, open-access
-catalog of spectra and photometry — discoverable through an interactive web interface
-and downloadable as research-grade data bundles.
+Nova Cat is a serverless data platform for aggregating, validating, and publishing
+classical nova observational data. It serves professional astronomers with a curated,
+open-access catalog of spectra and photometry — discoverable through an interactive web
+interface and downloadable as research-grade data bundles.
 
-The system ingests data from public astronomical archives (ESO, CfA, AAVSO, and others),
-resolves nova identity across archives, normalizes observations against IVOA standards,
-and publishes them through a static artifact architecture that separates data generation
-from presentation. The project draws inspiration from the Open Supernova Catalog
-(Guillochon et al. 2017, ApJ 835:64).
+The system ingests data from public astronomical archives
+([ESO](https://archive.eso.org/scienceportal/home), CfA,
+[VizieR](https://vizier.cds.unistra.fr/viz-bin/VizieR), and others), resolves object
+identity across archives, normalizes observations against
+[IVOA](https://www.ivoa.net/documents/) (International Virtual Observatory Alliance) standards,
+generates seven artifact types per object through a Fargate-based regeneration pipeline,
+and publishes them through an immutable release model that separates data generation from
+presentation. The project draws inspiration from the Open Supernova Catalog (Guillochon
+et al. 2017, ApJ 835:64).
 
 **This is a solo project** — architecture, infrastructure, backend services, data
-modeling, frontend, and documentation are all the work of a single developer with domain
-expertise in nova astronomy.
+modeling, artifact generation, frontend, and documentation are all the work of a single
+developer. 313 commits and counting.
 
 **Live site:** [Nova-Cat](https://aws-nova-cat.vercel.app/)
 
@@ -22,24 +26,32 @@ expertise in nova astronomy.
 ## What This Project Demonstrates
 
 - **End-to-end system design:** From ingestion pipeline through persistence layer through
-  published data products through interactive frontend — a complete data platform, not
-  just a service or a UI
+  artifact generation through CDN delivery through interactive frontend — a complete data
+  platform, not just a service or a UI
 - **Contract-first architecture:** Pydantic models define every inter-service boundary.
   JSON Schemas are auto-generated from contracts. Services are developed and tested
   against typed interfaces, not ad hoc payloads
 - **Infrastructure as code:** Full AWS CDK deployment (Python) with two isolated stacks
-  (production and smoke test), 15 Lambda functions, 6 Step Functions workflows, and
-  single-table-plus-dedicated-photometry DynamoDB design
-- **Domain-driven data modeling:** Multi-regime photometry (optical through radio),
-  IVOA-aligned spectral normalization, deterministic identity resolution with coordinate
-  deduplication, and a seven-layer ingestion pipeline designed to handle real-world data
-  heterogeneity
-- **Documentation discipline:** 21 architectural decision records, pre-ADR design
+  (production and smoke test), 17 Lambda functions, 7 Step Functions workflows, a Fargate
+  task for artifact generation, CloudFront distribution, EventBridge scheduling, and
+  single-table-plus-dedicated-secondary DynamoDB design
+- **Multi-stage data pipeline:** Ingest → validate → persist → detect changes → plan
+  regeneration → generate artifacts → publish immutable release → serve via CDN. Each
+  stage has its own failure model, retry semantics, and observability
+- **Domain-driven data modeling:** Multi-regime data (optical through radio), IVOA-aligned
+  normalization, deterministic identity resolution with coordinate deduplication, SHA-256
+  content fingerprinting, and profile-driven validation with explicit quarantine semantics
+- **Artifact generation engine:** A Fargate-based pipeline transforms internal database
+  state into seven published artifact types per object — metadata JSON, reference lists,
+  plot-ready spectra, multi-regime photometry with computed band offsets, SVG sparklines,
+  and research-grade data bundles with consolidated FITS tables
+- **Documentation discipline:** 30+ architectural decision records, 4 pre-ADR design
   documents, per-workflow operational docs, and formal schema specifications — written
   before implementation, not after
 - **Scientific visualization:** Interactive Plotly.js components for spectra (waterfall
   plots with epoch controls and spectral feature markers) and photometry (multi-regime
-  tabbed light curves with band toggles)
+  tabbed light curves with per-band offsets, density-preserving subsampling, and upper
+  limit handling)
 - **Rigorous quality gates:** mypy strict, ruff, CI with path-based filtering, end-to-end
   smoke tests against live AWS infrastructure
 
@@ -47,66 +59,89 @@ expertise in nova astronomy.
 
 ## Architecture Overview
 
-Nova Cat runs on AWS serverless infrastructure, optimized for low operational cost. The
-expected dataset is modest (<250 GB, <1000 novae) and the system is designed for single-
-operator maintenance.
+Nova Cat runs on AWS serverless infrastructure with a Fargate-based artifact generation
+layer, optimized for low operational cost. The expected dataset is modest (<250 GB,
+<1000 objects) and the system is designed for single-operator maintenance.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
 │                    Public Archives                            │
-│              (ESO, CfA, AAVSO, ADS, SIMBAD)                  │
+│              (ESO, CfA, VizieR, ADS, SIMBAD)                 │
 └──────────────────────┬───────────────────────────────────────┘
                        │
                        ▼
 ┌──────────────────────────────────────────────────────────────┐
 │              Ingestion Pipeline (Step Functions)              │
 │                                                              │
-│  ingest_new_nova → initialize_nova → discover_spectra →      │
-│  acquire_and_validate_spectra → refresh_references           │
+│  Archive-driven: ingest_new_nova → initialize_nova →         │
+│  discover_spectra → acquire_and_validate → refresh_refs      │
 │                                                              │
-│  15 Lambda services · FITS profile validation · quarantine   │
-│  semantics · deterministic identity resolution               │
+│  Ticket-driven: ingest_ticket → resolve_nova →               │
+│  branch (photometry | spectra) → finalize                    │
+│                                                              │
+│  17 Lambda functions · profile-driven FITS validation ·      │
+│  SHA-256 fingerprinting · quarantine semantics ·             │
+│  deterministic identity resolution                           │
+└──────────────────────┬───────────────────────────────────────┘
+                       │  WorkItem queue (DynamoDB)
+                       ▼
+┌──────────────────────────────────────────────────────────────┐
+│        Artifact Regeneration (EventBridge + Fargate)          │
+│                                                              │
+│  Coordinator Lambda → RegenBatchPlan → Fargate task          │
+│  (2 vCPU / 8 GB) → Finalize Lambda                          │
+│                                                              │
+│  Per-object: references.json · spectra.json ·                │
+│  photometry.json · sparkline.svg · nova.json · bundle.zip    │
+│  Global: catalog.json                                        │
+│                                                              │
+│  Immutable release model · atomic pointer switchover         │
 └──────────────────────┬───────────────────────────────────────┘
                        │
                        ▼
 ┌──────────────────────────────────────────────────────────────┐
 │                  Persistence Layer                            │
 │                                                              │
-│  DynamoDB (single-table, namespaced PK) + S3 (FITS files,   │
-│  derived artifacts, quarantine zone)                         │
+│  DynamoDB (single-table + dedicated photometry table) +      │
+│  S3 (raw data, derived artifacts, quarantine zone,           │
+│  published releases)                                         │
 └──────────────────────┬───────────────────────────────────────┘
                        │
                        ▼
 ┌──────────────────────────────────────────────────────────────┐
-│              Published Artifacts (S3 + CloudFront)            │
+│              Delivery (S3 + CloudFront + Vercel)              │
 │                                                              │
-│  catalog.json · nova.json · spectra.json · photometry.json   │
-│  sparkline.svg · bundle.zip                                  │
+│  Published artifacts: S3 → CloudFront (OAC)                  │
+│  App shell: Next.js → Vercel                                 │
 │                                                              │
-│  Pre-computed, frontend-ready · schema-versioned             │
+│  Pre-computed, frontend-ready · schema-versioned ·           │
+│  zero backend API calls at runtime                           │
 └──────────────────────┬───────────────────────────────────────┘
                        │
                        ▼
 ┌──────────────────────────────────────────────────────────────┐
 │                     Frontend (Next.js)                        │
 │                                                              │
-│  Catalog table · Nova detail pages · Spectra waterfall       │
-│  viewer · Multi-regime light curve panel · Client-side       │
-│  search · Semantic design token system                       │
+│  Catalog table · Detail pages · Spectra waterfall viewer ·   │
+│  Multi-regime light curve panel · Client-side search ·       │
+│  Semantic design token system · SVG sparklines               │
 └──────────────────────────────────────────────────────────────┘
 ```
 
 ### Key Architectural Decisions
 
 - **UUID-first identity** — Names are resolved once during ingestion; all downstream
-  operations use stable UUIDs. Coordinate-based deduplication prevents duplicate novae
+  operations use stable UUIDs. Coordinate-based deduplication prevents duplicate objects
   across archives (<2" = alias, 2–10" = quarantine, >10" = new object)
 - **Atomic data products** — Each spectrum is an independent unit with its own
-  acquisition status, validation state, fingerprint, and provenance. No dataset-level
-  abstractions
+  acquisition status, validation state, SHA-256 fingerprint, and provenance. No
+  dataset-level abstractions
 - **Profile-driven validation** — FITS files are validated against per-instrument
   profiles that define expected wavelength ranges, flux units, and header keywords.
   Non-conforming data is quarantined, not silently accepted
+- **Immutable release model** — Artifact generation produces a complete release to a
+  new S3 prefix. An atomic pointer update (`current.json`) makes it visible. Rollback
+  is a single JSON write. Users never see a partially updated catalog
 - **Published artifact architecture** — The frontend consumes pre-built static JSON
   artifacts. All scientific computation (normalization, subsampling, offset calculation)
   happens at artifact generation time. The website runs with zero backend API calls
@@ -120,41 +155,55 @@ operator maintenance.
 
 ### Spectra Ingestion Pipeline
 
-**Status: Operational — validated through end-to-end smoke tests against real novae.**
+**Status: Operational — validated through end-to-end smoke tests against real data.**
 
-The pipeline discovers spectra from provider archives, acquires and fingerprints the raw
-FITS files, validates them against instrument-specific profiles, normalizes to an
-IVOA-aligned canonical representation, and persists validated products with full
-provenance.
+Discovers spectra from provider archives, acquires and fingerprints the raw
+**FITS** (Flexible Image Transport System — the standard binary file format for
+astronomical data) files, validates them against instrument-specific profiles,
+normalizes to an IVOA-aligned canonical representation, and persists validated
+products with full provenance.
 
 Services: `nova_resolver` (identity resolution), `archive_resolver` (SIMBAD/TNS
 queries), `spectra_discoverer` (provider adapter dispatch), `spectra_acquirer`
 (download, fingerprint, ZIP unpack), `spectra_validator` (FITS profile validation and
-normalization), `reference_manager` (ADS bibcode integration, discovery date
+normalization), `reference_manager` ([ADS](https://ui.adsabs.harvard.edu/) bibcode integration, discovery date
 computation), `quarantine_handler` (conflict isolation), `workflow_launcher`
 (cross-workflow orchestration).
 
-### Photometry Ingestion Pipeline
+### Ticket-Driven Ingestion Pipeline
 
-**Status: In design — foundational ADRs complete, implementation paused pending
-design chain completion.**
+**Status: Operational — spectra and photometry ingestion via hand-curated metadata
+tickets.**
 
-The photometry system handles multi-regime data (optical magnitudes, X-ray count rates,
-gamma-ray photon fluxes, radio flux densities) through a seven-layer architecture: source
-file unpacking, pre-ingestion normalization (wide-to-long pivot, multi-nova splitting,
-sidecar context loading), a versioned band registry seeded from the SVO Filter Profile
-Service, a disambiguation algorithm for ambiguous filter strings, a revised photometry
-table model with provenance fields, column mapping via a tiered adapter architecture
-(canonical CSV → synonym → UCD → AI-assisted), and row-level DynamoDB persistence.
+The MVP primary ingestion path. A ticket is a plain-text file that fully describes one
+data file's structure (column indices, filter names, wavelength units). The pipeline
+parses the ticket, resolves object identity, and branches into photometry or spectra
+ingestion. Photometry rows are resolved against a versioned band registry seeded from the
+SVO Filter Profile Service. Spectra are converted to FITS with reconstructed headers and
+uploaded to S3.
 
-Design artifacts: `DESIGN-001` (full pipeline redesign), `DESIGN-002` (data provenance
-and derived quantities), ADR-015 through ADR-021.
+### Artifact Regeneration Pipeline
+
+**Status: Operational — Fargate-based, cron-triggered, immutable release publication.**
+
+Connects the backend persistence layer to the frontend presentation layer. Ingestion
+workflows write WorkItems to a DynamoDB queue. An EventBridge-triggered Coordinator
+Lambda builds a regeneration plan and launches a Fargate task that generates up to seven
+artifacts per object in dependency order. A four-phase publication sequence writes
+artifacts to a new S3 release prefix, copies unchanged objects from the previous release,
+generates a global catalog artifact, and performs an atomic pointer switchover.
+
+Key engineering: dependency-matrix-driven regeneration planning, sequential Fargate
+processing with per-object failure isolation, kd-tree-based photometry band offset
+computation with union-find clustering and DynamoDB caching, **LTTB**
+(Largest-Triangle-Three-Buckets) and density-preserving log subsampling, peak-flux normalization, multi-arm spectra merging, streaming ZIP
+assembly with consolidated FITS tables.
 
 ### Frontend
 
 **Status: Feature-complete MVP — all pages and visualization components implemented.**
 
-A React/Next.js application providing catalog browsing, per-nova detail pages, and
+A React/Next.js application providing catalog browsing, per-object detail pages, and
 interactive scientific visualizations. The design system uses a two-layer semantic CSS
 token architecture (primitive → semantic) that supports dark mode without component
 changes.
@@ -162,11 +211,13 @@ changes.
 Key components:
 - **Catalog table** — TanStack Table with sorting, pagination, and client-side
   name/alias search
-- **Spectra viewer** — Plotly.js waterfall plot with epoch format toggles (DPO/MJD/
-  Calendar Date), log/linear temporal scale, single-spectrum isolation mode, and
-  spectral feature marker overlays (Fe II / He-N / Nebular emission lines)
+- **Spectra viewer** — Plotly.js waterfall plot with epoch format toggles
+  (**DPO** — days post-outburst / **MJD** — Modified Julian Date / Calendar Date),
+  log/linear temporal scale, single-spectrum isolation mode, and spectral feature
+  marker overlays
 - **Light curve panel** — Tabbed Plotly.js scatter plot (one tab per wavelength regime),
   multi-band color scheme with toggleable legend, upper limit markers, error bar toggle
+- **Data client** — Release-aware artifact fetcher with dev-mode local fixture fallback
 
 Technology: React, Next.js, TypeScript, Plotly.js, TanStack Table, Tailwind CSS v4,
 DM Sans + DM Mono typography, Lucide icons.
@@ -178,9 +229,9 @@ DM Sans + DM Mono typography, Lucide icons.
 ```
 contracts/          Pydantic models, event schemas, JSON Schema exports
 docs/
-  adr/              21 architectural decision records (ADR-001 through ADR-021)
+  adr/              30+ architectural decision records
   architecture/     Architectural baselines and system diagrams
-  design/           Pre-ADR scoping documents
+  design/           Pre-ADR scoping documents (4 design docs)
   specs/            Schema specifications (photometry table, FITS profiles)
   storage/          DynamoDB item model, access patterns, S3 layout
   workflows/        Per-workflow operational documentation
@@ -189,8 +240,9 @@ frontend/           React/Next.js web application
   src/styles/       Semantic design tokens
 infra/              AWS CDK infrastructure (Python)
   nova_constructs/  CDK constructs (compute, storage, workflows)
-  workflows/        Step Functions ASL definitions
-services/           15 Lambda services (4 Docker-based for astropy/numpy)
+  workflows/        Step Functions ASL definitions (7 workflows)
+services/           17 Lambda services + 1 Fargate service
+  artifact_generator/  Fargate-based artifact generation (6 generators + shared utils)
 tests/
   services/         Unit tests
   integration/      Workflow integration tests
@@ -204,11 +256,15 @@ tools/              Operator tooling and research scripts
 
 - **CDK (Python):** Two-stack deployment — `NovaCat` (production) and `NovaCatSmoke`
   (isolated smoke test)
-- **Lambda:** 15 functions; 4 Docker-based (astropy/numpy compiled dependencies)
-- **Step Functions:** 6 workflows orchestrating the ingestion pipeline
-- **DynamoDB:** Main table (single-table design with namespaced partition keys and one GSI) plus dedicated photometry table
+- **Lambda:** 17 functions (13 zip-bundled, 4 container-based for compiled dependencies)
+- **Step Functions:** 7 workflows (6 Express, 1 Standard for Fargate orchestration)
+- **Fargate:** 1 task definition (artifact generator, 2 vCPU / 8 GB), 1 ECS cluster
+- **DynamoDB:** Main table (single-table design with namespaced partition keys and one
+  GSI) plus dedicated photometry table
 - **S3:** Private bucket (raw data, derived artifacts, quarantine) and public site
-  bucket (published frontend artifacts)
+  bucket (published releases with 7-day lifecycle)
+- **CloudFront:** 1 distribution (OAC, public site bucket origin)
+- **EventBridge:** 1 scheduled rule (6-hour artifact regeneration cron)
 - **SNS:** Quarantine notification topic
 
 ---
@@ -257,6 +313,12 @@ covers:
   architecture, visual design system, visualization design, artifact schemas)
 - **ADR-015 – ADR-021:** Photometry pipeline design (column mapping, band/filter
   resolution, band registry, storage format, pre-ingestion normalization)
+- **ADR-030 – ADR-032:** Governance, data layer readiness, artifact generation
+  algorithms
+
+Design documents: `DESIGN-001` (photometry ingestion redesign), `DESIGN-002` (data
+provenance), `DESIGN-003` (artifact regeneration pipeline), `DESIGN-004` (ticket-driven
+ingestion).
 
 ---
 
@@ -264,16 +326,17 @@ covers:
 
 | Component | Status |
 |-----------|--------|
-| Spectra ingestion pipeline | Operational (smoke-tested against real novae) |
+| Spectra ingestion pipeline | Operational (smoke-tested against real data) |
+| Ticket-driven ingestion | Operational (spectra and photometry) |
 | Reference management | Operational |
 | Identity resolution | Operational |
-| Photometry pipeline design | ADR-017 → ADR-018 → ADR-019 design chain in progress |
-| Frontend MVP | Feature-complete (spectra viewer, light curve panel, catalog) |
-| Artifact generation pipeline | Not yet built (connects backend to frontend) |
-| Hosting / deployment | Vercel (app) + S3/CloudFront (data) — not yet formalized |
+| Artifact regeneration pipeline | Operational (Fargate, immutable releases, CloudFront delivery) |
+| Frontend MVP | Feature-complete (catalog, detail pages, spectra viewer, light curve panel) |
+| Hosting / deployment | Vercel (app) + S3/CloudFront (data artifacts) |
+| Heuristic photometry pipeline | In design (ADR-015 → ADR-021, 7-layer architecture) |
 
 ---
 
 ## License
 
-TBD
+MIT

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -1,7 +1,287 @@
+/**
+ * About page — /about
+ *
+ * Dual-audience page: astronomers learn what the catalog offers and how
+ * to cite it; engineers and recruiters see the depth of the system design.
+ * One narrative serves both — the same facts read differently depending
+ * on who you are.
+ *
+ * Server Component. No client-side interactivity required.
+ */
+
+import Link from 'next/link';
+
+export const metadata = {
+  title: 'About — Open Nova Catalog',
+  description:
+    'What the Open Nova Catalog is, how it works, and what building it required.',
+};
+
+// ── Section wrapper ──────────────────────────────────────────────────────────
+
+function Section({
+  heading,
+  children,
+}: {
+  heading: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <h2 className="text-xl font-semibold text-text-primary mb-4">
+        {heading}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
+
 export default function AboutPage() {
   return (
-    <div className="py-12">
-      <h1 className="text-2xl font-semibold text-text-primary">About</h1>
+    <div className="py-12 flex flex-col gap-12 max-w-3xl">
+
+      {/* ── Header ─────────────────────────────────────────────────── */}
+      <div>
+        <h1 className="text-2xl font-semibold text-text-primary mb-4">
+          About
+        </h1>
+        <p className="text-base leading-relaxed text-text-secondary">
+          The Open Nova Catalog is a curated, publicly accessible repository of
+          observational data for classical novae. It aggregates spectroscopic and
+          photometric records from public astronomical archives and published
+          literature, structures them against international standards, and
+          delivers them through an interactive web interface and downloadable
+          research-grade data bundles. The project draws inspiration from the
+          Open Supernova Catalog (Guillochon et al. 2017, ApJ 835:64).
+        </p>
+      </div>
+
+      {/* ── Why it exists ──────────────────────────────────────────── */}
+      <Section heading="Why it exists">
+        <div className="flex flex-col gap-3 text-base leading-relaxed text-text-secondary">
+          <p>
+            Nova observational data is scattered across dozens of archives, each
+            with its own formats, naming conventions, and access patterns.
+            Assembling a multi-wavelength picture of a single nova — spectra from
+            ESO, photometry from VizieR, references from ADS — requires manual
+            work that most researchers repeat independently.
+          </p>
+          <p>
+            The Open Nova Catalog consolidates this work once. It resolves nova
+            identity across archives, normalizes observations against{' '}
+            <a
+              href="https://www.ivoa.net/documents/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-interactive no-underline hover:underline"
+            >
+              IVOA
+            </a>
+            {' '}(International Virtual Observatory Alliance)
+            standards, validates data quality, and publishes curated datasets
+            that are immediately usable for research. The goal is to make the
+            observational record of every known classical nova discoverable,
+            inspectable, and downloadable from a single location.
+          </p>
+        </div>
+      </Section>
+
+      {/* ── What you can do ────────────────────────────────────────── */}
+      <Section heading="What you can do here">
+        <div className="flex flex-col gap-3 text-base leading-relaxed text-text-secondary">
+          <p>
+            <span className="text-text-primary font-medium">Browse the catalog</span>{' '}
+            — a sortable, searchable table of all novae with observational
+            coverage at a glance. Each entry links to a dedicated nova page.
+          </p>
+          <p>
+            <span className="text-text-primary font-medium">Inspect observations visually</span>{' '}
+            — interactive spectra waterfall plots with epoch controls, spectral
+            feature markers (Fe II, He/N, nebular), and single-spectrum isolation
+            mode. Multi-regime light curves with per-band toggles, error bars,
+            and upper limit markers.
+          </p>
+          <p>
+            <span className="text-text-primary font-medium">Download data bundles</span>{' '}
+            — per-nova ZIP archives containing IVOA-compliant FITS spectra, a
+            consolidated photometry table, provenance records, and BibTeX
+            references. Ready for direct use in analysis pipelines.
+          </p>
+          <p>
+            For details on data formats and the decisions behind them, see
+            the{' '}
+            <Link
+              href="/docs"
+              className="text-interactive no-underline hover:underline"
+            >
+              Documentation
+            </Link>
+            .
+          </p>
+        </div>
+      </Section>
+
+      {/* ── How it's built ─────────────────────────────────────────── */}
+      <Section heading="How it&apos;s built">
+        <div className="flex flex-col gap-3 text-base leading-relaxed text-text-secondary">
+          <p>
+            The catalog is a complete data platform — not just a website or a
+            service, but an end-to-end system spanning data ingestion,
+            persistence, artifact generation, and interactive frontend delivery.
+            Architecture, infrastructure, backend services, data modeling,
+            frontend, and documentation are all the work of a single developer
+            with domain expertise in nova astronomy.
+          </p>
+          <p>
+            <span className="text-text-primary font-medium">Ingestion pipeline.</span>{' '}
+            Seven Step Functions workflows orchestrate 17 Lambda functions (13
+            zip-bundled, 4 container-based) to discover spectra from provider
+            archives, acquire and fingerprint raw FITS files, validate them
+            against instrument-specific profiles, resolve nova identity via
+            coordinate-based deduplication, and persist normalized products with
+            full provenance. A parallel ticket-driven path ingests photometry and
+            spectra from hand-curated metadata files that completely describe
+            each data file&apos;s structure.
+          </p>
+          <p>
+            <span className="text-text-primary font-medium">Artifact regeneration.</span>{' '}
+            A Fargate task (2 vCPU / 8 GB) transforms internal DynamoDB and S3
+            state into seven published artifact types per nova — metadata JSON,
+            references, plot-ready spectra and photometry, SVG sparklines, and
+            research-grade data bundles. Artifacts are published through an
+            immutable release model: all artifacts for a release are written to
+            S3 before an atomic pointer update makes them visible. Rollback is a
+            single JSON write.
+          </p>
+          <p>
+            <span className="text-text-primary font-medium">Contract-first architecture.</span>{' '}
+            Pydantic models define every inter-service boundary. JSON Schemas are
+            auto-generated from contracts. Services are developed and tested
+            against typed interfaces, not ad hoc payloads. Strict mypy checking
+            enforces type safety across all service code.
+          </p>
+          <p>
+            <span className="text-text-primary font-medium">Frontend.</span>{' '}
+            A React/Next.js application consuming pre-built static JSON
+            artifacts with zero runtime backend calls. Interactive Plotly.js
+            visualizations for spectra (waterfall plots) and photometry
+            (multi-regime tabbed light curves). A two-layer CSS design token
+            system enabling dark mode without touching component code.
+          </p>
+          <p>
+            <span className="text-text-primary font-medium">Documentation discipline.</span>{' '}
+            Over 30 architectural decision records, 4 pre-ADR design documents,
+            per-workflow operational docs, and formal schema specifications —
+            written before implementation, not after. The ADR corpus governs
+            everything from coordinate deduplication thresholds to photometry
+            visualization algorithms.
+          </p>
+        </div>
+      </Section>
+
+      {/* ── By the numbers ─────────────────────────────────────────── */}
+      <Section heading="By the numbers">
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+          {[
+            { value: '313', label: 'Commits' },
+            { value: '17', label: 'Lambda functions' },
+            { value: '7', label: 'Step Functions workflows' },
+            { value: '30+', label: 'Architecture decision records' },
+            { value: '2', label: 'DynamoDB tables' },
+            { value: '1', label: 'Fargate task definition' },
+          ].map(({ value, label }) => (
+            <div
+              key={label}
+              className="bg-surface-secondary border border-border-subtle rounded-lg p-4"
+            >
+              <div className="text-2xl font-semibold text-text-primary">
+                {value}
+              </div>
+              <div className="text-sm text-text-secondary mt-1">{label}</div>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      {/* ── Data sources ───────────────────────────────────────────── */}
+      <Section heading="Data sources">
+        <p className="text-base leading-relaxed text-text-secondary">
+          The catalog currently draws from the{' '}
+          <a
+            href="https://archive.eso.org/scienceportal/home"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-interactive no-underline hover:underline"
+          >
+            European Southern Observatory (ESO) Science Archive
+          </a>
+          , the Center for Astrophysics | Harvard &
+          Smithsonian (CfA) spectral archive,{' '}
+          <a
+            href="https://vizier.cds.unistra.fr/viz-bin/VizieR"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-interactive no-underline hover:underline"
+          >
+            VizieR
+          </a>
+          ,{' '}
+          <a
+            href="https://ui.adsabs.harvard.edu/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-interactive no-underline hover:underline"
+          >
+            NASA&apos;s Astrophysics Data System (ADS)
+          </a>
+          {' '}for literature references, and SIMBAD/TNS for identity
+          resolution. Additional archives will be integrated as the catalog
+          grows.
+        </p>
+      </Section>
+
+      {/* ── Citation guidance ──────────────────────────────────────── */}
+      <Section heading="Citation">
+        <div className="flex flex-col gap-3 text-base leading-relaxed text-text-secondary">
+          <p>
+            If you use data from the Open Nova Catalog in a publication, please
+            cite the original data sources listed in the BibTeX file included
+            with each data bundle. We also ask that you cite the Open Nova
+            Catalog itself. A formal citation record will be published as the
+            catalog matures; in the interim, a reference to the project URL and
+            the data bundle generation date is sufficient.
+          </p>
+        </div>
+      </Section>
+
+      {/* ── Links ──────────────────────────────────────────────────── */}
+      <Section heading="Links">
+        <div className="flex flex-col gap-2 text-base text-text-secondary">
+          <p>
+            <a
+              href="https://github.com/YOUR_USERNAME/nova-cat"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-interactive no-underline hover:underline"
+            >
+              GitHub repository ↗
+            </a>
+            {' '}— source code, infrastructure, documentation, and issue tracker.
+          </p>
+          <p>
+            <Link
+              href="/docs"
+              className="text-interactive no-underline hover:underline"
+            >
+              Documentation
+            </Link>
+            {' '}— data products, formats, and design decisions.
+          </p>
+        </div>
+      </Section>
+
     </div>
   );
 }

--- a/frontend/src/app/docs/page.tsx
+++ b/frontend/src/app/docs/page.tsx
@@ -1,7 +1,795 @@
+/**
+ * Documentation page — /docs
+ *
+ * Three sections:
+ *   1. Understanding the Catalog — what the numbers mean, identity model,
+ *      discovery dates, known limitations.
+ *   2. Data Products — what you get on the website and in bundles.
+ *   3. Design Decisions — the interesting engineering and scientific choices.
+ *
+ * Server Component. Content is static prose — no data fetching needed.
+ */
+
+import Link from 'next/link';
+
+export const metadata = {
+  title: 'Documentation — Open Nova Catalog',
+  description:
+    'Data products, catalog semantics, and design decisions behind the Open Nova Catalog.',
+};
+
+// ── Reusable components ──────────────────────────────────────────────────────
+
+function Section({
+  id,
+  heading,
+  children,
+}: {
+  id: string;
+  heading: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section id={id}>
+      <h2 className="text-xl font-semibold text-text-primary mb-4">
+        {heading}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function Subsection({
+  id,
+  heading,
+  children,
+}: {
+  id: string;
+  heading: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div id={id} className="flex flex-col gap-3">
+      <h3 className="text-base font-semibold text-text-primary">{heading}</h3>
+      {children}
+    </div>
+  );
+}
+
+function Prose({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-3 text-base leading-relaxed text-text-secondary">
+      {children}
+    </div>
+  );
+}
+
+// ── Table of contents ────────────────────────────────────────────────────────
+
+const TOC = [
+  {
+    label: 'Understanding the Catalog',
+    href: '#understanding',
+    children: [
+      { label: 'What the spectra count means', href: '#spectra-count' },
+      { label: 'Nova identity', href: '#identity' },
+      { label: 'Discovery dates', href: '#discovery-dates' },
+      { label: 'Recurrent novae', href: '#recurrent-novae' },
+    ],
+  },
+  {
+    label: 'Data Products',
+    href: '#data-products',
+    children: [
+      { label: 'Published artifacts', href: '#artifacts' },
+      { label: 'Data bundles', href: '#bundles' },
+      { label: 'FITS files', href: '#fits' },
+    ],
+  },
+  {
+    label: 'Design Decisions',
+    href: '#design-decisions',
+    children: [
+      { label: 'Coordinate-based deduplication', href: '#dedup' },
+      { label: 'SHA-256 fingerprinting', href: '#fingerprinting' },
+      { label: 'Profile-driven FITS validation', href: '#profile-validation' },
+      { label: 'Quarantine semantics', href: '#quarantine' },
+      { label: 'Multi-arm spectra merging', href: '#spectra-merging' },
+      { label: 'Same-night display deduplication', href: '#same-night' },
+      { label: 'Large photometry errors as upper limits', href: '#large-errors' },
+      { label: 'Upper limit suppression', href: '#upper-limit-suppression' },
+      { label: 'Downsampling algorithms', href: '#downsampling' },
+      { label: 'Photometry band offsets', href: '#band-offsets' },
+      { label: 'Immutable release model', href: '#release-model' },
+    ],
+  },
+];
+
+// ── Page ─────────────────────────────────────────────────────────────────────
+
 export default function DocsPage() {
   return (
-    <div className="py-12">
-      <h1 className="text-2xl font-semibold text-text-primary">Documentation</h1>
+    <div className="py-12 flex flex-col gap-12 max-w-3xl">
+
+      {/* ── Header ─────────────────────────────────────────────────── */}
+      <div>
+        <h1 className="text-2xl font-semibold text-text-primary mb-4">
+          Documentation
+        </h1>
+        <p className="text-base leading-relaxed text-text-secondary">
+          How the catalog works, what the data products contain, and the design
+          decisions behind them. For a high-level overview of the project, see
+          the{' '}
+          <Link
+            href="/about"
+            className="text-interactive no-underline hover:underline"
+          >
+            About
+          </Link>{' '}
+          page.
+        </p>
+      </div>
+
+      {/* ── Table of contents ──────────────────────────────────────── */}
+      <nav
+        aria-label="Documentation table of contents"
+        className="bg-surface-secondary border border-border-subtle rounded-lg p-6"
+      >
+        <p className="text-sm font-semibold text-text-primary mb-3">
+          Contents
+        </p>
+        <ol className="flex flex-col gap-2 text-sm">
+          {TOC.map((section) => (
+            <li key={section.href}>
+              <a
+                href={section.href}
+                className="text-interactive no-underline hover:underline font-medium"
+              >
+                {section.label}
+              </a>
+              {section.children.length > 0 && (
+                <ol className="mt-1 ml-4 flex flex-col gap-1">
+                  {section.children.map((child) => (
+                    <li key={child.href}>
+                      <a
+                        href={child.href}
+                        className="text-interactive no-underline hover:underline"
+                      >
+                        {child.label}
+                      </a>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </li>
+          ))}
+        </ol>
+      </nav>
+
+      {/* ================================================================ */}
+      {/* SECTION 1 — Understanding the Catalog                            */}
+      {/* ================================================================ */}
+
+      <Section id="understanding" heading="Understanding the Catalog">
+        <Prose>
+          <p>
+            The Open Nova Catalog aggregates spectroscopic and photometric
+            observations of classical novae from public astronomical archives
+            ({' '}
+            <a
+              href="https://archive.eso.org/scienceportal/home"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-interactive no-underline hover:underline"
+            >
+              ESO
+            </a>
+            , CfA,{' '}
+            <a
+              href="https://vizier.cds.unistra.fr/viz-bin/VizieR"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-interactive no-underline hover:underline"
+            >
+              VizieR
+            </a>
+            ) and published literature. Each nova in the
+            catalog has a dedicated page showing its observational history,
+            interactive visualizations, and a downloadable data bundle.
+          </p>
+          <p>
+            A few things are worth understanding about how the catalog
+            represents its data.
+          </p>
+        </Prose>
+      </Section>
+
+      {/* ── Spectra count ──────────────────────────────────────────── */}
+      <Subsection id="spectra-count" heading="What the spectra count means">
+        <Prose>
+          <p>
+            The spectra count displayed on the catalog table and nova pages is
+            the total number of validated spectra files in the catalog for that
+            nova — not the number of unique observing nights. A single night of
+            observation can produce multiple spectra files: different wavelength
+            arms from the same instrument (e.g., X-SHOOTER&apos;s UVB, VIS, and
+            NIR arms), separate grating settings, or observations taken at
+            different times during the night.
+          </p>
+          <p>
+            When displaying spectra in the waterfall plot, same-night
+            observations from the same instrument are merged for visual clarity
+            (see{' '}
+            <a
+              href="#spectra-merging"
+              className="text-interactive no-underline hover:underline"
+            >
+              multi-arm spectra merging
+            </a>
+            ), so the number of traces in the plot may be smaller than the
+            spectra count. The data bundle always contains every individual{' '}
+            <strong>FITS</strong> (Flexible Image Transport System — the standard
+            binary format for astronomical data) file.
+          </p>
+        </Prose>
+      </Subsection>
+
+      {/* ── Identity ───────────────────────────────────────────────── */}
+      <Subsection id="identity" heading="Nova identity">
+        <Prose>
+          <p>
+            Novae are known by many names across archives — a single object
+            might appear as V1324 Sco, Nova Sco 2012, and PNV
+            J17175531-3214245 depending on who reported it. The catalog resolves
+            these into a single stable identity using coordinate-based
+            deduplication (see{' '}
+            <a
+              href="#dedup"
+              className="text-interactive no-underline hover:underline"
+            >
+              design decisions
+            </a>
+            ). All known aliases are listed on the nova page, and the catalog
+            search matches against all of them.
+          </p>
+          <p>
+            Internally, every nova is identified by a UUID. Names are resolved
+            once during ingestion; all downstream operations — data
+            persistence, artifact generation, frontend routing — use the UUID
+            exclusively. This means renaming a nova or adding new aliases never
+            breaks references to its data.
+          </p>
+        </Prose>
+      </Subsection>
+
+      {/* ── Discovery dates ────────────────────────────────────────── */}
+      <Subsection id="discovery-dates" heading="Discovery dates">
+        <Prose>
+          <p>
+            Discovery dates are derived from{' '}
+            <a
+              href="https://ui.adsabs.harvard.edu/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-interactive no-underline hover:underline"
+            >
+              ADS
+            </a>
+            {' '}(NASA&apos;s Astrophysics Data
+            System). The catalog queries ADS for all references associated with
+            a nova and selects the earliest publication date as the discovery
+            date. Because ADS publication dates typically resolve to the month
+            rather than the calendar date, most discovery dates in the catalog
+            have month-level precision only. When the exact day is unavailable,
+            it is stored explicitly as unknown rather than silently defaulted
+            to the first of the month.
+          </p>
+          <p>
+            The spectra and photometry viewers can display observation epochs as
+            {' '}<strong>DPO</strong> (days post-outburst). When the discovery date has
+            only month precision, the DPO axis uses the first of the month as
+            the reference point. The outburst date is an approximation in either
+            case — the actual outburst may precede the earliest published report
+            by days or weeks.
+          </p>
+        </Prose>
+      </Subsection>
+
+      {/* ── Recurrent novae ────────────────────────────────────────── */}
+      <Subsection id="recurrent-novae" heading="Recurrent novae">
+        <Prose>
+          <p>
+            The catalog does not yet handle recurrent novae as a distinct class.
+            A recurrent nova like RS Oph has multiple outbursts separated by
+            years or decades, and ideally each outburst would be treated as an
+            independent event with its own DPO axis, light curve, and data
+            bundle. The current infrastructure treats each nova as a single
+            entity with one discovery date, which works well for classical novae
+            but conflates multiple outbursts for recurrents.
+          </p>
+          <p>
+            For now, recurrent novae fall back to using the earliest observation
+            in the catalog as the DPO reference point rather than the historical
+            discovery date (which may refer to an outburst centuries ago). Full
+            outburst segmentation — per-outburst identity, visualization, and
+            data packaging — is planned but requires dedicated design work.
+          </p>
+        </Prose>
+      </Subsection>
+
+      {/* ── Divider ────────────────────────────────────────────────── */}
+      <hr className="border-border-subtle" />
+
+      {/* ================================================================ */}
+      {/* SECTION 2 — Data Products                                        */}
+      {/* ================================================================ */}
+
+      <Section id="data-products" heading="Data Products">
+        <Prose>
+          <p>
+            The catalog publishes two kinds of data products: frontend-ready
+            artifacts that power the website, and research-grade data bundles
+            for download. These are distinct products optimized for different
+            purposes — the website shows pre-processed, subsampled, normalized
+            data for interactive visualization, while the bundles contain
+            original-resolution FITS files and full datasets.
+          </p>
+        </Prose>
+      </Section>
+
+      {/* ── Published artifacts ─────────────────────────────────────── */}
+      <Subsection id="artifacts" heading="Published artifacts">
+        <Prose>
+          <p>
+            Each nova in the catalog has up to seven published artifacts,
+            generated by a Fargate-based artifact regeneration pipeline and
+            served to browsers via S3 and CloudFront:
+          </p>
+        </Prose>
+        <div className="overflow-x-auto mt-2">
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr className="bg-surface-secondary text-text-secondary text-left">
+                <th className="px-3 py-2 font-semibold">Artifact</th>
+                <th className="px-3 py-2 font-semibold">Contents</th>
+              </tr>
+            </thead>
+            <tbody className="text-text-secondary">
+              {[
+                ['nova.json', 'Core metadata: name, aliases, coordinates, discovery date, observation counts.'],
+                ['references.json', 'ADS literature references with bibcodes, titles, authors, and publication dates.'],
+                ['spectra.json', 'Plot-ready spectra: wavelength/flux arrays, peak-flux normalized, with epoch and instrument metadata.'],
+                ['photometry.json', 'Multi-regime photometry: per-band observations with magnitudes or flux densities, error bars, and upper limit flags.'],
+                ['sparkline.svg', 'A 90×55px inline light curve for the catalog table.'],
+                ['bundle.zip', 'Research-grade data bundle (see below).'],
+                ['catalog.json', 'Global catalog summary: one entry per nova, aggregate statistics. Powers the homepage and catalog table.'],
+              ].map(([artifact, desc]) => (
+                <tr key={artifact} className="border-t border-border-subtle">
+                  <td className="px-3 py-2 font-mono text-text-primary whitespace-nowrap">
+                    {artifact}
+                  </td>
+                  <td className="px-3 py-2">{desc}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <Prose>
+          <p>
+            All scientific computation — normalization, subsampling, offset
+            calculation, outburst date resolution — happens at artifact
+            generation time. The frontend performs zero scientific computation
+            and makes zero backend API calls.
+          </p>
+        </Prose>
+      </Subsection>
+
+      {/* ── Bundles ────────────────────────────────────────────────── */}
+      <Subsection id="bundles" heading="Data bundles">
+        <Prose>
+          <p>
+            Each nova has a downloadable ZIP bundle containing
+            research-grade data:
+          </p>
+        </Prose>
+        <div className="overflow-x-auto mt-2">
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr className="bg-surface-secondary text-text-secondary text-left">
+                <th className="px-3 py-2 font-semibold">File</th>
+                <th className="px-3 py-2 font-semibold">Contents</th>
+              </tr>
+            </thead>
+            <tbody className="text-text-secondary">
+              {[
+                ['README.txt', 'Nova identity, bundle inventory, format descriptions, and citation guidance.'],
+                ['<nova>_metadata.json', 'Nova properties: name, aliases, coordinates, discovery date.'],
+                ['<nova>_sources.json', 'Provenance records: provider, archive, original identifiers, retrieval date.'],
+                ['<nova>_references.bib', 'BibTeX file of all associated literature references.'],
+                ['spectra/*.fits', 'Individual FITS spectra in IVOA Spectrum DM v1.2 format, original (non-normalized) flux units.'],
+                ['<nova>_photometry.fits', 'Consolidated photometry BINTABLE: time, band, magnitude/flux, errors, upper limits, provenance.'],
+              ].map(([file, desc]) => (
+                <tr key={file} className="border-t border-border-subtle">
+                  <td className="px-3 py-2 font-mono text-text-primary whitespace-nowrap">
+                    {file}
+                  </td>
+                  <td className="px-3 py-2">{desc}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <Prose>
+          <p>
+            Bundle filenames follow a deterministic convention: FITS files are
+            named{' '}
+            <span className="font-mono text-sm text-text-primary">
+              &lt;nova&gt;_spectrum_&lt;provider&gt;_&lt;telescope&gt;_&lt;instrument&gt;_&lt;epoch_mjd&gt;.fits
+            </span>
+            , where each segment is always present (unknown values use the
+            explicit sentinel &ldquo;unknown&rdquo;) and the fractional{' '}
+            <strong>MJD</strong> (Modified Julian Date — a standard astronomical
+            time system) provides sub-night temporal uniqueness.
+          </p>
+        </Prose>
+      </Subsection>
+
+      {/* ── FITS ───────────────────────────────────────────────────── */}
+      <Subsection id="fits" heading="FITS files">
+        <Prose>
+          <p>
+            Spectrum FITS files conform to the{' '}
+            <a
+              href="https://www.ivoa.net/documents/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-interactive no-underline hover:underline"
+            >
+              <strong>IVOA</strong>
+            </a>
+            {' '}(International Virtual Observatory Alliance) Spectrum Data Model v1.2.
+            Each file contains a BINTABLE extension with WAVELENGTH (nm) and
+            FLUX columns in the original flux units reported by the instrument
+            pipeline. Instrument, telescope, epoch, and provider metadata are
+            recorded in the FITS header using standard IVOA keywords.
+          </p>
+          <p>
+            Photometry FITS files conform to IVOA PhotDM 1.1 and contain a
+            BINTABLE with columns for time (MJD), band identification,
+            magnitude or flux density, uncertainties, upper limit flags, and
+            provenance fields.
+          </p>
+        </Prose>
+      </Subsection>
+
+      {/* ── Divider ────────────────────────────────────────────────── */}
+      <hr className="border-border-subtle" />
+
+      {/* ================================================================ */}
+      {/* SECTION 3 — Design Decisions                                     */}
+      {/* ================================================================ */}
+
+      <Section id="design-decisions" heading="Design Decisions">
+        <Prose>
+          <p>
+            The catalog makes a number of deliberate choices about how data is
+            ingested, validated, transformed, and displayed. These decisions are
+            documented here both to help researchers understand and trust the
+            data they download, and to illustrate the engineering reasoning
+            behind the system. Each decision is backed by a formal architectural
+            decision record (ADR) in the project&apos;s documentation corpus.
+          </p>
+        </Prose>
+      </Section>
+
+      {/* ── Coordinate dedup ───────────────────────────────────────── */}
+      <Subsection id="dedup" heading="Coordinate-based deduplication">
+        <Prose>
+          <p>
+            When a new nova name is encountered during ingestion, the system
+            queries SIMBAD and TNS for its coordinates, then compares against
+            all existing novae in the catalog using angular separation
+            thresholds:
+          </p>
+        </Prose>
+        <div className="overflow-x-auto mt-2">
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr className="bg-surface-secondary text-text-secondary text-left">
+                <th className="px-3 py-2 font-semibold">Separation</th>
+                <th className="px-3 py-2 font-semibold">Action</th>
+              </tr>
+            </thead>
+            <tbody className="text-text-secondary">
+              <tr className="border-t border-border-subtle">
+                <td className="px-3 py-2 font-mono text-text-primary">&lt; 2″</td>
+                <td className="px-3 py-2">Attach as alias to existing nova</td>
+              </tr>
+              <tr className="border-t border-border-subtle">
+                <td className="px-3 py-2 font-mono text-text-primary">2–10″</td>
+                <td className="px-3 py-2">Identity quarantine — too close to be independent, too far for confident alias</td>
+              </tr>
+              <tr className="border-t border-border-subtle">
+                <td className="px-3 py-2 font-mono text-text-primary">&gt; 10″</td>
+                <td className="px-3 py-2">Create new nova</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <Prose>
+          <p>
+            The 2-arcsecond threshold reflects the typical astrometric
+            precision of discovery reports. The quarantine zone between 2 and 10
+            arcseconds captures ambiguous cases for operator review rather than
+            making a silent wrong decision. This is an instance of the
+            catalog&apos;s general{' '}
+            <a
+              href="#quarantine"
+              className="text-interactive no-underline hover:underline"
+            >
+              quarantine philosophy
+            </a>
+            .
+          </p>
+        </Prose>
+      </Subsection>
+
+      {/* ── SHA-256 fingerprinting ─────────────────────────────────── */}
+      <Subsection id="fingerprinting" heading="SHA-256 fingerprinting">
+        <Prose>
+          <p>
+            Every spectrum acquired from a provider archive is fingerprinted
+            with a SHA-256 hash of its raw bytes at acquisition time. After
+            validation, this fingerprint is checked against all existing
+            validated spectra for the same nova. If a byte-level match is
+            found, the new product is marked as a duplicate of the canonical
+            product and is not counted as a separate spectrum.
+          </p>
+          <p>
+            This catches the case where different archives — or different
+            access paths within the same archive — expose the same underlying
+            data product under different identifiers. Discovery-time metadata
+            deduplication catches most of these, but SHA-256 provides a
+            definitive second layer that operates on actual content rather than
+            metadata.
+          </p>
+        </Prose>
+      </Subsection>
+
+      {/* ── Profile-driven validation ──────────────────────────────── */}
+      <Subsection
+        id="profile-validation"
+        heading="Profile-driven FITS validation"
+      >
+        <Prose>
+          <p>
+            FITS files are not taken at face value. Each spectrum is validated
+            against a per-instrument profile that defines expected wavelength
+            ranges, flux units, header keywords, and normalization rules. The
+            profile is selected automatically based on the data provider and
+            header signature fields (INSTRUME, TELESCOP).
+          </p>
+          <p>
+            Validation includes structural checks (spectral axis monotonicity,
+            non-empty flux arrays, finite values, plausible wavelength ranges)
+            and metadata checks (required IVOA-aligned header fields present
+            and parseable). Files that fail validation or that match no known
+            profile are quarantined — not silently dropped or silently accepted.
+          </p>
+        </Prose>
+      </Subsection>
+
+      {/* ── Quarantine ─────────────────────────────────────────────── */}
+      <Subsection id="quarantine" heading="Quarantine semantics">
+        <Prose>
+          <p>
+            A recurring design principle throughout the catalog: when the system
+            encounters an irreconcilable conflict — identity ambiguity, validation
+            failure, metadata inconsistency — it quarantines the item for
+            operator review rather than making a guess. Quarantined items are
+            persisted with diagnostic metadata explaining why they were
+            quarantined, and an SNS notification alerts the operator.
+          </p>
+          <p>
+            This means the catalog may have fewer items than a system that
+            silently resolves conflicts, but the items it does have are ones
+            the system is confident about. A quarantine count of zero is not
+            the goal — a nonzero quarantine queue is evidence that the system
+            is correctly detecting ambiguity.
+          </p>
+        </Prose>
+      </Subsection>
+
+      {/* ── Multi-arm merging ──────────────────────────────────────── */}
+      <Subsection id="spectra-merging" heading="Multi-arm spectra merging">
+        <Prose>
+          <p>
+            Instruments like VLT X-SHOOTER observe simultaneously in multiple
+            wavelength arms (UVB, VIS, NIR), producing separate FITS files for
+            each arm. The catalog detects these by grouping spectra from the
+            same instrument taken within a tight time window (typically less
+            than 0.01 days).
+          </p>
+          <p>
+            When arms are detected, they are merged into a single continuous
+            spectrum for display. In overlap regions between arms, the system
+            blends the flux values; in gaps, NaN sentinels are inserted so the
+            plot shows a visible break rather than a misleading interpolation.
+            If the overlap between arms exceeds a threshold, the system selects
+            the better arm (by wavelength range, then point count) rather than
+            producing a confusing blend.
+          </p>
+          <p>
+            This merging is a display-layer operation only — the data bundle
+            always contains the individual per-arm FITS files.
+          </p>
+        </Prose>
+      </Subsection>
+
+      {/* ── Same-night dedup ───────────────────────────────────────── */}
+      <Subsection
+        id="same-night"
+        heading="Same-night display deduplication"
+      >
+        <Prose>
+          <p>
+            When a nova has dense observational coverage — dozens of spectra
+            from different nights — the waterfall plot can become cluttered.
+            For display, the viewer collapses same-day observations into a
+            single representative spectrum per day, selected by wavelength
+            coverage (broader is better), then point count, then range.
+          </p>
+          <p>
+            For novae with very long temporal baselines, an additional
+            log-spaced thinning pass ensures that late-epoch observations
+            (which may be separated by months) are not crowded out by dense
+            early coverage. The goal is to preserve the shape of the nova&apos;s
+            spectral evolution across its full timeline.
+          </p>
+        </Prose>
+      </Subsection>
+
+      {/* ── Large errors as limits ─────────────────────────────────── */}
+      <Subsection
+        id="large-errors"
+        heading="Large photometry errors as upper limits"
+      >
+        <Prose>
+          <p>
+            Optical photometry observations with magnitude uncertainties
+            greater than 1.0 mag are treated as upper limits for display
+            purposes. An error of this size means the detection is not
+            scientifically trustworthy as a measurement — it is better
+            understood as a constraint on the nova&apos;s brightness.
+          </p>
+          <p>
+            This is a display-layer decision. The underlying data in DynamoDB
+            is not mutated — the original magnitude, error, and upper limit
+            flag are preserved. The auto-flagging applies only to the optical
+            regime (magnitude-based); non-optical regimes (X-ray count rates,
+            radio flux densities) use different error scales and are not
+            affected.
+          </p>
+        </Prose>
+      </Subsection>
+
+      {/* ── Upper limit suppression ────────────────────────────────── */}
+      <Subsection
+        id="upper-limit-suppression"
+        heading="Upper limit suppression"
+      >
+        <Prose>
+          <p>
+            An upper limit is informative only if it constrains the data — that
+            is, if it tells you the nova was fainter than something you
+            couldn&apos;t otherwise infer from the detections. An upper limit
+            that is brighter than the brightest actual detection in the same
+            band provides no additional information and would only compress the
+            y-axis dynamic range.
+          </p>
+          <p>
+            The catalog drops non-constraining upper limits on a per-band
+            basis during artifact generation. This filtering is applied
+            per-band so that it remains correct when a user isolates a single
+            band in the light curve viewer and the y-axis rescales.
+          </p>
+        </Prose>
+      </Subsection>
+
+      {/* ── Downsampling ───────────────────────────────────────────── */}
+      <Subsection id="downsampling" heading="Downsampling algorithms">
+        <Prose>
+          <p>
+            Raw photometry datasets can contain thousands of observations,
+            which would produce an unreadable plot. The catalog uses two
+            complementary downsampling strategies, both applied during artifact
+            generation:
+          </p>
+          <p>
+            <span className="text-text-primary font-medium">
+              LTTB (Largest-Triangle-Three-Buckets).
+            </span>{' '}
+            A purpose-built time-series downsampling algorithm (Steinarsson
+            2013) that preferentially preserves peaks, troughs, and inflection
+            points. Used for sparklines (downsampled to 90 points) and for
+            spectra display. LTTB divides the data into equal-count buckets
+            and selects the point in each bucket that maximizes the triangle
+            area with its neighbors — ensuring that the visual shape of the
+            light curve is preserved even at aggressive reduction ratios.
+          </p>
+          <p>
+            <span className="text-text-primary font-medium">
+              Density-preserving log subsampling.
+            </span>{' '}
+            Used for photometry (capped at 500 points per wavelength regime).
+            Observation budgets are allocated proportionally across bands, then
+            within each band, log-spaced time intervals with dynamic boundary
+            stretching select representative points. Detections are preferred
+            over upper limits. This ensures that sparse late-epoch
+            observations — which carry high scientific value — are never
+            crowded out by dense early coverage.
+          </p>
+        </Prose>
+      </Subsection>
+
+      {/* ── Band offsets ───────────────────────────────────────────── */}
+      <Subsection id="band-offsets" heading="Photometry band offsets">
+        <Prose>
+          <p>
+            When multiple photometric bands occupy overlapping magnitude ranges,
+            their data points can form an unreadable cluster. The catalog
+            computes per-band vertical offsets to separate overlapping traces,
+            using a multi-stage algorithm:
+          </p>
+          <p>
+            First, each band&apos;s time-series is fit with a smoothing spline.
+            A gap analysis then measures the pairwise overlap between bands
+            using the splined curves — specifically, the fraction of their
+            shared time domain where the curves are within a threshold
+            magnitude of each other. Bands are partitioned into overlap
+            clusters using a union-find structure, so that well-separated bands
+            (like I-band at 12 mag when V and R are at ~10 mag) are never
+            displaced. Within each cluster, an exhaustive search finds the
+            ordering and offset magnitudes that best separate the traces.
+          </p>
+          <p>
+            Offsets are rounded to half-magnitude increments (e.g., +0.5, +1.0)
+            for clean visual presentation, and are displayed in the band legend
+            so researchers always know a shift has been applied. Results are
+            cached in DynamoDB and invalidated when band membership or
+            observation density changes significantly.
+          </p>
+        </Prose>
+      </Subsection>
+
+      {/* ── Release model ──────────────────────────────────────────── */}
+      <Subsection id="release-model" heading="Immutable release model">
+        <Prose>
+          <p>
+            Published artifacts are delivered through an immutable release
+            model. Each artifact generation sweep writes all artifacts — both
+            for novae with new data and unchanged novae copied from the
+            previous release — to a new, timestamped S3 prefix. Only after
+            every artifact is in place does an atomic pointer update
+            (<span className="font-mono text-sm text-text-primary">current.json</span>)
+            make the new release visible to browsers via CloudFront.
+          </p>
+          <p>
+            This means users never see a partially updated catalog. The
+            previous release remains available until the new one is fully
+            written. Rolling back to a previous release is a single JSON
+            write — no per-artifact operations required. Old releases are
+            automatically cleaned up by an S3 lifecycle rule after 7 days.
+          </p>
+          <p>
+            The frontend makes zero backend API calls. It fetches static JSON
+            artifacts from CloudFront and renders them entirely on the client.
+            This architecture keeps operational costs near zero and eliminates
+            an entire class of backend availability concerns.
+          </p>
+        </Prose>
+      </Subsection>
+
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Added About page (`/about`) with dual-audience content targeting both astronomers and recruiters/employers
- Added Documentation page (`/docs`) with catalog semantics, data product descriptions, and 11 design decision writeups
- Updated README with current resource counts, Fargate/CloudFront/EventBridge infrastructure, new architecture diagram, and refreshed status table
- Scrubbed AAVSO from all documents; replaced with VizieR
- Added external links to ESO, VizieR, ADS, and IVOA standards across all three documents
- Added bold inline definitions for domain-specific acronyms (FITS, DPO, MJD, IVOA, LTTB)
- License: TBD → MIT

## Why
- The About and Docs pages have been empty placeholders since ADR-010 defined them as nav items. The site now links to pages with no content — not a great look for a live site or a portfolio piece.
- The README was stale: listed 15 Lambdas (now 17), 6 workflows (now 7), 21 ADRs (now 30+), and had no mention of Fargate, CloudFront, EventBridge, the artifact regeneration pipeline, or the ticket-driven ingestion path. The architecture diagram was missing two entire system layers.
- AAVSO needed to be removed from all public-facing content.

## Testing
- About and Docs pages verified via local `next dev` — layout, links, anchor navigation, and responsive behavior all check out
- README renders correctly on GitHub (verified link syntax, table formatting, ASCII diagram alignment)
- `grep -r AAVSO` across all three files returns zero hits

## Notes
- The About page uses a "one narrative, two audiences" strategy: the same technical facts read as domain competence to astronomers and as system design depth to recruiters. No separate pitches.
- The Docs page is a single page with anchor-linked TOC rather than sub-routes. Content is cohesive enough that splitting would add navigation friction without adding value. Can be refactored to `/docs/[slug]` later if it grows.
- Commit count (313) and ADR count (30+) in the About page's stats grid will go stale over time. Acceptable for now; could be pulled dynamically later.
- The GitHub URL in the About page has a `YOUR_USERNAME/nova-cat` placeholder that needs updating before merge.

## Out of Scope
- Dark mode testing for the new pages (token system supports it, but not verified)
- Frontend unit tests for the new page components (static content, no interactive logic)
- Updating `current-architecture.md` references to the About/Docs pages (still listed as "Placeholder (content TBD)")