### PR TITLE
Epic/28 spectra compositing

### DIFF
--- a/docs/adr/ADR-033-spectra-compositing-pipeline.md
+++ b/docs/adr/ADR-033-spectra-compositing-pipeline.md
@@ -293,7 +293,7 @@ separate task would add operational complexity (new task definition, new Step Fu
 state, new IAM role) for no functional benefit. The compositing sweep is lightweight
 for most novae and only expensive for the minority with dense same-night coverage.
 
-### Decision 10 — Degenerate Composites (Single-Spectrum Groups)
+## Decision 10 — Degenerate Composites (Single-Spectrum Groups)
 
 When a compositing group has multiple spectra on the same night but all but one are
 rejected (e.g., below the 2000-point threshold), no actual composite CSV is produced —
@@ -302,18 +302,25 @@ written to DynamoDB with:
 
 - `constituent_data_product_ids` containing the single surviving spectrum's ID
 - `rejected_data_product_ids` containing the rejected spectra
-- `composite_fingerprint` covering all evaluated spectra (same as Decision 7)
-- `composite_s3_key` and `web_ready_s3_key` set to `None` (no composite CSVs exist)
+- `composite_fingerprint` covering the constituent and its content hash
+- `composite_s3_key` set to `None` (no full-resolution composite CSV exists)
+- `web_ready_s3_key` set to the **surviving spectrum's existing web-ready CSV path**
+  (e.g., `derived/spectra/<nova_id>/<data_product_id>/web_ready.csv`)
 
-This prevents the system from re-evaluating the same group on every subsequent sweep.
-Without the degenerate record, the sweep would see multiple same-night spectra, attempt
-to build a composite, reject all but one, produce nothing, and repeat this wasted work
-on the next sweep.
+This design serves two purposes:
 
-The spectra generator identifies degenerate composites by
-`len(constituent_data_product_ids) == 1` and treats the single constituent as a
-pass-through — it reads the original spectrum's web-ready CSV as usual. Rejected
-spectra are still excluded from the waterfall plot per Decision 5.
+1. **Prevents repeated evaluation.** Without the degenerate record, the sweep would
+   see multiple same-night spectra, attempt to build a composite, reject all but one,
+   produce nothing, and repeat this wasted work on the next sweep.
+
+2. **Eliminates special-case logic in the spectra generator.** The generator treats all
+   composites uniformly: see composite → fetch `web_ready_s3_key` → use it. There is
+   no need to check `len(constituent_data_product_ids) == 1` or implement a
+   pass-through path. The suppression of rejected spectra works identically for
+   degenerate and non-degenerate composites.
+
+No CSV data is copied or duplicated — the degenerate composite's `web_ready_s3_key`
+references the original spectrum's existing file in place.
 
 ---
 

--- a/services/artifact_generator/generators/compositing.py
+++ b/services/artifact_generator/generators/compositing.py
@@ -1,0 +1,485 @@
+"""Spectra compositing — pure computation utilities.
+
+Core building blocks for the spectra compositing pipeline: grouping
+same-instrument spectra into observing nights, determining a common
+wavelength grid for resampling, cleaning and resampling individual
+spectra, combining them into composites, and computing deterministic
+composite identifiers and fingerprints for rebuild avoidance.
+
+All functions are pure (no AWS I/O, no side effects) and operate on
+plain dicts / numpy arrays so they can be tested without mocks.
+The one exception is ``clean_spectrum``, which imports from
+``generators.shared`` at call time (deferred import to avoid circular
+dependencies in the Fargate module layout).
+
+See ADR-033 for design rationale.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from typing import Any, TypedDict
+
+import numpy as np
+from numpy.typing import NDArray
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: MJD gap threshold for night clustering.
+#: 0.5 days = 12 hours.  Separates consecutive observing nights at all
+#: major professional spectroscopic facilities.
+NIGHT_GAP_THRESHOLD_DAYS: float = 0.5
+
+#: Minimum native-resolution data points for a spectrum to be included
+#: in a composite.
+MIN_POINTS_FOR_COMPOSITE: int = 2000
+
+#: NovaCat UUID v5 namespace for deterministic composite IDs.
+#: Generated once via uuid.uuid4() and frozen here.
+_NOVACAT_UUID_NAMESPACE: uuid.UUID = uuid.UUID("7f1b3c5e-8a2d-4e6f-b9c1-d3e5f7a8b0c2")
+
+
+# ---------------------------------------------------------------------------
+# Typed structures
+# ---------------------------------------------------------------------------
+
+
+class CompositingGroup(TypedDict):
+    """A group of spectra eligible for compositing evaluation.
+
+    All members share the same instrument and observing night.
+    """
+
+    instrument: str
+    products: list[dict[str, Any]]
+
+
+class CleanedSpectrum(TypedDict):
+    """A cleaned spectrum ready for resampling.
+
+    Wavelengths and fluxes are parallel arrays of equal length,
+    monotonically increasing in wavelength, with detector artifacts
+    removed.
+    """
+
+    data_product_id: str
+    wavelengths: NDArray[np.float64]
+    fluxes: NDArray[np.float64]
+
+
+# ---------------------------------------------------------------------------
+# Night clustering
+# ---------------------------------------------------------------------------
+
+
+def cluster_by_night(
+    products: list[dict[str, Any]],
+    gap_threshold: float = NIGHT_GAP_THRESHOLD_DAYS,
+) -> list[list[dict[str, Any]]]:
+    """Group DataProduct dicts into observing nights by MJD gap detection.
+
+    Single-linkage clustering on ``observation_date_mjd`` with a
+    configurable gap threshold.
+
+    Parameters
+    ----------
+    products:
+        DataProduct-like dicts.  Each must contain an
+        ``observation_date_mjd`` key with a numeric value (``float``,
+        ``int``, or ``Decimal``).
+    gap_threshold:
+        Maximum MJD difference between consecutive spectra within the
+        same night.  Defaults to 0.5 days (12 hours).
+
+    Returns
+    -------
+    list[list[dict]]:
+        Groups of products, each representing one observing night.
+        Within each group, products are sorted by MJD ascending.
+        Groups are returned in chronological order (earliest night
+        first).
+
+    Raises
+    ------
+    ValueError:
+        If *products* is empty or any product lacks
+        ``observation_date_mjd``.
+    """
+    if not products:
+        raise ValueError("products must not be empty")
+
+    # Sort by MJD.  Convert Decimal → float defensively.
+    sorted_prods = sorted(products, key=lambda p: float(p["observation_date_mjd"]))
+
+    groups: list[list[dict[str, Any]]] = [[sorted_prods[0]]]
+    for prev, curr in zip(sorted_prods, sorted_prods[1:], strict=False):
+        gap = float(curr["observation_date_mjd"]) - float(prev["observation_date_mjd"])
+        if gap > gap_threshold:
+            groups.append([curr])
+        else:
+            groups[-1].append(curr)
+
+    return groups
+
+
+def identify_compositing_groups(
+    products: list[dict[str, Any]],
+    gap_threshold: float = NIGHT_GAP_THRESHOLD_DAYS,
+) -> list[CompositingGroup]:
+    """Identify all compositing groups for a single nova.
+
+    Groups products by instrument, then clusters each instrument's
+    products into observing nights.  Only returns groups where at
+    least 2 products share the same instrument and night — singletons
+    are excluded because they produce no composite.
+
+    Parameters
+    ----------
+    products:
+        All VALID spectra DataProduct dicts for one nova.  Each must
+        have ``instrument`` (str) and ``observation_date_mjd`` (numeric).
+    gap_threshold:
+        Night clustering gap threshold (days).
+
+    Returns
+    -------
+    list[CompositingGroup]:
+        Groups with ≥ 2 members, suitable for compositing evaluation.
+        Empty list if no multi-member groups exist.
+    """
+    # Group by instrument.
+    by_instrument: dict[str, list[dict[str, Any]]] = {}
+    for p in products:
+        inst = str(p["instrument"])
+        by_instrument.setdefault(inst, []).append(p)
+
+    groups: list[CompositingGroup] = []
+    for instrument, inst_products in by_instrument.items():
+        if len(inst_products) < 2:
+            continue
+        nights = cluster_by_night(inst_products, gap_threshold)
+        for night in nights:
+            if len(night) >= 2:
+                groups.append(CompositingGroup(instrument=instrument, products=night))
+
+    return groups
+
+
+# ---------------------------------------------------------------------------
+# Common wavelength grid
+# ---------------------------------------------------------------------------
+
+
+def determine_common_grid(
+    spectra: list[CleanedSpectrum],
+) -> NDArray[np.float64]:
+    """Build the common wavelength grid for resampling.
+
+    Grid spacing is determined by the coarsest-resolution spectrum in
+    the group.  The grid spans the full union wavelength range.
+
+    Parameters
+    ----------
+    spectra:
+        Cleaned spectra with monotonically increasing wavelength arrays.
+        Must contain at least 2 spectra (compositing requires ≥ 2).
+
+    Returns
+    -------
+    NDArray[np.float64]:
+        Uniformly spaced wavelength grid.
+
+    Raises
+    ------
+    ValueError:
+        If fewer than 2 spectra are provided, or any spectrum has
+        fewer than 2 data points.
+    """
+    if len(spectra) < 2:
+        raise ValueError(f"Need ≥ 2 spectra for compositing, got {len(spectra)}")
+
+    # Find the coarsest median step and the union wavelength range.
+    max_median_step: float = 0.0
+    global_wl_min: float = np.inf
+    global_wl_max: float = -np.inf
+
+    for spec in spectra:
+        wl = spec["wavelengths"]
+        if len(wl) < 2:
+            raise ValueError(f"Spectrum {spec['data_product_id']} has < 2 points after cleaning")
+        steps = np.diff(wl)
+        median_step = float(np.median(steps))
+        if median_step > max_median_step:
+            max_median_step = median_step
+
+        global_wl_min = min(global_wl_min, float(wl[0]))
+        global_wl_max = max(global_wl_max, float(wl[-1]))
+
+    if max_median_step <= 0:
+        raise ValueError("Coarsest median step is <= 0; degenerate input")
+
+    # Build uniformly spaced grid.
+    n_points = int(np.ceil((global_wl_max - global_wl_min) / max_median_step)) + 1
+    grid = np.linspace(global_wl_min, global_wl_max, n_points)
+    return grid
+
+
+# ---------------------------------------------------------------------------
+# Composite fingerprint
+# ---------------------------------------------------------------------------
+
+
+def compute_composite_fingerprint(
+    constituent_ids: list[str],
+    sha256_by_id: dict[str, str],
+) -> str:
+    """Compute a deterministic fingerprint for a compositing group.
+
+    The fingerprint covers constituent data_product_ids and their
+    content sha256 hashes.
+
+    The fingerprint is a SHA-256 hex digest of the concatenation of
+    sorted ``(data_product_id, sha256)`` pairs.  Deterministic sorting
+    ensures the same set of inputs always produces the same fingerprint
+    regardless of iteration order.
+
+    Parameters
+    ----------
+    constituent_ids:
+        ``data_product_id`` values of the spectra that will be combined.
+    sha256_by_id:
+        Mapping from ``data_product_id`` to its content ``sha256`` hash
+        string (from the DataProduct DDB item).
+
+    Returns
+    -------
+    str:
+        SHA-256 hex digest (64 characters).
+
+    Raises
+    ------
+    KeyError:
+        If any ID in *constituent_ids* is missing from *sha256_by_id*.
+    ValueError:
+        If *constituent_ids* is empty.
+    """
+    if not constituent_ids:
+        raise ValueError("constituent_ids must not be empty")
+
+    # Sort for determinism, then concatenate id:sha256 pairs.
+    sorted_ids = sorted(constituent_ids)
+    parts: list[str] = []
+    for cid in sorted_ids:
+        sha = sha256_by_id[cid]
+        parts.append(f"{cid}:{sha}")
+
+    payload = "|".join(parts)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Deterministic composite ID (UUID v5)
+# ---------------------------------------------------------------------------
+
+
+def compute_composite_id(constituent_ids: list[str]) -> str:
+    """Compute a deterministic composite UUID from constituent IDs.
+
+    Uses UUID v5 (SHA-1 based, namespace-scoped) so that the same set
+    of constituents always produces the same composite ID.
+
+    Parameters
+    ----------
+    constituent_ids:
+        ``data_product_id`` values of the spectra being combined.
+        Order does not matter — IDs are sorted internally.
+
+    Returns
+    -------
+    str:
+        UUID v5 string (lowercase, hyphenated).
+
+    Raises
+    ------
+    ValueError:
+        If *constituent_ids* is empty.
+    """
+    if not constituent_ids:
+        raise ValueError("constituent_ids must not be empty")
+
+    sorted_ids = sorted(constituent_ids)
+    name = "|".join(sorted_ids)
+    return str(uuid.uuid5(_NOVACAT_UUID_NAMESPACE, name))
+
+
+# ---------------------------------------------------------------------------
+# Spectrum cleaning (wraps shared.py utilities)
+# ---------------------------------------------------------------------------
+
+
+def clean_spectrum(
+    data_product_id: str,
+    wavelengths: NDArray[np.float64],
+    fluxes: NDArray[np.float64],
+) -> CleanedSpectrum | None:
+    """Apply the full cleaning pipeline to a single raw spectrum.
+
+    Wraps the three shared cleaning functions in the order required
+    by the compositing pipeline: edge trimming → interior dead run
+    removal → chip gap artifact rejection.
+
+    Parameters
+    ----------
+    data_product_id:
+        ID for logging context (passed through to cleaning functions).
+    wavelengths:
+        Monotonically increasing wavelength array (nm) from FITS.
+    fluxes:
+        Flux array parallel to *wavelengths*.
+
+    Returns
+    -------
+    CleanedSpectrum | None:
+        Cleaned spectrum, or ``None`` if cleaning eliminated all points.
+    """
+    from generators.shared import (
+        reject_chip_gap_artifacts,
+        remove_interior_dead_runs,
+        trim_dead_edges,
+    )
+
+    wl = wavelengths.tolist()
+    fx = fluxes.tolist()
+
+    wl, fx = trim_dead_edges(wl, fx, data_product_id)
+    if not wl:
+        return None
+
+    wl, fx = remove_interior_dead_runs(wl, fx, data_product_id)
+    if not wl:
+        return None
+
+    wl, fx = reject_chip_gap_artifacts(wl, fx, data_product_id)
+    if not wl:
+        return None
+
+    return CleanedSpectrum(
+        data_product_id=data_product_id,
+        wavelengths=np.asarray(wl, dtype=np.float64),
+        fluxes=np.asarray(fx, dtype=np.float64),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Resampling
+# ---------------------------------------------------------------------------
+
+
+def resample_to_grid(
+    spectrum: CleanedSpectrum,
+    grid: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Resample a cleaned spectrum onto a common wavelength grid.
+
+    Uses linear interpolation.  Grid points outside the spectrum's
+    wavelength range are set to NaN (no extrapolation).
+
+    Parameters
+    ----------
+    spectrum:
+        Cleaned spectrum with monotonically increasing wavelengths.
+    grid:
+        Target wavelength grid (uniformly spaced, from
+        ``determine_common_grid``).
+
+    Returns
+    -------
+    NDArray[np.float64]:
+        Flux values on the common grid.  NaN where the grid extends
+        beyond this spectrum's coverage.
+    """
+    wl = spectrum["wavelengths"]
+    fx = spectrum["fluxes"]
+
+    # np.interp extrapolates by default; we want NaN outside coverage.
+    resampled = np.interp(grid, wl, fx)
+
+    # Mask points outside the spectrum's wavelength range.
+    out_of_range = (grid < wl[0]) | (grid > wl[-1])
+    resampled[out_of_range] = np.nan
+
+    return resampled
+
+
+# ---------------------------------------------------------------------------
+# Combination
+# ---------------------------------------------------------------------------
+
+
+def combine_spectra(
+    resampled_fluxes: list[NDArray[np.float64]],
+) -> NDArray[np.float64]:
+    """Average resampled flux arrays with subset-aware averaging.
+
+    At each grid point, the average is taken over only the spectra
+    that have coverage there (non-NaN values).  Grid points with no
+    coverage from any spectrum are NaN in the output.
+
+    Parameters
+    ----------
+    resampled_fluxes:
+        One flux array per spectrum, all on the same common grid.
+        Must contain at least 2 arrays.
+
+    Returns
+    -------
+    NDArray[np.float64]:
+        Combined flux array on the common grid.
+    """
+    if len(resampled_fluxes) < 2:
+        raise ValueError(f"Need ≥ 2 flux arrays for combination, got {len(resampled_fluxes)}")
+
+    stacked = np.vstack(resampled_fluxes)
+    with np.errstate(all="ignore"):
+        combined: NDArray[np.float64] = np.nanmedian(stacked, axis=0)
+    return combined
+
+
+# ---------------------------------------------------------------------------
+# CSV serialization
+# ---------------------------------------------------------------------------
+
+
+def composite_to_csv(
+    wavelengths: NDArray[np.float64],
+    fluxes: NDArray[np.float64],
+) -> str:
+    """Serialize a composite spectrum to CSV format.
+
+    Produces a two-column CSV (``wavelength_nm,flux``) matching the
+    web-ready CSV format used by the spectra generator.  NaN flux
+    values (grid points with no spectral coverage) are excluded.
+
+    Parameters
+    ----------
+    wavelengths:
+        Common grid wavelength array (nm).
+    fluxes:
+        Combined flux array (from ``combine_spectra``).
+
+    Returns
+    -------
+    str:
+        CSV string with header row, ready for S3 upload.
+    """
+    mask = np.isfinite(fluxes)
+    wl_clean = wavelengths[mask]
+    fx_clean = fluxes[mask]
+
+    lines = ["wavelength_nm,flux"]
+    for w, f in zip(wl_clean, fx_clean, strict=True):
+        lines.append(f"{w:.6f},{f}")
+    return "\n".join(lines) + "\n"

--- a/services/artifact_generator/generators/compositing.py
+++ b/services/artifact_generator/generators/compositing.py
@@ -1,16 +1,14 @@
-"""Spectra compositing — pure computation utilities.
+"""Spectra compositing pipeline.
 
-Core building blocks for the spectra compositing pipeline: grouping
-same-instrument spectra into observing nights, determining a common
-wavelength grid for resampling, cleaning and resampling individual
-spectra, combining them into composites, and computing deterministic
-composite identifiers and fingerprints for rebuild avoidance.
+Groups same-instrument, same-night spectra into compositing candidates,
+cleans and resamples them onto a common wavelength grid, combines them
+via median, and persists the results to DynamoDB and S3.  Also computes
+deterministic composite identifiers and fingerprints for rebuild
+avoidance.
 
-All functions are pure (no AWS I/O, no side effects) and operate on
-plain dicts / numpy arrays so they can be tested without mocks.
-The one exception is ``clean_spectrum``, which imports from
-``generators.shared`` at call time (deferred import to avoid circular
-dependencies in the Fargate module layout).
+Pure-computation functions (clustering, grid, resampling, combination)
+are testable without mocks.  DDB/S3 operations (queries, writes, CSV
+uploads) follow the same inline-IO pattern as the other generators.
 
 See ADR-033 for design rationale.
 """
@@ -18,11 +16,15 @@ See ADR-033 for design rationale.
 from __future__ import annotations
 
 import hashlib
+import logging
 import uuid
+from datetime import UTC, datetime
 from typing import Any, TypedDict
 
 import numpy as np
 from numpy.typing import NDArray
+
+_logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -233,13 +235,15 @@ def determine_common_grid(
 
 
 def compute_composite_fingerprint(
-    constituent_ids: list[str],
+    evaluated_ids: list[str],
     sha256_by_id: dict[str, str],
 ) -> str:
     """Compute a deterministic fingerprint for a compositing group.
 
-    The fingerprint covers constituent data_product_ids and their
-    content sha256 hashes.
+    The fingerprint covers all evaluated data_product_ids (both
+    constituents and rejected) and their content sha256 hashes.
+    Including the full evaluated set ensures that changes to any
+    group member — including rejected spectra — trigger a rebuild.
 
     The fingerprint is a SHA-256 hex digest of the concatenation of
     sorted ``(data_product_id, sha256)`` pairs.  Deterministic sorting
@@ -248,8 +252,9 @@ def compute_composite_fingerprint(
 
     Parameters
     ----------
-    constituent_ids:
-        ``data_product_id`` values of the spectra that will be combined.
+    evaluated_ids:
+        ``data_product_id`` values of ALL spectra in the compositing
+        group (constituents + rejected).
     sha256_by_id:
         Mapping from ``data_product_id`` to its content ``sha256`` hash
         string (from the DataProduct DDB item).
@@ -262,19 +267,19 @@ def compute_composite_fingerprint(
     Raises
     ------
     KeyError:
-        If any ID in *constituent_ids* is missing from *sha256_by_id*.
+        If any ID in *evaluated_ids* is missing from *sha256_by_id*.
     ValueError:
-        If *constituent_ids* is empty.
+        If *evaluated_ids* is empty.
     """
-    if not constituent_ids:
-        raise ValueError("constituent_ids must not be empty")
+    if not evaluated_ids:
+        raise ValueError("evaluated_ids must not be empty")
 
     # Sort for determinism, then concatenate id:sha256 pairs.
-    sorted_ids = sorted(constituent_ids)
+    sorted_ids = sorted(evaluated_ids)
     parts: list[str] = []
-    for cid in sorted_ids:
-        sha = sha256_by_id[cid]
-        parts.append(f"{cid}:{sha}")
+    for eid in sorted_ids:
+        sha = sha256_by_id[eid]
+        parts.append(f"{eid}:{sha}")
 
     payload = "|".join(parts)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
@@ -422,11 +427,13 @@ def resample_to_grid(
 def combine_spectra(
     resampled_fluxes: list[NDArray[np.float64]],
 ) -> NDArray[np.float64]:
-    """Average resampled flux arrays with subset-aware averaging.
+    """Median-combine resampled flux arrays with subset-aware averaging.
 
-    At each grid point, the average is taken over only the spectra
+    At each grid point, the median is taken over only the spectra
     that have coverage there (non-NaN values).  Grid points with no
-    coverage from any spectrum are NaN in the output.
+    coverage from any spectrum are NaN in the output.  Median is
+    preferred over mean for robustness against calibration artifacts
+    and cosmic ray residuals.
 
     Parameters
     ----------
@@ -483,3 +490,617 @@ def composite_to_csv(
     for w, f in zip(wl_clean, fx_clean, strict=True):
         lines.append(f"{w:.6f},{f}")
     return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# DDB queries
+# ---------------------------------------------------------------------------
+
+_COMPOSITE_MARKER = "COMPOSITE"
+
+
+def find_compositable_products(
+    table: Any,
+    nova_id: str,
+) -> list[dict[str, Any]]:
+    """Query all VALID individual spectra DataProducts for a nova.
+
+    Returns only non-composite items (SK does not contain the
+    ``COMPOSITE`` segment).  Results are used by the compositing sweep
+    to identify candidate groups.
+
+    Parameters
+    ----------
+    table:
+        Boto3 DynamoDB Table resource.
+    nova_id:
+        Nova UUID string (the partition key value).
+
+    Returns
+    -------
+    list[dict]:
+        VALID individual spectra DataProduct items from DDB.
+    """
+    from boto3.dynamodb.conditions import Attr, Key
+
+    items: list[dict[str, Any]] = []
+    kwargs: dict[str, Any] = {
+        "KeyConditionExpression": (
+            Key("PK").eq(nova_id) & Key("SK").begins_with("PRODUCT#SPECTRA#")
+        ),
+        "FilterExpression": Attr("validation_status").eq("VALID"),
+    }
+
+    while True:
+        resp = table.query(**kwargs)
+        for item in resp.get("Items", []):
+            sk = str(item.get("SK", ""))
+            if _COMPOSITE_MARKER not in sk:
+                items.append(item)
+        if "LastEvaluatedKey" not in resp:
+            break
+        kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+
+    return items
+
+
+def find_existing_composites(
+    table: Any,
+    nova_id: str,
+) -> list[dict[str, Any]]:
+    """Query all existing composite DataProduct items for a nova.
+
+    Composites are identified by the ``COMPOSITE`` segment in their
+    sort key.
+
+    Parameters
+    ----------
+    table:
+        Boto3 DynamoDB Table resource.
+    nova_id:
+        Nova UUID string.
+
+    Returns
+    -------
+    list[dict]:
+        Composite DataProduct items, possibly empty.
+    """
+    from boto3.dynamodb.conditions import Key
+
+    items: list[dict[str, Any]] = []
+    kwargs: dict[str, Any] = {
+        "KeyConditionExpression": (
+            Key("PK").eq(nova_id) & Key("SK").begins_with("PRODUCT#SPECTRA#")
+        ),
+    }
+
+    while True:
+        resp = table.query(**kwargs)
+        for item in resp.get("Items", []):
+            sk = str(item.get("SK", ""))
+            if _COMPOSITE_MARKER in sk:
+                items.append(item)
+        if "LastEvaluatedKey" not in resp:
+            break
+        kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+
+    return items
+
+
+# ---------------------------------------------------------------------------
+# DDB writes
+# ---------------------------------------------------------------------------
+
+
+def write_composite_data_product(
+    table: Any,
+    nova_id: str,
+    composite_id: str,
+    provider: str,
+    instrument: str,
+    telescope: str | None,
+    observation_date_mjd: float,
+    constituent_data_product_ids: list[str],
+    rejected_data_product_ids: list[str],
+    composite_fingerprint: str,
+    composite_s3_key: str | None,
+    web_ready_s3_key: str | None,
+) -> None:
+    """Write a composite (or degenerate composite) DataProduct to DDB.
+
+    Uses unconditional PutItem — the compositing sweep is the sole
+    writer of composite items and runs sequentially within a single
+    Fargate task.
+
+    For degenerate composites (single survivor after threshold
+    filtering), ``composite_s3_key`` and ``web_ready_s3_key`` are
+    ``None`` — no CSV artifacts exist.
+
+    Parameters
+    ----------
+    table:
+        Boto3 DynamoDB Table resource.
+    nova_id:
+        Nova UUID string.
+    composite_id:
+        Deterministic UUID v5 for this composite.
+    provider:
+        Shared provider of the compositing group.
+    instrument:
+        Shared instrument of the compositing group.
+    telescope:
+        Shared telescope (may be None).
+    observation_date_mjd:
+        Mean MJD of the constituent spectra.
+    constituent_data_product_ids:
+        IDs of spectra that were combined (sorted).
+    rejected_data_product_ids:
+        IDs of spectra considered but excluded (e.g., below
+        2000-point threshold).  May be empty.
+    composite_fingerprint:
+        SHA-256 fingerprint covering constituents and their content
+        hashes.
+    composite_s3_key:
+        S3 key for composite_full.csv, or None for degenerate composites.
+    web_ready_s3_key:
+        S3 key for web_ready.csv, or None for degenerate composites.
+    """
+    now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    sk = f"PRODUCT#SPECTRA#{provider}#COMPOSITE#{composite_id}"
+
+    item: dict[str, Any] = {
+        "PK": nova_id,
+        "SK": sk,
+        "entity_type": "DataProduct",
+        "data_product_id": composite_id,
+        "product_type": "SPECTRA",
+        "provider": provider,
+        "instrument": instrument,
+        "observation_date_mjd": _to_decimal(observation_date_mjd),
+        "constituent_data_product_ids": constituent_data_product_ids,
+        "rejected_data_product_ids": rejected_data_product_ids,
+        "composite_fingerprint": composite_fingerprint,
+        "validation_status": "VALID",
+        "eligibility": "NONE",
+        "created_at": now,
+        "updated_at": now,
+    }
+
+    if telescope is not None:
+        item["telescope"] = telescope
+    if composite_s3_key is not None:
+        item["composite_s3_key"] = composite_s3_key
+    if web_ready_s3_key is not None:
+        item["web_ready_s3_key"] = web_ready_s3_key
+
+    table.put_item(Item=item)
+
+    _logger.info(
+        "Wrote composite DataProduct",
+        extra={
+            "nova_id": nova_id,
+            "composite_id": composite_id,
+            "instrument": instrument,
+            "n_constituents": len(constituent_data_product_ids),
+            "n_rejected": len(rejected_data_product_ids),
+            "degenerate": composite_s3_key is None,
+        },
+    )
+
+
+def _to_decimal(value: float) -> Any:
+    """Convert a float to Decimal for DynamoDB storage."""
+    from decimal import Decimal
+
+    return Decimal(str(value))
+
+
+# ---------------------------------------------------------------------------
+# S3 writes + LTTB downsampling
+# ---------------------------------------------------------------------------
+
+
+def persist_composite_csvs(
+    s3_client: Any,
+    bucket: str,
+    nova_id: str,
+    composite_id: str,
+    grid_wavelengths: NDArray[np.float64],
+    combined_fluxes: NDArray[np.float64],
+) -> tuple[str, str]:
+    """Write composite_full.csv and web_ready.csv to S3.
+
+    The full-resolution CSV is persisted so that LTTB threshold changes
+    don't require recompositing from FITS.  The web-ready CSV is
+    LTTB-downsampled to ≤ 2000 points for the spectra generator.
+
+    Parameters
+    ----------
+    s3_client:
+        Boto3 S3 client.
+    bucket:
+        Private data bucket name.
+    nova_id:
+        Nova UUID string.
+    composite_id:
+        Composite UUID string.
+    grid_wavelengths:
+        Common wavelength grid (nm).
+    combined_fluxes:
+        Median-combined flux array on the common grid.
+
+    Returns
+    -------
+    tuple[str, str]:
+        ``(composite_s3_key, web_ready_s3_key)`` — the S3 keys written.
+    """
+    prefix = f"derived/spectra/{nova_id}/{composite_id}"
+    composite_s3_key = f"{prefix}/composite_full.csv"
+    web_ready_s3_key = f"{prefix}/web_ready.csv"
+
+    # Full-resolution composite.
+    full_csv = composite_to_csv(grid_wavelengths, combined_fluxes)
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=composite_s3_key,
+        Body=full_csv.encode("utf-8"),
+        ContentType="text/csv",
+    )
+
+    # LTTB-downsampled web-ready composite.
+    web_wl, web_fx = _lttb_downsample(grid_wavelengths, combined_fluxes)
+    web_csv = composite_to_csv(
+        np.asarray(web_wl, dtype=np.float64),
+        np.asarray(web_fx, dtype=np.float64),
+    )
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=web_ready_s3_key,
+        Body=web_csv.encode("utf-8"),
+        ContentType="text/csv",
+    )
+
+    _logger.info(
+        "Persisted composite CSVs to S3",
+        extra={
+            "nova_id": nova_id,
+            "composite_id": composite_id,
+            "composite_s3_key": composite_s3_key,
+            "web_ready_s3_key": web_ready_s3_key,
+            "full_points": len(grid_wavelengths),
+            "web_ready_points": len(web_wl),
+        },
+    )
+
+    return composite_s3_key, web_ready_s3_key
+
+
+def _lttb_downsample(
+    wavelengths: NDArray[np.float64],
+    fluxes: NDArray[np.float64],
+) -> tuple[list[float], list[float]]:
+    """Downsample a composite spectrum to ≤ 2000 points via LTTB.
+
+    Strips NaN values before downsampling (LTTB expects a clean array),
+    then delegates to ``segment_aware_lttb`` from shared.py.
+
+    Parameters
+    ----------
+    wavelengths:
+        Common grid wavelength array (nm).
+    fluxes:
+        Combined flux array (may contain NaN at no-coverage grid
+        points).
+
+    Returns
+    -------
+    tuple[list[float], list[float]]:
+        ``(wavelengths, fluxes)`` downsampled to ≤ 2000 points.
+    """
+    from generators.shared import segment_aware_lttb
+
+    # Strip NaN values — LTTB operates on clean arrays.
+    mask = np.isfinite(fluxes)
+    clean_wl = wavelengths[mask].tolist()
+    clean_fx = fluxes[mask].tolist()
+
+    return segment_aware_lttb(clean_wl, clean_fx)
+
+
+# ---------------------------------------------------------------------------
+# Sweep result type
+# ---------------------------------------------------------------------------
+
+
+class CompositingSweepResult(TypedDict):
+    """Summary of a compositing sweep for one nova."""
+
+    groups_found: int
+    skipped: int
+    built: int
+    degenerate: int
+    errors: int
+
+
+# ---------------------------------------------------------------------------
+# D1 — Sweep orchestration
+# ---------------------------------------------------------------------------
+
+
+def run_compositing_sweep(
+    nova_id: str,
+    table: Any,
+    s3_client: Any,
+    bucket: str,
+) -> CompositingSweepResult:
+    """Run the compositing sweep for a single nova.
+
+    Implements the full rebuild decision tree: identify compositing
+    groups, check fingerprints against existing composites, and build
+    or skip as appropriate.  Called by ``main.py`` as Phase 1 before
+    the per-nova artifact generators run.
+
+    Parameters
+    ----------
+    nova_id:
+        Nova UUID string.
+    table:
+        Boto3 DynamoDB Table resource.
+    s3_client:
+        Boto3 S3 client.
+    bucket:
+        Private data bucket name.
+
+    Returns
+    -------
+    CompositingSweepResult:
+        Counts of groups found, skipped, built, degenerate, and errors.
+    """
+
+    result = CompositingSweepResult(
+        groups_found=0,
+        skipped=0,
+        built=0,
+        degenerate=0,
+        errors=0,
+    )
+
+    # 1. Query DDB for individual spectra and existing composites.
+    individuals = find_compositable_products(table, nova_id)
+    if len(individuals) < 2:
+        return result
+
+    existing_composites = find_existing_composites(table, nova_id)
+
+    # Index existing composites by fingerprint for O(1) lookup.
+    existing_by_fp: dict[str, dict[str, Any]] = {
+        str(c["composite_fingerprint"]): c
+        for c in existing_composites
+        if "composite_fingerprint" in c
+    }
+
+    # 2. Group by instrument + night.
+    groups = identify_compositing_groups(individuals)
+    result["groups_found"] = len(groups)
+
+    if not groups:
+        return result
+
+    # 3. Process each group.
+    for group in groups:
+        try:
+            _process_compositing_group(
+                nova_id=nova_id,
+                group=group,
+                existing_by_fp=existing_by_fp,
+                table=table,
+                s3_client=s3_client,
+                bucket=bucket,
+                result=result,
+            )
+        except Exception:
+            _logger.warning(
+                "Error processing compositing group",
+                extra={
+                    "nova_id": nova_id,
+                    "instrument": group["instrument"],
+                    "group_size": len(group["products"]),
+                },
+                exc_info=True,
+            )
+            result["errors"] += 1
+
+    _logger.info(
+        "Compositing sweep complete",
+        extra={"nova_id": nova_id, **result},
+    )
+
+    return result
+
+
+def _process_compositing_group(
+    nova_id: str,
+    group: CompositingGroup,
+    existing_by_fp: dict[str, dict[str, Any]],
+    table: Any,
+    s3_client: Any,
+    bucket: str,
+    result: CompositingSweepResult,
+) -> None:
+    """Process a single compositing group through the rebuild decision tree.
+
+    Mutates *result* in place to track counts.
+    """
+    from generators.fits_reader import read_fits_spectrum
+
+    products = group["products"]
+    instrument = group["instrument"]
+
+    # Compute fingerprint from all group members.
+    member_ids = [str(p["data_product_id"]) for p in products]
+    sha256_map = {str(p["data_product_id"]): str(p["sha256"]) for p in products}
+    fingerprint = compute_composite_fingerprint(member_ids, sha256_map)
+
+    # Fingerprint check — skip if unchanged.
+    if fingerprint in existing_by_fp:
+        _logger.debug(
+            "Compositing group unchanged, skipping",
+            extra={
+                "nova_id": nova_id,
+                "instrument": instrument,
+                "fingerprint": fingerprint[:16],
+            },
+        )
+        result["skipped"] += 1
+        return
+
+    # --- Fingerprint miss: read FITS and evaluate threshold. ---
+
+    # Read FITS for each group member, check native point counts.
+    constituents: list[dict[str, Any]] = []
+    rejected: list[dict[str, Any]] = []
+
+    for product in products:
+        dp_id = str(product["data_product_id"])
+        raw_key = product.get("raw_s3_key")
+        raw_bucket = product.get("raw_s3_bucket", bucket)
+
+        if not raw_key:
+            _logger.warning(
+                "No raw_s3_key on DataProduct, skipping for compositing",
+                extra={"data_product_id": dp_id},
+            )
+            rejected.append(product)
+            continue
+
+        _logger.info("Reading FITS for compositing", extra={"data_product_id": dp_id})
+        fits_result = read_fits_spectrum(s3_client, raw_bucket, raw_key, dp_id)
+        if fits_result is None:
+            _logger.warning(
+                "Could not read FITS for compositing",
+                extra={"data_product_id": dp_id},
+            )
+            rejected.append(product)
+            continue
+
+        wavelengths, fluxes = fits_result
+        if len(wavelengths) < MIN_POINTS_FOR_COMPOSITE:
+            _logger.debug(
+                "Spectrum below compositing threshold",
+                extra={
+                    "data_product_id": dp_id,
+                    "n_points": len(wavelengths),
+                    "threshold": MIN_POINTS_FOR_COMPOSITE,
+                },
+            )
+            rejected.append(product)
+            continue
+
+        # Attach raw arrays for downstream processing.
+        product["_raw_wavelengths"] = wavelengths
+        product["_raw_fluxes"] = fluxes
+        constituents.append(product)
+
+    constituent_ids = sorted(str(p["data_product_id"]) for p in constituents)
+    rejected_ids = sorted(str(p["data_product_id"]) for p in rejected)
+
+    # Shared metadata from the group.
+    provider = str(products[0]["provider"])
+    telescope = products[0].get("telescope")
+    if telescope is not None:
+        telescope = str(telescope)
+    mean_mjd = float(np.mean([float(p["observation_date_mjd"]) for p in products]))
+
+    # --- Degenerate case: 0 or 1 constituents. ---
+    if len(constituents) < 2:
+        if len(constituents) == 1:
+            # Degenerate composite — point at the survivor's web-ready CSV.
+            survivor = constituents[0]
+            survivor_id = str(survivor["data_product_id"])
+            composite_id = compute_composite_id([survivor_id])
+
+            # Build the web_ready_s3_key from the survivor's existing CSV.
+            survivor_web_ready = f"derived/spectra/{nova_id}/{survivor_id}/web_ready.csv"
+
+            write_composite_data_product(
+                table=table,
+                nova_id=nova_id,
+                composite_id=composite_id,
+                provider=provider,
+                instrument=instrument,
+                telescope=telescope,
+                observation_date_mjd=mean_mjd,
+                constituent_data_product_ids=constituent_ids,
+                rejected_data_product_ids=rejected_ids,
+                composite_fingerprint=fingerprint,
+                composite_s3_key=None,
+                web_ready_s3_key=survivor_web_ready,
+            )
+            result["degenerate"] += 1
+        # else: 0 constituents — nothing to do, all rejected.
+        return
+
+    # --- Real composite: ≥ 2 constituents. ---
+    composite_id = compute_composite_id(constituent_ids)
+
+    # Clean each constituent.
+    cleaned_spectra: list[CleanedSpectrum] = []
+    for product in constituents:
+        dp_id = str(product["data_product_id"])
+        cleaned = clean_spectrum(
+            dp_id,
+            product["_raw_wavelengths"],
+            product["_raw_fluxes"],
+        )
+        if cleaned is None:
+            _logger.warning(
+                "Cleaning eliminated all points",
+                extra={"data_product_id": dp_id},
+            )
+            continue
+        cleaned_spectra.append(cleaned)
+
+    if len(cleaned_spectra) < 2:
+        _logger.warning(
+            "Fewer than 2 spectra survived cleaning, skipping composite",
+            extra={
+                "nova_id": nova_id,
+                "instrument": instrument,
+                "cleaned_count": len(cleaned_spectra),
+            },
+        )
+        return
+
+    # Resample onto common grid.
+    grid = determine_common_grid(cleaned_spectra)
+    resampled = [resample_to_grid(spec, grid) for spec in cleaned_spectra]
+
+    # Combine via median.
+    combined = combine_spectra(resampled)
+
+    # Persist CSVs to S3.
+    composite_s3_key, web_ready_s3_key = persist_composite_csvs(
+        s3_client,
+        bucket,
+        nova_id,
+        composite_id,
+        grid,
+        combined,
+    )
+
+    # Write composite DataProduct to DDB.
+    write_composite_data_product(
+        table=table,
+        nova_id=nova_id,
+        composite_id=composite_id,
+        provider=provider,
+        instrument=instrument,
+        telescope=telescope,
+        observation_date_mjd=mean_mjd,
+        constituent_data_product_ids=constituent_ids,
+        rejected_data_product_ids=rejected_ids,
+        composite_fingerprint=fingerprint,
+        composite_s3_key=composite_s3_key,
+        web_ready_s3_key=web_ready_s3_key,
+    )
+    result["built"] += 1

--- a/services/artifact_generator/generators/fits_reader.py
+++ b/services/artifact_generator/generators/fits_reader.py
@@ -80,6 +80,12 @@ def extract_spectrum_from_fits(
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]] | None:
     """Extract wavelength and flux arrays from in-memory FITS bytes.
 
+    Tries three strategies in order:
+    1. Primary HDU (hdul[0]) image data + WCS wavelength keywords.
+    2. First extension (hdul[1]) image data + WCS (common for ESO
+       UVES/X-Shooter where the primary HDU is header-only).
+    3. Binary table extension with named wavelength/flux columns.
+
     Separated from ``read_fits_spectrum`` so it can be tested with
     synthetic FITS data without mocking S3.
 
@@ -97,36 +103,31 @@ def extract_spectrum_from_fits(
     """
     try:
         with fits.open(io.BytesIO(fits_bytes), memmap=False) as hdul:
-            header = hdul[0].header  # type: ignore[index]
-            flux_data = hdul[0].data  # type: ignore[index]
+            # --- Strategy 1: Primary HDU image data + WCS ---
+            primary_data = hdul[0].data  # type: ignore[index]
+            if primary_data is not None and primary_data.ndim > 0:
+                return _extract_from_image_hdu(hdul, 0, data_product_id)
 
-            if flux_data is None or flux_data.ndim == 0:
-                _logger.warning(
-                    "FITS primary HDU has no data array",
-                    extra={"data_product_id": data_product_id},
-                )
-                return None
+            # --- Strategy 2: First extension image data + WCS ---
+            # Many ESO products (UVES, X-Shooter) store the spectrum
+            # in hdul[1] with the same image+WCS layout.  Only attempt
+            # this on ImageHDUs — BinTableHDUs fall through to Strategy 3.
+            if len(hdul) > 1 and isinstance(hdul[1], fits.ImageHDU | fits.CompImageHDU):
+                ext1_data = hdul[1].data
+                if ext1_data is not None and ext1_data.ndim > 0:
+                    result = _extract_from_image_hdu(hdul, 1, data_product_id)
+                    if result is not None:
+                        return result
 
-            # Flatten if the data has extra degenerate dimensions
-            # (some ESO products have shape (1, 1, N)).
-            flux = flux_data.squeeze()
-            if flux.ndim != 1:
-                _logger.warning(
-                    "FITS flux array is not 1-D after squeeze",
-                    extra={
-                        "data_product_id": data_product_id,
-                        "shape": str(flux_data.shape),
-                    },
-                )
-                return None
+            # --- Strategy 3: Binary table extension with named columns ---
+            if len(hdul) > 1:
+                return _extract_from_table_hdu(hdul, data_product_id)
 
-            # Build wavelength array from WCS.
-            wavelengths_nm = _wavelengths_from_wcs(header, len(flux), data_product_id)
-            if wavelengths_nm is None:
-                return None
-
-            flux_arr = np.asarray(flux, dtype=np.float64)
-            return wavelengths_nm, flux_arr
+            _logger.warning(
+                "FITS has no image data and no table extensions",
+                extra={"data_product_id": data_product_id},
+            )
+            return None
 
     except Exception:
         _logger.warning(
@@ -135,6 +136,154 @@ def extract_spectrum_from_fits(
             exc_info=True,
         )
         return None
+
+
+#: Column name candidates for wavelength and flux in binary table HDUs.
+#: Tried in order; first match wins.
+_WAVELENGTH_COLUMNS = ("WAVE", "WAVELENGTH", "LAMBDA", "wave", "wavelength", "lambda")
+_FLUX_COLUMNS = ("FLUX", "FLUX_REDUCED", "DATA", "FLUX_OPTIMAL", "flux", "data")
+
+
+def _extract_from_image_hdu(
+    hdul: Any,
+    ext_idx: int,
+    data_product_id: str,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]] | None:
+    """Extract spectrum from an image HDU with data + WCS."""
+    header = hdul[ext_idx].header  # type: ignore[index]
+    flux_data = hdul[ext_idx].data  # type: ignore[index]
+
+    flux = flux_data.squeeze()
+    if flux.ndim != 1:
+        _logger.warning(
+            "FITS flux array is not 1-D after squeeze",
+            extra={
+                "data_product_id": data_product_id,
+                "shape": str(flux_data.shape),
+            },
+        )
+        return None
+
+    wavelengths_nm = _wavelengths_from_wcs(header, len(flux), data_product_id)
+    if wavelengths_nm is None:
+        return None
+
+    return wavelengths_nm, np.asarray(flux, dtype=np.float64)
+
+
+def _extract_from_table_hdu(
+    hdul: Any,
+    data_product_id: str,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]] | None:
+    """Extract spectrum from a binary table extension with named columns."""
+    # Search extensions for a table with recognisable wavelength + flux columns.
+    for ext_idx in range(1, len(hdul)):
+        ext = hdul[ext_idx]
+        if not hasattr(ext, "columns"):
+            continue
+
+        col_names = [c.name for c in ext.columns]
+
+        wl_col = _find_column(col_names, _WAVELENGTH_COLUMNS)
+        fx_col = _find_column(col_names, _FLUX_COLUMNS)
+
+        if wl_col is None or fx_col is None:
+            continue
+
+        wl_raw = np.asarray(ext.data[wl_col], dtype=np.float64).squeeze()
+        fx_raw = np.asarray(ext.data[fx_col], dtype=np.float64).squeeze()
+
+        if wl_raw.ndim != 1 or fx_raw.ndim != 1:
+            _logger.warning(
+                "Binary table columns are not 1-D after squeeze",
+                extra={
+                    "data_product_id": data_product_id,
+                    "ext_index": ext_idx,
+                    "wl_shape": str(wl_raw.shape),
+                    "fx_shape": str(fx_raw.shape),
+                },
+            )
+            continue
+
+        if len(wl_raw) != len(fx_raw):
+            _logger.warning(
+                "Wavelength and flux columns have different lengths",
+                extra={
+                    "data_product_id": data_product_id,
+                    "wl_len": len(wl_raw),
+                    "fx_len": len(fx_raw),
+                },
+            )
+            continue
+
+        # Convert wavelength to nm.  Binary table wavelengths are
+        # typically in Angstrom for ESO products.  Check the header
+        # for a unit hint.
+        wl_nm = _convert_table_wavelengths_to_nm(wl_raw, hdul[ext_idx].header, data_product_id)
+
+        _logger.debug(
+            "Extracted spectrum from binary table extension",
+            extra={
+                "data_product_id": data_product_id,
+                "ext_index": ext_idx,
+                "wl_col": wl_col,
+                "fx_col": fx_col,
+                "n_points": len(wl_nm),
+            },
+        )
+        return wl_nm, fx_raw
+
+    _logger.warning(
+        "No binary table extension with recognisable wavelength/flux columns",
+        extra={"data_product_id": data_product_id},
+    )
+    return None
+
+
+def _find_column(
+    available: list[str],
+    candidates: tuple[str, ...],
+) -> str | None:
+    """Return the first candidate name present in *available*, or None."""
+    for name in candidates:
+        if name in available:
+            return name
+    return None
+
+
+def _convert_table_wavelengths_to_nm(
+    wavelengths: NDArray[np.float64],
+    header: Any,
+    data_product_id: str,
+) -> NDArray[np.float64]:
+    """Convert binary table wavelengths to nm.
+
+    Checks ``TUNIT`` keywords and common header hints.  Falls back
+    to assuming Angstrom if no unit metadata is found.
+    """
+    # Check TUNITn keywords for the wavelength column.
+    for key in header:
+        if key.startswith("TUNIT"):
+            val = str(header[key]).strip().lower()
+            if val in ("angstrom", "angstroms", "ang", "a"):
+                return wavelengths / 10.0
+            if val in ("nm", "nanometer", "nanometers", "nanometre"):
+                return wavelengths
+            if val in ("m", "meter", "metre"):
+                return wavelengths * 1e9
+
+    # Heuristic: if median wavelength is > 100, it's probably Angstrom.
+    median_wl = float(np.median(wavelengths))
+    if median_wl > 100.0:
+        _logger.debug(
+            "No wavelength unit in table header; assuming Angstrom (median=%.1f)",
+            median_wl,
+            extra={"data_product_id": data_product_id},
+        )
+        return wavelengths / 10.0
+
+    # Already in nm (or something exotic — best guess is nm).
+    return wavelengths
 
 
 def _wavelengths_from_wcs(

--- a/services/artifact_generator/generators/fits_reader.py
+++ b/services/artifact_generator/generators/fits_reader.py
@@ -1,0 +1,191 @@
+"""FITS spectrum reader for the compositing pipeline.
+
+Downloads a raw FITS file from S3 and extracts the wavelength and
+flux arrays needed for compositing.  Wavelengths are returned in nm
+regardless of the unit stored in the FITS header (handled via astropy
+WCS and unit conversion).
+
+This is the only module in the compositing pipeline that touches S3.
+All downstream processing (cleaning, resampling, combination) operates
+on the numpy arrays returned here.
+
+See ADR-033 for design rationale.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import Any
+
+import astropy.units as u
+import numpy as np
+from astropy.io import fits
+from astropy.wcs import WCS
+from numpy.typing import NDArray
+
+_logger = logging.getLogger(__name__)
+
+
+def read_fits_spectrum(
+    s3_client: Any,
+    bucket: str,
+    raw_s3_key: str,
+    data_product_id: str,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]] | None:
+    """Download a FITS file from S3 and extract wavelength + flux arrays.
+
+    Wavelengths are converted to nanometres using the WCS unit metadata
+    in the FITS header (``CUNIT1``).  If no unit is specified, Ångströms
+    are assumed (the ESO default).
+
+    Parameters
+    ----------
+    s3_client:
+        Boto3 S3 client (not resource).
+    bucket:
+        Private data bucket name.
+    raw_s3_key:
+        S3 key for the raw FITS file.
+    data_product_id:
+        For logging context.
+
+    Returns
+    -------
+    tuple[NDArray, NDArray] | None:
+        ``(wavelengths_nm, fluxes)`` as float64 arrays, or ``None`` if
+        the FITS file could not be read or contains no usable data.
+    """
+    try:
+        resp = s3_client.get_object(Bucket=bucket, Key=raw_s3_key)
+        fits_bytes = resp["Body"].read()
+    except Exception:
+        _logger.warning(
+            "Failed to download FITS from S3",
+            extra={
+                "data_product_id": data_product_id,
+                "bucket": bucket,
+                "raw_s3_key": raw_s3_key,
+            },
+            exc_info=True,
+        )
+        return None
+
+    return extract_spectrum_from_fits(fits_bytes, data_product_id)
+
+
+def extract_spectrum_from_fits(
+    fits_bytes: bytes,
+    data_product_id: str,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]] | None:
+    """Extract wavelength and flux arrays from in-memory FITS bytes.
+
+    Separated from ``read_fits_spectrum`` so it can be tested with
+    synthetic FITS data without mocking S3.
+
+    Parameters
+    ----------
+    fits_bytes:
+        Raw FITS file contents.
+    data_product_id:
+        For logging context.
+
+    Returns
+    -------
+    tuple[NDArray, NDArray] | None:
+        ``(wavelengths_nm, fluxes)`` or ``None`` on failure.
+    """
+    try:
+        with fits.open(io.BytesIO(fits_bytes), memmap=False) as hdul:
+            header = hdul[0].header  # type: ignore[index]
+            flux_data = hdul[0].data  # type: ignore[index]
+
+            if flux_data is None or flux_data.ndim == 0:
+                _logger.warning(
+                    "FITS primary HDU has no data array",
+                    extra={"data_product_id": data_product_id},
+                )
+                return None
+
+            # Flatten if the data has extra degenerate dimensions
+            # (some ESO products have shape (1, 1, N)).
+            flux = flux_data.squeeze()
+            if flux.ndim != 1:
+                _logger.warning(
+                    "FITS flux array is not 1-D after squeeze",
+                    extra={
+                        "data_product_id": data_product_id,
+                        "shape": str(flux_data.shape),
+                    },
+                )
+                return None
+
+            # Build wavelength array from WCS.
+            wavelengths_nm = _wavelengths_from_wcs(header, len(flux), data_product_id)
+            if wavelengths_nm is None:
+                return None
+
+            flux_arr = np.asarray(flux, dtype=np.float64)
+            return wavelengths_nm, flux_arr
+
+    except Exception:
+        _logger.warning(
+            "Failed to parse FITS file",
+            extra={"data_product_id": data_product_id},
+            exc_info=True,
+        )
+        return None
+
+
+def _wavelengths_from_wcs(
+    header: Any,
+    n_pixels: int,
+    data_product_id: str,
+) -> NDArray[np.float64] | None:
+    """Reconstruct the wavelength array from FITS WCS header keywords.
+
+    Uses astropy's WCS to handle the pixel → world coordinate
+    transformation, including unit conversion to nm.  Falls back to
+    assuming Ångströms if ``CUNIT1`` is absent.
+
+    Parameters
+    ----------
+    header:
+        FITS primary HDU header.
+    n_pixels:
+        Length of the flux array (``NAXIS1``).
+    data_product_id:
+        For logging context.
+
+    Returns
+    -------
+    NDArray[np.float64] | None:
+        Wavelength array in nm, or ``None`` if WCS reconstruction fails.
+    """
+    try:
+        wcs = WCS(header, naxis=1)
+        pixel_indices = np.arange(n_pixels)
+        wavelengths_raw = wcs.pixel_to_world(pixel_indices)
+
+        # pixel_to_world returns an astropy Quantity if the WCS has a
+        # recognised spectral axis, or a plain ndarray if CUNIT1 is
+        # missing.
+        if hasattr(wavelengths_raw, "unit"):
+            wavelengths_nm = wavelengths_raw.to(u.nm).value
+        else:
+            # No unit metadata — assume Ångströms (ESO default).
+            _logger.debug(
+                "No CUNIT1 in FITS header; assuming Angstrom",
+                extra={"data_product_id": data_product_id},
+            )
+            wavelengths_nm = np.asarray(wavelengths_raw, dtype=np.float64) / 10.0
+
+        return np.asarray(wavelengths_nm, dtype=np.float64)
+
+    except Exception:
+        _logger.warning(
+            "Failed to reconstruct wavelengths from WCS",
+            extra={"data_product_id": data_product_id},
+            exc_info=True,
+        )
+        return None

--- a/services/artifact_generator/generators/spectra.py
+++ b/services/artifact_generator/generators/spectra.py
@@ -93,6 +93,13 @@ def generate_spectra_json(
     # Step 1 — Query VALID spectra DataProduct items.
     products = _query_valid_spectra(nova_id, table)
 
+    # Capture individual (non-composite) products before filtering.
+    # Used for the observation table, which shows all original spectra.
+    individual_products = [p for p in products if "COMPOSITE" not in p.get("SK", "")]
+
+    # Step 1b — Post-query filtering: composites replace their constituents.
+    products = _filter_composites(products)
+
     # Step 2a — First pass: parse CSV + trim dead edges for each spectrum.
     parsed: list[dict[str, Any]] = []
     for product in products:
@@ -194,9 +201,11 @@ def generate_spectra_json(
     # Step 3 — Sort by epoch ascending (oldest at bottom of waterfall).
     spectra.sort(key=lambda s: s["epoch_mjd"])
 
-    # Step 4 — Build observations list from raw products.
+    # Step 4 — Build observations list from individual (pre-filter) products.
+    # ADR-033 Decision 5: individual spectra remain visible in the observation
+    # table even when replaced by composites in the waterfall plot.
     observations_list: list[dict[str, Any]] = []
-    for product in products:
+    for product in individual_products:
         obs: dict[str, Any] = {
             "data_product_id": product["data_product_id"],
             "instrument": product.get("instrument") or "Unknown",
@@ -219,13 +228,13 @@ def generate_spectra_json(
     observations_list.sort(key=lambda o: o["epoch_mjd"])
 
     # Step 5 — Update context.
-    nova_context["spectra_count"] = len(products)
+    nova_context["spectra_count"] = len(individual_products)
 
     # Group by integer MJD (floor) to count distinct nights.
     distinct_nights = len(
         {
             int(float(p["observation_date_mjd"]))
-            for p in products
+            for p in individual_products
             if p.get("observation_date_mjd") is not None
         }
     )
@@ -235,7 +244,7 @@ def generate_spectra_json(
         "Generated spectra.json",
         extra={
             "nova_id": nova_id,
-            "valid_products": len(products),
+            "valid_products": len(individual_products),
             "spectra_output": len(spectra),
             "phase": "generate_spectra",
         },
@@ -248,7 +257,7 @@ def generate_spectra_json(
         "outburst_mjd": outburst_mjd,
         "outburst_mjd_is_estimated": outburst_mjd_is_estimated,
         "wavelength_unit": _WAVELENGTH_UNIT,
-        "total_data_products": len(products),
+        "total_data_products": len(individual_products),
         "observations": observations_list,
         "spectra": spectra,
     }
@@ -288,6 +297,35 @@ def _query_valid_spectra(
 
 
 # ---------------------------------------------------------------------------
+# Composite filtering
+# ---------------------------------------------------------------------------
+
+
+def _filter_composites(products: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Filter products so composites replace their constituent/rejected spectra.
+
+    Composites are identified by having ``"COMPOSITE"`` in their ``SK`` field.
+    Their ``constituent_data_product_ids`` and ``rejected_data_product_ids``
+    lists define a suppression set — individual spectra in that set are excluded
+    from the display set.
+    """
+    composites = [p for p in products if "COMPOSITE" in p.get("SK", "")]
+    if not composites:
+        return products
+
+    suppression_set: set[str] = set()
+    for comp in composites:
+        suppression_set.update(comp.get("constituent_data_product_ids", []))
+        suppression_set.update(comp.get("rejected_data_product_ids", []))
+
+    return [
+        p
+        for p in products
+        if "COMPOSITE" in p.get("SK", "") or p["data_product_id"] not in suppression_set
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Per-spectrum processing
 # ---------------------------------------------------------------------------
 
@@ -304,7 +342,11 @@ def _process_spectrum_stage1(
     original product metadata, or ``None`` to skip this spectrum.
     """
     data_product_id: str = product["data_product_id"]
-    s3_key = f"derived/spectra/{nova_id}/{data_product_id}/web_ready.csv"
+    # Composites store their S3 key directly; individuals use the convention.
+    if "COMPOSITE" in product.get("SK", ""):
+        s3_key = product["web_ready_s3_key"]
+    else:
+        s3_key = f"derived/spectra/{nova_id}/{data_product_id}/web_ready.csv"
 
     # --- S3 read ---
     try:

--- a/services/artifact_generator/main.py
+++ b/services/artifact_generator/main.py
@@ -438,6 +438,32 @@ def _process_nova(
                 nova_id, _table, _dynamodb
             )
 
+        # --- Phase 1: Spectra compositing sweep (ADR-033) ---
+        dirty_types: list[str] = manifest.get("dirty_types", [])
+        if "spectra" in dirty_types:
+            try:
+                from generators.compositing import run_compositing_sweep
+
+                sweep_result = run_compositing_sweep(nova_id, _table, _s3, _PRIVATE_BUCKET)
+                _logger.info(
+                    "Compositing sweep completed",
+                    extra={
+                        "nova_id": nova_id,
+                        "primary_name": primary_name,
+                        "groups_found": sweep_result["groups_found"],
+                        "skipped": sweep_result["skipped"],
+                        "built": sweep_result["built"],
+                        "degenerate": sweep_result["degenerate"],
+                        "errors": sweep_result["errors"],
+                    },
+                )
+            except Exception:
+                _logger.warning(
+                    "Compositing sweep failed — continuing with artifact generation",
+                    extra={"nova_id": nova_id, "primary_name": primary_name},
+                    exc_info=True,
+                )
+
         # --- Generate and publish artifacts in dependency order ---
         generated_artifacts: set[str] = set()
         failed_artifacts: list[str] = []

--- a/tests/services/artifact_generator/fits_reader.py
+++ b/tests/services/artifact_generator/fits_reader.py
@@ -1,0 +1,191 @@
+"""FITS spectrum reader for the compositing pipeline.
+
+Downloads a raw FITS file from S3 and extracts the wavelength and
+flux arrays needed for compositing.  Wavelengths are returned in nm
+regardless of the unit stored in the FITS header (handled via astropy
+WCS and unit conversion).
+
+This is the only module in the compositing pipeline that touches S3.
+All downstream processing (cleaning, resampling, combination) operates
+on the numpy arrays returned here.
+
+See ADR-033 for design rationale.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import Any
+
+import astropy.units as u
+import numpy as np
+from astropy.io import fits
+from astropy.wcs import WCS
+from numpy.typing import NDArray
+
+_logger = logging.getLogger(__name__)
+
+
+def read_fits_spectrum(
+    s3_client: Any,
+    bucket: str,
+    raw_s3_key: str,
+    data_product_id: str,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]] | None:
+    """Download a FITS file from S3 and extract wavelength + flux arrays.
+
+    Wavelengths are converted to nanometres using the WCS unit metadata
+    in the FITS header (``CUNIT1``).  If no unit is specified, Ångströms
+    are assumed (the ESO default).
+
+    Parameters
+    ----------
+    s3_client:
+        Boto3 S3 client (not resource).
+    bucket:
+        Private data bucket name.
+    raw_s3_key:
+        S3 key for the raw FITS file.
+    data_product_id:
+        For logging context.
+
+    Returns
+    -------
+    tuple[NDArray, NDArray] | None:
+        ``(wavelengths_nm, fluxes)`` as float64 arrays, or ``None`` if
+        the FITS file could not be read or contains no usable data.
+    """
+    try:
+        resp = s3_client.get_object(Bucket=bucket, Key=raw_s3_key)
+        fits_bytes = resp["Body"].read()
+    except Exception:
+        _logger.warning(
+            "Failed to download FITS from S3",
+            extra={
+                "data_product_id": data_product_id,
+                "bucket": bucket,
+                "raw_s3_key": raw_s3_key,
+            },
+            exc_info=True,
+        )
+        return None
+
+    return extract_spectrum_from_fits(fits_bytes, data_product_id)
+
+
+def extract_spectrum_from_fits(
+    fits_bytes: bytes,
+    data_product_id: str,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]] | None:
+    """Extract wavelength and flux arrays from in-memory FITS bytes.
+
+    Separated from ``read_fits_spectrum`` so it can be tested with
+    synthetic FITS data without mocking S3.
+
+    Parameters
+    ----------
+    fits_bytes:
+        Raw FITS file contents.
+    data_product_id:
+        For logging context.
+
+    Returns
+    -------
+    tuple[NDArray, NDArray] | None:
+        ``(wavelengths_nm, fluxes)`` or ``None`` on failure.
+    """
+    try:
+        with fits.open(io.BytesIO(fits_bytes), memmap=False) as hdul:
+            header = hdul[0].header  # type: ignore[index]
+            flux_data = hdul[0].data  # type: ignore[index]
+
+            if flux_data is None or flux_data.ndim == 0:
+                _logger.warning(
+                    "FITS primary HDU has no data array",
+                    extra={"data_product_id": data_product_id},
+                )
+                return None
+
+            # Flatten if the data has extra degenerate dimensions
+            # (some ESO products have shape (1, 1, N)).
+            flux = flux_data.squeeze()
+            if flux.ndim != 1:
+                _logger.warning(
+                    "FITS flux array is not 1-D after squeeze",
+                    extra={
+                        "data_product_id": data_product_id,
+                        "shape": str(flux_data.shape),
+                    },
+                )
+                return None
+
+            # Build wavelength array from WCS.
+            wavelengths_nm = _wavelengths_from_wcs(header, len(flux), data_product_id)
+            if wavelengths_nm is None:
+                return None
+
+            flux_arr = np.asarray(flux, dtype=np.float64)
+            return wavelengths_nm, flux_arr
+
+    except Exception:
+        _logger.warning(
+            "Failed to parse FITS file",
+            extra={"data_product_id": data_product_id},
+            exc_info=True,
+        )
+        return None
+
+
+def _wavelengths_from_wcs(
+    header: Any,
+    n_pixels: int,
+    data_product_id: str,
+) -> NDArray[np.float64] | None:
+    """Reconstruct the wavelength array from FITS WCS header keywords.
+
+    Uses astropy's WCS to handle the pixel → world coordinate
+    transformation, including unit conversion to nm.  Falls back to
+    assuming Ångströms if ``CUNIT1`` is absent.
+
+    Parameters
+    ----------
+    header:
+        FITS primary HDU header.
+    n_pixels:
+        Length of the flux array (``NAXIS1``).
+    data_product_id:
+        For logging context.
+
+    Returns
+    -------
+    NDArray[np.float64] | None:
+        Wavelength array in nm, or ``None`` if WCS reconstruction fails.
+    """
+    try:
+        wcs = WCS(header, naxis=1)
+        pixel_indices = np.arange(n_pixels)
+        wavelengths_raw = wcs.pixel_to_world(pixel_indices)
+
+        # pixel_to_world returns an astropy Quantity if the WCS has a
+        # recognised spectral axis, or a plain ndarray if CUNIT1 is
+        # missing.
+        if hasattr(wavelengths_raw, "unit"):
+            wavelengths_nm = wavelengths_raw.to(u.nm).value
+        else:
+            # No unit metadata — assume Ångströms (ESO default).
+            _logger.debug(
+                "No CUNIT1 in FITS header; assuming Angstrom",
+                extra={"data_product_id": data_product_id},
+            )
+            wavelengths_nm = np.asarray(wavelengths_raw, dtype=np.float64) / 10.0
+
+        return np.asarray(wavelengths_nm, dtype=np.float64)
+
+    except Exception:
+        _logger.warning(
+            "Failed to reconstruct wavelengths from WCS",
+            extra={"data_product_id": data_product_id},
+            exc_info=True,
+        )
+        return None

--- a/tests/services/artifact_generator/test_compositing.py
+++ b/tests/services/artifact_generator/test_compositing.py
@@ -1,0 +1,411 @@
+"""Tests for generators.compositing — pure computation utilities.
+
+Covers night clustering, compositing group identification, common grid
+determination, composite fingerprinting, and deterministic composite ID
+generation.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import numpy as np
+import pytest
+from generators.compositing import (
+    CleanedSpectrum,
+    cluster_by_night,
+    compute_composite_fingerprint,
+    compute_composite_id,
+    determine_common_grid,
+    identify_compositing_groups,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _product(
+    mjd: float | Decimal,
+    instrument: str = "UVES",
+    dp_id: str | None = None,
+) -> dict[str, Any]:
+    """Build a minimal DataProduct-like dict for testing."""
+    return {
+        "observation_date_mjd": mjd,
+        "instrument": instrument,
+        "data_product_id": dp_id or f"dp-{float(mjd):.4f}",
+    }
+
+
+def _cleaned(
+    dp_id: str,
+    wl_start: float,
+    wl_end: float,
+    n_points: int,
+) -> CleanedSpectrum:
+    """Build a CleanedSpectrum with uniform wavelength spacing."""
+    return CleanedSpectrum(
+        data_product_id=dp_id,
+        wavelengths=np.linspace(wl_start, wl_end, n_points),
+        fluxes=np.ones(n_points),
+    )
+
+
+# ===================================================================
+# cluster_by_night
+# ===================================================================
+
+
+class TestClusterByNight:
+    """Night clustering via sequential gap detection."""
+
+    def test_single_product(self) -> None:
+        """A single product forms one group of one."""
+        groups = cluster_by_night([_product(60000.5)])
+        assert len(groups) == 1
+        assert len(groups[0]) == 1
+
+    def test_two_products_same_night(self) -> None:
+        """Products within the gap threshold land in the same group."""
+        groups = cluster_by_night(
+            [
+                _product(60000.3),
+                _product(60000.5),
+            ]
+        )
+        assert len(groups) == 1
+        assert len(groups[0]) == 2
+
+    def test_two_products_different_nights(self) -> None:
+        """Products separated by more than the threshold split."""
+        groups = cluster_by_night(
+            [
+                _product(60000.3),
+                _product(60001.0),
+            ]
+        )
+        assert len(groups) == 2
+        assert len(groups[0]) == 1
+        assert len(groups[1]) == 1
+
+    def test_three_nights(self) -> None:
+        """Multiple nights are correctly separated."""
+        groups = cluster_by_night(
+            [
+                _product(60000.3),
+                _product(60000.4),
+                _product(60001.3),
+                _product(60002.3),
+                _product(60002.4),
+                _product(60002.45),
+            ]
+        )
+        assert len(groups) == 3
+        assert len(groups[0]) == 2
+        assert len(groups[1]) == 1
+        assert len(groups[2]) == 3
+
+    def test_chronological_ordering(self) -> None:
+        """Groups and their members are sorted by MJD ascending."""
+        groups = cluster_by_night(
+            [
+                _product(60002.0),
+                _product(60000.1),
+                _product(60000.3),
+            ]
+        )
+        assert len(groups) == 2
+        # First group is the earliest night.
+        assert float(groups[0][0]["observation_date_mjd"]) == pytest.approx(60000.1)
+        assert float(groups[0][1]["observation_date_mjd"]) == pytest.approx(60000.3)
+        assert float(groups[1][0]["observation_date_mjd"]) == pytest.approx(60002.0)
+
+    def test_decimal_mjd_values(self) -> None:
+        """DynamoDB returns Decimal; clustering handles it transparently."""
+        groups = cluster_by_night(
+            [
+                _product(Decimal("60000.300")),
+                _product(Decimal("60000.400")),
+                _product(Decimal("60001.500")),
+            ]
+        )
+        assert len(groups) == 2
+        assert len(groups[0]) == 2
+        assert len(groups[1]) == 1
+
+    def test_gap_exactly_at_threshold(self) -> None:
+        """A gap exactly equal to the threshold does NOT split."""
+        groups = cluster_by_night(
+            [
+                _product(60000.0),
+                _product(60000.5),
+            ]
+        )
+        assert len(groups) == 1
+
+    def test_gap_just_over_threshold(self) -> None:
+        """A gap just above the threshold does split."""
+        groups = cluster_by_night(
+            [
+                _product(60000.0),
+                _product(60000.5001),
+            ]
+        )
+        assert len(groups) == 2
+
+    def test_custom_gap_threshold(self) -> None:
+        """A tighter threshold splits observations that would otherwise group."""
+        groups = cluster_by_night(
+            [_product(60000.0), _product(60000.1)],
+            gap_threshold=0.05,
+        )
+        assert len(groups) == 2
+
+    def test_empty_raises(self) -> None:
+        """Empty input raises ValueError."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            cluster_by_night([])
+
+
+# ===================================================================
+# identify_compositing_groups
+# ===================================================================
+
+
+class TestIdentifyCompositingGroups:
+    """Instrument grouping + night clustering → compositing groups."""
+
+    def test_two_same_instrument_same_night(self) -> None:
+        """The simplest compositable case: 2 spectra, same instrument, same night."""
+        groups = identify_compositing_groups(
+            [
+                _product(60000.3, instrument="UVES"),
+                _product(60000.4, instrument="UVES"),
+            ]
+        )
+        assert len(groups) == 1
+        assert groups[0]["instrument"] == "UVES"
+        assert len(groups[0]["products"]) == 2
+
+    def test_different_instruments_not_grouped(self) -> None:
+        """Same-night spectra from different instruments are separate."""
+        groups = identify_compositing_groups(
+            [
+                _product(60000.3, instrument="UVES"),
+                _product(60000.4, instrument="XSHOOTER"),
+            ]
+        )
+        assert len(groups) == 0
+
+    def test_singletons_excluded(self) -> None:
+        """A night with only one spectrum per instrument produces no group."""
+        groups = identify_compositing_groups(
+            [
+                _product(60000.3, instrument="UVES"),
+                _product(60001.3, instrument="UVES"),
+            ]
+        )
+        assert len(groups) == 0
+
+    def test_mixed_instruments_and_nights(self) -> None:
+        """Multiple instruments across multiple nights."""
+        groups = identify_compositing_groups(
+            [
+                _product(60000.3, instrument="UVES"),
+                _product(60000.4, instrument="UVES"),
+                _product(60000.35, instrument="XSHOOTER"),
+                _product(60001.3, instrument="UVES"),
+                _product(60001.4, instrument="UVES"),
+                _product(60001.45, instrument="UVES"),
+            ]
+        )
+        # UVES night 1 (2 spectra), UVES night 2 (3 spectra).
+        # XSHOOTER singleton excluded.
+        assert len(groups) == 2
+        uves_groups = [g for g in groups if g["instrument"] == "UVES"]
+        assert len(uves_groups) == 2
+        sizes = sorted(len(g["products"]) for g in uves_groups)
+        assert sizes == [2, 3]
+
+    def test_single_instrument_single_product(self) -> None:
+        """One product total → no groups."""
+        groups = identify_compositing_groups(
+            [
+                _product(60000.3, instrument="UVES"),
+            ]
+        )
+        assert len(groups) == 0
+
+    def test_empty_input(self) -> None:
+        """No products → no groups (not an error)."""
+        groups = identify_compositing_groups([])
+        assert groups == []
+
+
+# ===================================================================
+# determine_common_grid
+# ===================================================================
+
+
+class TestDetermineCommonGrid:
+    """Common wavelength grid from coarsest input."""
+
+    def test_two_identical_spectra(self) -> None:
+        """Two spectra with the same resolution produce a grid matching that resolution."""
+        s1 = _cleaned("a", 400.0, 500.0, 1001)
+        s2 = _cleaned("b", 400.0, 500.0, 1001)
+        grid = determine_common_grid([s1, s2])
+        step = float(grid[1] - grid[0])
+        expected_step = 100.0 / 1000  # 0.1 nm
+        assert step == pytest.approx(expected_step, rel=0.01)
+        assert float(grid[0]) == pytest.approx(400.0)
+        assert float(grid[-1]) == pytest.approx(500.0)
+
+    def test_coarsest_sets_step(self) -> None:
+        """The coarser spectrum's step size determines the grid."""
+        fine = _cleaned("fine", 400.0, 500.0, 10001)  # ~0.01 nm step
+        coarse = _cleaned("coarse", 400.0, 500.0, 101)  # ~1.0 nm step
+        grid = determine_common_grid([fine, coarse])
+        step = float(grid[1] - grid[0])
+        # Should be close to the coarse step (~1.0 nm), not the fine one.
+        assert step == pytest.approx(1.0, rel=0.05)
+
+    def test_union_wavelength_range(self) -> None:
+        """Grid spans the union range even for non-overlapping spectra."""
+        blue = _cleaned("blue", 300.0, 500.0, 2001)
+        red = _cleaned("red", 600.0, 900.0, 3001)
+        grid = determine_common_grid([blue, red])
+        assert float(grid[0]) == pytest.approx(300.0)
+        assert float(grid[-1]) == pytest.approx(900.0)
+
+    def test_partial_overlap(self) -> None:
+        """Partially overlapping spectra produce a grid spanning the union."""
+        s1 = _cleaned("a", 400.0, 600.0, 2001)
+        s2 = _cleaned("b", 500.0, 700.0, 2001)
+        grid = determine_common_grid([s1, s2])
+        assert float(grid[0]) == pytest.approx(400.0)
+        assert float(grid[-1]) == pytest.approx(700.0)
+
+    def test_uniform_spacing(self) -> None:
+        """The grid is uniformly spaced (constant step)."""
+        s1 = _cleaned("a", 400.0, 500.0, 501)
+        s2 = _cleaned("b", 400.0, 500.0, 201)
+        grid = determine_common_grid([s1, s2])
+        steps = np.diff(grid)
+        assert np.allclose(steps, steps[0], rtol=1e-10)
+
+    def test_fewer_than_two_raises(self) -> None:
+        """A single spectrum raises ValueError."""
+        with pytest.raises(ValueError, match="Need ≥ 2"):
+            determine_common_grid([_cleaned("a", 400.0, 500.0, 100)])
+
+    def test_spectrum_with_one_point_raises(self) -> None:
+        """A spectrum with < 2 points after cleaning raises."""
+        s1 = _cleaned("a", 400.0, 500.0, 1001)
+        s2 = CleanedSpectrum(
+            data_product_id="tiny",
+            wavelengths=np.array([450.0]),
+            fluxes=np.array([1.0]),
+        )
+        with pytest.raises(ValueError, match="< 2 points"):
+            determine_common_grid([s1, s2])
+
+
+# ===================================================================
+# compute_composite_fingerprint
+# ===================================================================
+
+
+class TestCompositeFingerprint:
+    """Deterministic fingerprint from constituent IDs + sha256 hashes."""
+
+    def test_deterministic(self) -> None:
+        """Same inputs always produce the same fingerprint."""
+        ids = ["dp-aaa", "dp-bbb"]
+        shas = {"dp-aaa": "sha_aaa", "dp-bbb": "sha_bbb"}
+        fp1 = compute_composite_fingerprint(ids, shas)
+        fp2 = compute_composite_fingerprint(ids, shas)
+        assert fp1 == fp2
+
+    def test_order_independent(self) -> None:
+        """Input order does not affect the fingerprint."""
+        shas = {"dp-aaa": "sha_aaa", "dp-bbb": "sha_bbb"}
+        fp_forward = compute_composite_fingerprint(["dp-aaa", "dp-bbb"], shas)
+        fp_reverse = compute_composite_fingerprint(["dp-bbb", "dp-aaa"], shas)
+        assert fp_forward == fp_reverse
+
+    def test_different_shas_different_fingerprint(self) -> None:
+        """Changing a sha256 changes the fingerprint."""
+        ids = ["dp-aaa", "dp-bbb"]
+        fp1 = compute_composite_fingerprint(ids, {"dp-aaa": "sha_1", "dp-bbb": "sha_2"})
+        fp2 = compute_composite_fingerprint(ids, {"dp-aaa": "sha_1", "dp-bbb": "sha_CHANGED"})
+        assert fp1 != fp2
+
+    def test_different_ids_different_fingerprint(self) -> None:
+        """A different set of constituent IDs produces a different fingerprint."""
+        shas = {"dp-aaa": "sha_aaa", "dp-bbb": "sha_bbb", "dp-ccc": "sha_ccc"}
+        fp_ab = compute_composite_fingerprint(["dp-aaa", "dp-bbb"], shas)
+        fp_ac = compute_composite_fingerprint(["dp-aaa", "dp-ccc"], shas)
+        assert fp_ab != fp_ac
+
+    def test_hex_digest_length(self) -> None:
+        """Result is a 64-character SHA-256 hex digest."""
+        fp = compute_composite_fingerprint(["dp-x"], {"dp-x": "sha_x"})
+        assert len(fp) == 64
+        assert all(c in "0123456789abcdef" for c in fp)
+
+    def test_missing_sha_raises(self) -> None:
+        """A constituent ID not in the sha256 map raises KeyError."""
+        with pytest.raises(KeyError):
+            compute_composite_fingerprint(
+                ["dp-aaa", "dp-missing"],
+                {"dp-aaa": "sha_aaa"},
+            )
+
+    def test_empty_ids_raises(self) -> None:
+        """Empty constituent list raises ValueError."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            compute_composite_fingerprint([], {})
+
+
+# ===================================================================
+# compute_composite_id
+# ===================================================================
+
+
+class TestCompositeId:
+    """Deterministic UUID v5 from constituent IDs."""
+
+    def test_deterministic(self) -> None:
+        """Same inputs always produce the same UUID."""
+        id1 = compute_composite_id(["dp-aaa", "dp-bbb"])
+        id2 = compute_composite_id(["dp-aaa", "dp-bbb"])
+        assert id1 == id2
+
+    def test_order_independent(self) -> None:
+        """Input order does not affect the UUID."""
+        id_forward = compute_composite_id(["dp-aaa", "dp-bbb"])
+        id_reverse = compute_composite_id(["dp-bbb", "dp-aaa"])
+        assert id_forward == id_reverse
+
+    def test_valid_uuid_format(self) -> None:
+        """Result is a valid hyphenated UUID string."""
+        import uuid as uuid_mod
+
+        cid = compute_composite_id(["dp-aaa", "dp-bbb"])
+        parsed = uuid_mod.UUID(cid)
+        assert str(parsed) == cid
+        assert parsed.version == 5
+
+    def test_different_constituents_different_id(self) -> None:
+        """Different sets of constituents produce different IDs."""
+        id_ab = compute_composite_id(["dp-aaa", "dp-bbb"])
+        id_ac = compute_composite_id(["dp-aaa", "dp-ccc"])
+        assert id_ab != id_ac
+
+    def test_empty_raises(self) -> None:
+        """Empty constituent list raises ValueError."""
+        with pytest.raises(ValueError, match="must not be empty"):
+            compute_composite_id([])

--- a/tests/services/artifact_generator/test_compositing_a2.py
+++ b/tests/services/artifact_generator/test_compositing_a2.py
@@ -1,0 +1,346 @@
+"""Tests for compositing A2 functions — cleaning, resampling, combination, CSV.
+
+clean_spectrum tests mock the shared.py cleaning functions to isolate
+the wrapper logic.  All other functions are tested directly with
+synthetic data.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from generators.compositing import (
+    CleanedSpectrum,
+    clean_spectrum,
+    combine_spectra,
+    composite_to_csv,
+    resample_to_grid,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _cleaned(
+    dp_id: str,
+    wl_start: float,
+    wl_end: float,
+    n_points: int,
+    flux_value: float = 1.0,
+) -> CleanedSpectrum:
+    """Build a CleanedSpectrum with uniform spacing and constant flux."""
+    return CleanedSpectrum(
+        data_product_id=dp_id,
+        wavelengths=np.linspace(wl_start, wl_end, n_points),
+        fluxes=np.full(n_points, flux_value),
+    )
+
+
+# ===================================================================
+# clean_spectrum
+# ===================================================================
+
+
+class TestCleanSpectrum:
+    """Wrapper around the three shared cleaning functions."""
+
+    _SHARED = "generators.compositing.generators.shared"
+
+    def _passthrough(
+        self, wl: list[float], fx: list[float], dp_id: str, **kwargs: object
+    ) -> tuple[list[float], list[float]]:
+        """Cleaning function that returns input unchanged."""
+        return wl, fx
+
+    def _empty(
+        self, wl: list[float], fx: list[float], dp_id: str, **kwargs: object
+    ) -> tuple[list[float], list[float]]:
+        """Cleaning function that eliminates all points."""
+        return [], []
+
+    def test_all_cleaning_passes(self) -> None:
+        """When all three cleaners pass through, the result is a CleanedSpectrum."""
+        wl = np.linspace(400.0, 500.0, 100)
+        fx = np.ones(100)
+        with (
+            patch("generators.shared.trim_dead_edges", side_effect=self._passthrough),
+            patch("generators.shared.remove_interior_dead_runs", side_effect=self._passthrough),
+            patch("generators.shared.reject_chip_gap_artifacts", side_effect=self._passthrough),
+        ):
+            result = clean_spectrum("dp-001", wl, fx)
+
+        assert result is not None
+        assert result["data_product_id"] == "dp-001"
+        assert len(result["wavelengths"]) == 100
+        assert len(result["fluxes"]) == 100
+
+    def test_trim_dead_edges_empties(self) -> None:
+        """Returns None when edge trimming eliminates all points."""
+        wl = np.linspace(400.0, 500.0, 100)
+        fx = np.ones(100)
+        with (
+            patch("generators.shared.trim_dead_edges", side_effect=self._empty),
+            patch("generators.shared.remove_interior_dead_runs", side_effect=self._passthrough),
+            patch("generators.shared.reject_chip_gap_artifacts", side_effect=self._passthrough),
+        ):
+            result = clean_spectrum("dp-001", wl, fx)
+
+        assert result is None
+
+    def test_interior_dead_runs_empties(self) -> None:
+        """Returns None when interior dead run removal eliminates all points."""
+        wl = np.linspace(400.0, 500.0, 100)
+        fx = np.ones(100)
+        with (
+            patch("generators.shared.trim_dead_edges", side_effect=self._passthrough),
+            patch("generators.shared.remove_interior_dead_runs", side_effect=self._empty),
+            patch("generators.shared.reject_chip_gap_artifacts", side_effect=self._passthrough),
+        ):
+            result = clean_spectrum("dp-001", wl, fx)
+
+        assert result is None
+
+    def test_chip_gap_rejection_empties(self) -> None:
+        """Returns None when chip gap rejection eliminates all points."""
+        wl = np.linspace(400.0, 500.0, 100)
+        fx = np.ones(100)
+        with (
+            patch("generators.shared.trim_dead_edges", side_effect=self._passthrough),
+            patch("generators.shared.remove_interior_dead_runs", side_effect=self._passthrough),
+            patch("generators.shared.reject_chip_gap_artifacts", side_effect=self._empty),
+        ):
+            result = clean_spectrum("dp-001", wl, fx)
+
+        assert result is None
+
+    def test_converts_to_numpy(self) -> None:
+        """Output arrays are numpy float64, even though shared functions return lists."""
+        wl = np.array([400.0, 450.0, 500.0])
+        fx = np.array([1.0, 2.0, 3.0])
+        with (
+            patch("generators.shared.trim_dead_edges", side_effect=self._passthrough),
+            patch("generators.shared.remove_interior_dead_runs", side_effect=self._passthrough),
+            patch("generators.shared.reject_chip_gap_artifacts", side_effect=self._passthrough),
+        ):
+            result = clean_spectrum("dp-001", wl, fx)
+
+        assert result is not None
+        assert isinstance(result["wavelengths"], np.ndarray)
+        assert result["wavelengths"].dtype == np.float64
+
+    def test_calls_functions_in_order(self) -> None:
+        """Cleaning functions are called in the correct order."""
+        call_order: list[str] = []
+
+        def _track_trim(
+            wl: list[float], fx: list[float], dp_id: str
+        ) -> tuple[list[float], list[float]]:
+            call_order.append("trim")
+            return wl, fx
+
+        def _track_interior(
+            wl: list[float], fx: list[float], dp_id: str, **kw: object
+        ) -> tuple[list[float], list[float]]:
+            call_order.append("interior")
+            return wl, fx
+
+        def _track_chip(
+            wl: list[float], fx: list[float], dp_id: str
+        ) -> tuple[list[float], list[float]]:
+            call_order.append("chip")
+            return wl, fx
+
+        wl = np.linspace(400.0, 500.0, 50)
+        fx = np.ones(50)
+        with (
+            patch("generators.shared.trim_dead_edges", side_effect=_track_trim),
+            patch("generators.shared.remove_interior_dead_runs", side_effect=_track_interior),
+            patch("generators.shared.reject_chip_gap_artifacts", side_effect=_track_chip),
+        ):
+            clean_spectrum("dp-001", wl, fx)
+
+        assert call_order == ["trim", "interior", "chip"]
+
+
+# ===================================================================
+# resample_to_grid
+# ===================================================================
+
+
+class TestResampleToGrid:
+    """Linear interpolation onto a common wavelength grid."""
+
+    def test_exact_coverage(self) -> None:
+        """Spectrum covering the full grid has no NaN values."""
+        spec = _cleaned("a", 400.0, 500.0, 101, flux_value=2.0)
+        grid = np.linspace(400.0, 500.0, 51)
+        result = resample_to_grid(spec, grid)
+        assert not np.any(np.isnan(result))
+        np.testing.assert_allclose(result, 2.0)
+
+    def test_partial_coverage_nan_outside(self) -> None:
+        """Grid points outside the spectrum's range are NaN."""
+        spec = _cleaned("a", 450.0, 550.0, 101)
+        grid = np.linspace(400.0, 600.0, 201)
+        result = resample_to_grid(spec, grid)
+
+        # Points inside 450–550 should be valid.
+        inside = (grid >= 450.0) & (grid <= 550.0)
+        assert not np.any(np.isnan(result[inside]))
+
+        # Points outside should be NaN.
+        outside = (grid < 450.0) | (grid > 550.0)
+        assert np.all(np.isnan(result[outside]))
+
+    def test_interpolation_accuracy(self) -> None:
+        """Linear interpolation produces correct intermediate values."""
+        # Spectrum with a linear ramp: flux = wavelength.
+        wl = np.array([400.0, 500.0])
+        fx = np.array([400.0, 500.0])
+        spec = CleanedSpectrum(data_product_id="ramp", wavelengths=wl, fluxes=fx)
+        grid = np.array([400.0, 425.0, 450.0, 475.0, 500.0])
+        result = resample_to_grid(spec, grid)
+        np.testing.assert_allclose(result, grid)
+
+    def test_grid_wider_than_spectrum(self) -> None:
+        """NaN regions don't contaminate the valid interior."""
+        spec = _cleaned("a", 500.0, 600.0, 101, flux_value=5.0)
+        grid = np.linspace(400.0, 700.0, 301)
+        result = resample_to_grid(spec, grid)
+
+        valid_count = np.count_nonzero(~np.isnan(result))
+        # Approximately 100 of 301 grid points should be valid (500–600 region).
+        assert 95 <= valid_count <= 105
+
+
+# ===================================================================
+# combine_spectra
+# ===================================================================
+
+
+class TestCombineSpectra:
+    """Subset-aware median combination of resampled flux arrays."""
+
+    def test_full_overlap_median(self) -> None:
+        """Two fully overlapping spectra produce the median at each point."""
+        fx1 = np.array([1.0, 3.0, 5.0])
+        fx2 = np.array([2.0, 4.0, 6.0])
+        result = combine_spectra([fx1, fx2])
+        # Median of [1,2]=1.5, [3,4]=3.5, [5,6]=5.5
+        np.testing.assert_allclose(result, [1.5, 3.5, 5.5])
+
+    def test_three_spectra_median(self) -> None:
+        """Three spectra — median picks the middle value."""
+        fx1 = np.array([1.0, 10.0])
+        fx2 = np.array([2.0, 20.0])
+        fx3 = np.array([3.0, 30.0])
+        result = combine_spectra([fx1, fx2, fx3])
+        np.testing.assert_allclose(result, [2.0, 20.0])
+
+    def test_outlier_robustness(self) -> None:
+        """Median resists a single outlier spectrum."""
+        fx_normal1 = np.array([1.0, 1.0, 1.0])
+        fx_normal2 = np.array([1.0, 1.0, 1.0])
+        fx_outlier = np.array([1.0, 1000.0, 1.0])
+        result = combine_spectra([fx_normal1, fx_normal2, fx_outlier])
+        np.testing.assert_allclose(result, [1.0, 1.0, 1.0])
+
+    def test_partial_overlap(self) -> None:
+        """Non-overlapping regions use the single contributing spectrum."""
+        # Spectrum A covers full range, B covers only the middle.
+        fx_a = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        fx_b = np.array([np.nan, 20.0, 30.0, 40.0, np.nan])
+        result = combine_spectra([fx_a, fx_b])
+        # Endpoints: only A contributes → A's value.
+        assert result[0] == pytest.approx(1.0)
+        assert result[4] == pytest.approx(5.0)
+        # Overlap region: median of [2,20]=11, [3,30]=16.5, [4,40]=22
+        assert result[1] == pytest.approx(11.0)
+        assert result[2] == pytest.approx(16.5)
+        assert result[3] == pytest.approx(22.0)
+
+    def test_disjoint_spectra(self) -> None:
+        """Completely disjoint spectra each contribute in their own region."""
+        fx_a = np.array([1.0, 2.0, np.nan, np.nan])
+        fx_b = np.array([np.nan, np.nan, 3.0, 4.0])
+        result = combine_spectra([fx_a, fx_b])
+        np.testing.assert_allclose(result, [1.0, 2.0, 3.0, 4.0])
+
+    def test_all_nan_produces_nan(self) -> None:
+        """Grid points with no coverage from any spectrum remain NaN."""
+        fx_a = np.array([1.0, np.nan, 3.0])
+        fx_b = np.array([2.0, np.nan, 4.0])
+        result = combine_spectra([fx_a, fx_b])
+        assert np.isnan(result[1])
+        assert result[0] == pytest.approx(1.5)
+        assert result[2] == pytest.approx(3.5)
+
+    def test_fewer_than_two_raises(self) -> None:
+        """Single flux array raises ValueError."""
+        with pytest.raises(ValueError, match="Need ≥ 2"):
+            combine_spectra([np.array([1.0, 2.0])])
+
+
+# ===================================================================
+# composite_to_csv
+# ===================================================================
+
+
+class TestCompositeToCsv:
+    """CSV serialization of composite spectra."""
+
+    def test_basic_output(self) -> None:
+        """Produces a valid two-column CSV with header."""
+        wl = np.array([400.0, 450.0, 500.0])
+        fx = np.array([1.5, 2.5, 3.5])
+        csv_str = composite_to_csv(wl, fx)
+        lines = csv_str.strip().split("\n")
+        assert lines[0] == "wavelength_nm,flux"
+        assert len(lines) == 4  # header + 3 data rows
+
+    def test_nan_excluded(self) -> None:
+        """NaN flux values are excluded from the output."""
+        wl = np.array([400.0, 450.0, 500.0, 550.0])
+        fx = np.array([1.0, np.nan, 3.0, np.nan])
+        csv_str = composite_to_csv(wl, fx)
+        lines = csv_str.strip().split("\n")
+        assert len(lines) == 3  # header + 2 data rows (NaNs excluded)
+
+    def test_wavelength_precision(self) -> None:
+        """Wavelengths are formatted to 6 decimal places."""
+        wl = np.array([400.123456789])
+        fx = np.array([1.0])
+        csv_str = composite_to_csv(wl, fx)
+        data_line = csv_str.strip().split("\n")[1]
+        wl_str = data_line.split(",")[0]
+        assert wl_str == "400.123457"  # rounded to 6 dp
+
+    def test_trailing_newline(self) -> None:
+        """Output ends with a newline."""
+        wl = np.array([400.0])
+        fx = np.array([1.0])
+        csv_str = composite_to_csv(wl, fx)
+        assert csv_str.endswith("\n")
+
+    def test_empty_after_nan_removal(self) -> None:
+        """All-NaN input produces a header-only CSV."""
+        wl = np.array([400.0, 500.0])
+        fx = np.array([np.nan, np.nan])
+        csv_str = composite_to_csv(wl, fx)
+        lines = csv_str.strip().split("\n")
+        assert len(lines) == 1
+        assert lines[0] == "wavelength_nm,flux"
+
+    def test_roundtrip_values(self) -> None:
+        """CSV values can be parsed back to the original floats."""
+        wl = np.array([400.0, 500.0])
+        fx = np.array([1.23e-15, 4.56e-15])
+        csv_str = composite_to_csv(wl, fx)
+        lines = csv_str.strip().split("\n")[1:]
+        for i, line in enumerate(lines):
+            parts = line.split(",")
+            assert float(parts[0]) == pytest.approx(wl[i], rel=1e-5)
+            assert float(parts[1]) == pytest.approx(fx[i], rel=1e-10)

--- a/tests/services/artifact_generator/test_compositing_c.py
+++ b/tests/services/artifact_generator/test_compositing_c.py
@@ -1,0 +1,542 @@
+"""Tests for compositing C1+C2 — DDB queries, DDB writes, S3 persistence.
+
+Uses moto to mock DynamoDB and S3.  LTTB downsampling is tested via
+persist_composite_csvs with arrays exceeding the 2000-point threshold.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+from unittest.mock import patch
+
+import boto3
+import numpy as np
+import pytest
+from generators.compositing import (
+    _lttb_downsample,
+    find_compositable_products,
+    find_existing_composites,
+    persist_composite_csvs,
+    write_composite_data_product,
+)
+from moto import mock_aws
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_TABLE_NAME = "TestNovaCat"
+_BUCKET_NAME = "test-private-bucket"
+_NOVA_ID = "aaaa-bbbb-cccc-dddd"
+
+
+def _create_table(dynamodb: Any) -> Any:
+    """Create a minimal DDB table matching the NovaCat key schema."""
+    table = dynamodb.create_table(
+        TableName=_TABLE_NAME,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    table.wait_until_exists()
+    return table
+
+
+def _create_bucket(s3_client: Any) -> None:
+    """Create a test S3 bucket."""
+    s3_client.create_bucket(Bucket=_BUCKET_NAME)
+
+
+def _put_individual_spectrum(
+    table: Any,
+    nova_id: str,
+    dp_id: str,
+    provider: str = "ESO",
+    instrument: str = "UVES",
+    validation_status: str = "VALID",
+    observation_date_mjd: float = 60000.3,
+    sha256: str = "abc123",
+) -> None:
+    """Write a minimal individual spectra DataProduct item."""
+    table.put_item(
+        Item={
+            "PK": nova_id,
+            "SK": f"PRODUCT#SPECTRA#{provider}#{dp_id}",
+            "entity_type": "DataProduct",
+            "data_product_id": dp_id,
+            "product_type": "SPECTRA",
+            "provider": provider,
+            "instrument": instrument,
+            "validation_status": validation_status,
+            "observation_date_mjd": Decimal(str(observation_date_mjd)),
+            "sha256": sha256,
+        }
+    )
+
+
+def _put_composite_spectrum(
+    table: Any,
+    nova_id: str,
+    composite_id: str,
+    provider: str = "ESO",
+    instrument: str = "UVES",
+    constituent_ids: list[str] | None = None,
+    fingerprint: str = "fp-abc",
+) -> None:
+    """Write a minimal composite DataProduct item."""
+    table.put_item(
+        Item={
+            "PK": nova_id,
+            "SK": f"PRODUCT#SPECTRA#{provider}#COMPOSITE#{composite_id}",
+            "entity_type": "DataProduct",
+            "data_product_id": composite_id,
+            "product_type": "SPECTRA",
+            "provider": provider,
+            "instrument": instrument,
+            "validation_status": "VALID",
+            "constituent_data_product_ids": constituent_ids or [],
+            "rejected_data_product_ids": [],
+            "composite_fingerprint": fingerprint,
+        }
+    )
+
+
+# ===================================================================
+# find_compositable_products
+# ===================================================================
+
+
+class TestFindCompositableProducts:
+    """Query for VALID individual spectra, excluding composites."""
+
+    @mock_aws
+    def test_returns_valid_individuals(self) -> None:
+        """Returns VALID individual spectra DataProducts."""
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        table = _create_table(dynamodb)
+
+        _put_individual_spectrum(table, _NOVA_ID, "dp-001")
+        _put_individual_spectrum(table, _NOVA_ID, "dp-002")
+
+        result = find_compositable_products(table, _NOVA_ID)
+        ids = {item["data_product_id"] for item in result}
+        assert ids == {"dp-001", "dp-002"}
+
+    @mock_aws
+    def test_excludes_non_valid(self) -> None:
+        """Non-VALID spectra are filtered out."""
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        table = _create_table(dynamodb)
+
+        _put_individual_spectrum(table, _NOVA_ID, "dp-valid", validation_status="VALID")
+        _put_individual_spectrum(table, _NOVA_ID, "dp-failed", validation_status="FAILED")
+        _put_individual_spectrum(table, _NOVA_ID, "dp-unval", validation_status="UNVALIDATED")
+
+        result = find_compositable_products(table, _NOVA_ID)
+        ids = {item["data_product_id"] for item in result}
+        assert ids == {"dp-valid"}
+
+    @mock_aws
+    def test_excludes_composites(self) -> None:
+        """Composite DataProducts are excluded from the result."""
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        table = _create_table(dynamodb)
+
+        _put_individual_spectrum(table, _NOVA_ID, "dp-001")
+        _put_composite_spectrum(table, _NOVA_ID, "comp-001", constituent_ids=["dp-001"])
+
+        result = find_compositable_products(table, _NOVA_ID)
+        ids = {item["data_product_id"] for item in result}
+        assert ids == {"dp-001"}
+
+    @mock_aws
+    def test_empty_nova(self) -> None:
+        """Nova with no spectra returns empty list."""
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        table = _create_table(dynamodb)
+
+        result = find_compositable_products(table, _NOVA_ID)
+        assert result == []
+
+    @mock_aws
+    def test_ignores_other_novas(self) -> None:
+        """Only returns products for the requested nova."""
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        table = _create_table(dynamodb)
+
+        _put_individual_spectrum(table, _NOVA_ID, "dp-mine")
+        _put_individual_spectrum(table, "other-nova-id", "dp-theirs")
+
+        result = find_compositable_products(table, _NOVA_ID)
+        ids = {item["data_product_id"] for item in result}
+        assert ids == {"dp-mine"}
+
+
+# ===================================================================
+# find_existing_composites
+# ===================================================================
+
+
+class TestFindExistingComposites:
+    """Query for existing composite DataProduct items."""
+
+    @mock_aws
+    def test_returns_composites(self) -> None:
+        """Returns composite items identified by COMPOSITE in SK."""
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        table = _create_table(dynamodb)
+
+        _put_composite_spectrum(table, _NOVA_ID, "comp-001")
+        _put_composite_spectrum(table, _NOVA_ID, "comp-002")
+
+        result = find_existing_composites(table, _NOVA_ID)
+        ids = {item["data_product_id"] for item in result}
+        assert ids == {"comp-001", "comp-002"}
+
+    @mock_aws
+    def test_excludes_individuals(self) -> None:
+        """Individual spectra are excluded from the result."""
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        table = _create_table(dynamodb)
+
+        _put_individual_spectrum(table, _NOVA_ID, "dp-001")
+        _put_composite_spectrum(table, _NOVA_ID, "comp-001")
+
+        result = find_existing_composites(table, _NOVA_ID)
+        ids = {item["data_product_id"] for item in result}
+        assert ids == {"comp-001"}
+
+    @mock_aws
+    def test_empty_nova(self) -> None:
+        """Nova with no composites returns empty list."""
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        table = _create_table(dynamodb)
+
+        _put_individual_spectrum(table, _NOVA_ID, "dp-001")
+
+        result = find_existing_composites(table, _NOVA_ID)
+        assert result == []
+
+
+# ===================================================================
+# write_composite_data_product
+# ===================================================================
+
+
+class TestWriteCompositeDataProduct:
+    """PutItem for composite (and degenerate) DataProducts."""
+
+    @mock_aws
+    def test_writes_real_composite(self) -> None:
+        """A real composite item has all expected fields."""
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        table = _create_table(dynamodb)
+
+        write_composite_data_product(
+            table=table,
+            nova_id=_NOVA_ID,
+            composite_id="comp-001",
+            provider="ESO",
+            instrument="UVES",
+            telescope="VLT-UT2",
+            observation_date_mjd=60000.35,
+            constituent_data_product_ids=["dp-001", "dp-002"],
+            rejected_data_product_ids=["dp-003"],
+            composite_fingerprint="fp-xyz",
+            composite_s3_key="derived/spectra/nova/comp-001/composite_full.csv",
+            web_ready_s3_key="derived/spectra/nova/comp-001/web_ready.csv",
+        )
+
+        resp = table.get_item(
+            Key={
+                "PK": _NOVA_ID,
+                "SK": "PRODUCT#SPECTRA#ESO#COMPOSITE#comp-001",
+            }
+        )
+        item = resp["Item"]
+
+        assert item["entity_type"] == "DataProduct"
+        assert item["data_product_id"] == "comp-001"
+        assert item["product_type"] == "SPECTRA"
+        assert item["provider"] == "ESO"
+        assert item["instrument"] == "UVES"
+        assert item["telescope"] == "VLT-UT2"
+        assert item["validation_status"] == "VALID"
+        assert item["eligibility"] == "NONE"
+        assert item["constituent_data_product_ids"] == ["dp-001", "dp-002"]
+        assert item["rejected_data_product_ids"] == ["dp-003"]
+        assert item["composite_fingerprint"] == "fp-xyz"
+        assert item["composite_s3_key"] == "derived/spectra/nova/comp-001/composite_full.csv"
+        assert item["web_ready_s3_key"] == "derived/spectra/nova/comp-001/web_ready.csv"
+        assert "created_at" in item
+        assert "updated_at" in item
+
+    @mock_aws
+    def test_writes_degenerate_composite(self) -> None:
+        """A degenerate composite has web_ready_s3_key but no composite_s3_key."""
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        table = _create_table(dynamodb)
+
+        write_composite_data_product(
+            table=table,
+            nova_id=_NOVA_ID,
+            composite_id="comp-degen",
+            provider="ESO",
+            instrument="UVES",
+            telescope=None,
+            observation_date_mjd=60000.4,
+            constituent_data_product_ids=["dp-survivor"],
+            rejected_data_product_ids=["dp-rejected-1", "dp-rejected-2"],
+            composite_fingerprint="fp-degen",
+            composite_s3_key=None,
+            web_ready_s3_key="derived/spectra/nova/dp-survivor/web_ready.csv",
+        )
+
+        resp = table.get_item(
+            Key={
+                "PK": _NOVA_ID,
+                "SK": "PRODUCT#SPECTRA#ESO#COMPOSITE#comp-degen",
+            }
+        )
+        item = resp["Item"]
+
+        assert item["constituent_data_product_ids"] == ["dp-survivor"]
+        assert item["rejected_data_product_ids"] == ["dp-rejected-1", "dp-rejected-2"]
+        assert "composite_s3_key" not in item
+        assert item["web_ready_s3_key"] == "derived/spectra/nova/dp-survivor/web_ready.csv"
+        assert "telescope" not in item
+
+    @mock_aws
+    def test_overwrites_existing(self) -> None:
+        """A second PutItem with the same key replaces the item."""
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        table = _create_table(dynamodb)
+
+        for fp in ("fp-old", "fp-new"):
+            write_composite_data_product(
+                table=table,
+                nova_id=_NOVA_ID,
+                composite_id="comp-001",
+                provider="ESO",
+                instrument="UVES",
+                telescope=None,
+                observation_date_mjd=60000.3,
+                constituent_data_product_ids=["dp-001", "dp-002"],
+                rejected_data_product_ids=[],
+                composite_fingerprint=fp,
+                composite_s3_key="derived/s.csv",
+                web_ready_s3_key="derived/w.csv",
+            )
+
+        resp = table.get_item(
+            Key={
+                "PK": _NOVA_ID,
+                "SK": "PRODUCT#SPECTRA#ESO#COMPOSITE#comp-001",
+            }
+        )
+        assert resp["Item"]["composite_fingerprint"] == "fp-new"
+
+    @mock_aws
+    def test_observation_date_stored_as_decimal(self) -> None:
+        """MJD is stored as a Decimal (DynamoDB number type)."""
+        dynamodb = boto3.resource("dynamodb", region_name="us-east-1")
+        table = _create_table(dynamodb)
+
+        write_composite_data_product(
+            table=table,
+            nova_id=_NOVA_ID,
+            composite_id="comp-001",
+            provider="ESO",
+            instrument="UVES",
+            telescope=None,
+            observation_date_mjd=60000.3456,
+            constituent_data_product_ids=["dp-001", "dp-002"],
+            rejected_data_product_ids=[],
+            composite_fingerprint="fp-test",
+            composite_s3_key="s.csv",
+            web_ready_s3_key="w.csv",
+        )
+
+        resp = table.get_item(
+            Key={
+                "PK": _NOVA_ID,
+                "SK": "PRODUCT#SPECTRA#ESO#COMPOSITE#comp-001",
+            }
+        )
+        mjd = resp["Item"]["observation_date_mjd"]
+        assert isinstance(mjd, Decimal)
+        assert float(mjd) == pytest.approx(60000.3456)
+
+
+# ===================================================================
+# persist_composite_csvs
+# ===================================================================
+
+
+class TestPersistCompositeCsvs:
+    """S3 upload of full-resolution and web-ready composite CSVs."""
+
+    @mock_aws
+    def test_writes_both_csvs(self) -> None:
+        """Both composite_full.csv and web_ready.csv are written to S3."""
+        s3 = boto3.client("s3", region_name="us-east-1")
+        _create_bucket(s3)
+
+        wl = np.linspace(400.0, 500.0, 100)
+        fx = np.ones(100)
+
+        full_key, wr_key = persist_composite_csvs(
+            s3,
+            _BUCKET_NAME,
+            _NOVA_ID,
+            "comp-001",
+            wl,
+            fx,
+        )
+
+        assert full_key == f"derived/spectra/{_NOVA_ID}/comp-001/composite_full.csv"
+        assert wr_key == f"derived/spectra/{_NOVA_ID}/comp-001/web_ready.csv"
+
+        # Verify both objects exist in S3.
+        full_obj = s3.get_object(Bucket=_BUCKET_NAME, Key=full_key)
+        wr_obj = s3.get_object(Bucket=_BUCKET_NAME, Key=wr_key)
+
+        full_body = full_obj["Body"].read().decode("utf-8")
+        wr_body = wr_obj["Body"].read().decode("utf-8")
+
+        assert full_body.startswith("wavelength_nm,flux")
+        assert wr_body.startswith("wavelength_nm,flux")
+
+    @mock_aws
+    def test_full_csv_has_all_points(self) -> None:
+        """The full-resolution CSV contains all non-NaN grid points."""
+        s3 = boto3.client("s3", region_name="us-east-1")
+        _create_bucket(s3)
+
+        wl = np.linspace(400.0, 500.0, 500)
+        fx = np.ones(500)
+
+        full_key, _ = persist_composite_csvs(
+            s3,
+            _BUCKET_NAME,
+            _NOVA_ID,
+            "comp-001",
+            wl,
+            fx,
+        )
+
+        body = s3.get_object(Bucket=_BUCKET_NAME, Key=full_key)["Body"].read().decode()
+        lines = body.strip().split("\n")
+        # Header + 500 data rows.
+        assert len(lines) == 501
+
+    @mock_aws
+    def test_web_ready_downsampled(self) -> None:
+        """Web-ready CSV is downsampled to ≤ 2000 points for large composites."""
+        s3 = boto3.client("s3", region_name="us-east-1")
+        _create_bucket(s3)
+
+        # 10000 points — well above the 2000 LTTB threshold.
+        wl = np.linspace(400.0, 800.0, 10000)
+        fx = np.sin(np.linspace(0, 20 * np.pi, 10000))
+
+        _, wr_key = persist_composite_csvs(
+            s3,
+            _BUCKET_NAME,
+            _NOVA_ID,
+            "comp-001",
+            wl,
+            fx,
+        )
+
+        body = s3.get_object(Bucket=_BUCKET_NAME, Key=wr_key)["Body"].read().decode()
+        lines = body.strip().split("\n")
+        data_rows = len(lines) - 1  # subtract header
+        assert data_rows <= 2000
+
+    @mock_aws
+    def test_small_composite_not_downsampled(self) -> None:
+        """Composites with ≤ 2000 points are not downsampled."""
+        s3 = boto3.client("s3", region_name="us-east-1")
+        _create_bucket(s3)
+
+        wl = np.linspace(400.0, 500.0, 500)
+        fx = np.ones(500)
+
+        full_key, wr_key = persist_composite_csvs(
+            s3,
+            _BUCKET_NAME,
+            _NOVA_ID,
+            "comp-001",
+            wl,
+            fx,
+        )
+
+        full_body = s3.get_object(Bucket=_BUCKET_NAME, Key=full_key)["Body"].read().decode()
+        wr_body = s3.get_object(Bucket=_BUCKET_NAME, Key=wr_key)["Body"].read().decode()
+
+        full_rows = len(full_body.strip().split("\n")) - 1
+        wr_rows = len(wr_body.strip().split("\n")) - 1
+        assert full_rows == wr_rows == 500
+
+    @mock_aws
+    def test_nan_excluded_from_both_csvs(self) -> None:
+        """NaN flux values are excluded from both CSVs."""
+        s3 = boto3.client("s3", region_name="us-east-1")
+        _create_bucket(s3)
+
+        wl = np.linspace(400.0, 500.0, 10)
+        fx = np.array([1.0, np.nan, 3.0, np.nan, 5.0, 6.0, np.nan, 8.0, 9.0, 10.0])
+
+        full_key, wr_key = persist_composite_csvs(
+            s3,
+            _BUCKET_NAME,
+            _NOVA_ID,
+            "comp-001",
+            wl,
+            fx,
+        )
+
+        full_body = s3.get_object(Bucket=_BUCKET_NAME, Key=full_key)["Body"].read().decode()
+        full_rows = len(full_body.strip().split("\n")) - 1
+        assert full_rows == 7  # 10 - 3 NaN
+
+
+# ===================================================================
+# _lttb_downsample
+# ===================================================================
+
+
+class TestLttbDownsample:
+    """LTTB downsampling wrapper with NaN stripping."""
+
+    def test_strips_nan_before_lttb(self) -> None:
+        """NaN values are removed before LTTB processes the data."""
+        wl = np.array([1.0, 2.0, np.nan, 4.0, 5.0])
+        fx = np.array([10.0, 20.0, np.nan, 40.0, 50.0])
+
+        # Patch segment_aware_lttb to verify it receives clean arrays.
+        def _capture_lttb(w: list[float], f: list[float]) -> tuple[list[float], list[float]]:
+            assert not any(np.isnan(v) for v in w)
+            assert not any(np.isnan(v) for v in f)
+            return w, f
+
+        with patch("generators.shared.segment_aware_lttb", side_effect=_capture_lttb):
+            result_wl, result_fx = _lttb_downsample(wl, fx)
+
+        assert len(result_wl) == 4  # 5 - 1 NaN in wavelengths
+
+    def test_below_threshold_passthrough(self) -> None:
+        """Arrays with ≤ 2000 points pass through unchanged."""
+        wl = np.linspace(400.0, 500.0, 100)
+        fx = np.ones(100)
+        result_wl, result_fx = _lttb_downsample(wl, fx)
+        assert len(result_wl) == 100
+        assert len(result_fx) == 100

--- a/tests/services/artifact_generator/test_compositing_d1.py
+++ b/tests/services/artifact_generator/test_compositing_d1.py
@@ -1,0 +1,545 @@
+"""Tests for compositing D1 — sweep orchestration.
+
+End-to-end tests using moto for DDB and S3, with FITS reads and
+cleaning functions mocked to return synthetic data.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+from unittest.mock import patch
+
+import boto3
+import numpy as np
+from generators.compositing import (
+    run_compositing_sweep,
+)
+from moto import mock_aws
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_TABLE_NAME = "TestNovaCat"
+_BUCKET_NAME = "test-private-bucket"
+_NOVA_ID = "aaaa-bbbb-cccc-dddd"
+_REGION = "us-east-1"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _create_table(dynamodb: Any) -> Any:
+    """Create a minimal DDB table."""
+    table = dynamodb.create_table(
+        TableName=_TABLE_NAME,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    table.wait_until_exists()
+    return table
+
+
+def _create_bucket(s3_client: Any) -> None:
+    """Create a test S3 bucket."""
+    s3_client.create_bucket(Bucket=_BUCKET_NAME)
+
+
+def _put_spectrum(
+    table: Any,
+    dp_id: str,
+    nova_id: str = _NOVA_ID,
+    provider: str = "ESO",
+    instrument: str = "UVES",
+    observation_date_mjd: float = 60000.3,
+    sha256: str = "sha_default",
+    raw_s3_key: str | None = "raw/test.fits",
+    validation_status: str = "VALID",
+) -> None:
+    """Write an individual spectra DataProduct item."""
+    item: dict[str, Any] = {
+        "PK": nova_id,
+        "SK": f"PRODUCT#SPECTRA#{provider}#{dp_id}",
+        "entity_type": "DataProduct",
+        "data_product_id": dp_id,
+        "product_type": "SPECTRA",
+        "provider": provider,
+        "instrument": instrument,
+        "validation_status": validation_status,
+        "observation_date_mjd": Decimal(str(observation_date_mjd)),
+        "sha256": sha256,
+        "telescope": "VLT-UT2",
+    }
+    if raw_s3_key is not None:
+        item["raw_s3_key"] = raw_s3_key
+    table.put_item(Item=item)
+
+
+def _put_existing_composite(
+    table: Any,
+    composite_id: str,
+    fingerprint: str,
+    constituent_ids: list[str],
+    rejected_ids: list[str] | None = None,
+    nova_id: str = _NOVA_ID,
+    provider: str = "ESO",
+    instrument: str = "UVES",
+) -> None:
+    """Write an existing composite DataProduct item."""
+    table.put_item(
+        Item={
+            "PK": nova_id,
+            "SK": f"PRODUCT#SPECTRA#{provider}#COMPOSITE#{composite_id}",
+            "entity_type": "DataProduct",
+            "data_product_id": composite_id,
+            "product_type": "SPECTRA",
+            "provider": provider,
+            "instrument": instrument,
+            "validation_status": "VALID",
+            "constituent_data_product_ids": constituent_ids,
+            "rejected_data_product_ids": rejected_ids or [],
+            "composite_fingerprint": fingerprint,
+            "observation_date_mjd": Decimal("60000.35"),
+        }
+    )
+
+
+def _mock_fits_reader(n_points: int = 3000) -> Any:
+    """Return a mock for read_fits_spectrum that produces synthetic arrays.
+
+    The default n_points (3000) is above MIN_POINTS_FOR_COMPOSITE.
+    """
+
+    def _reader(
+        s3_client: Any,
+        bucket: str,
+        raw_s3_key: str,
+        data_product_id: str,
+    ) -> tuple[np.ndarray, np.ndarray] | None:
+        wl = np.linspace(400.0, 700.0, n_points)
+        fx = np.sin(np.linspace(0, 10 * np.pi, n_points)) + 2.0
+        return wl, fx
+
+    return _reader
+
+
+def _mock_fits_reader_by_id(
+    point_counts: dict[str, int],
+    default_points: int = 3000,
+) -> Any:
+    """Return a mock FITS reader that returns different point counts per dp_id."""
+
+    def _reader(
+        s3_client: Any,
+        bucket: str,
+        raw_s3_key: str,
+        data_product_id: str,
+    ) -> tuple[np.ndarray, np.ndarray] | None:
+        n = point_counts.get(data_product_id, default_points)
+        wl = np.linspace(400.0, 700.0, n)
+        fx = np.ones(n) + 1.0
+        return wl, fx
+
+    return _reader
+
+
+def _passthrough_clean(
+    wl: list[float],
+    fx: list[float],
+    dp_id: str,
+    **kwargs: object,
+) -> tuple[list[float], list[float]]:
+    """Cleaning function that passes through unchanged."""
+    return wl, fx
+
+
+# ---------------------------------------------------------------------------
+# Patches applied to all sweep tests
+# ---------------------------------------------------------------------------
+
+
+def _sweep_patches() -> list[Any]:
+    """Context manager stack for patching FITS reader + cleaning functions."""
+    return [
+        patch(
+            "generators.fits_reader.read_fits_spectrum",
+            side_effect=_mock_fits_reader(),
+        ),
+        patch("generators.shared.trim_dead_edges", side_effect=_passthrough_clean),
+        patch("generators.shared.remove_interior_dead_runs", side_effect=_passthrough_clean),
+        patch("generators.shared.reject_chip_gap_artifacts", side_effect=_passthrough_clean),
+        patch("generators.shared.segment_aware_lttb", side_effect=lambda wl, fx: (wl, fx)),
+    ]
+
+
+# ===================================================================
+# run_compositing_sweep
+# ===================================================================
+
+
+class TestRunCompositingSweep:
+    """End-to-end sweep orchestration."""
+
+    @mock_aws
+    def test_no_individuals(self) -> None:
+        """Nova with < 2 spectra returns immediately."""
+        dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+        table = _create_table(dynamodb)
+        s3 = boto3.client("s3", region_name=_REGION)
+
+        _put_spectrum(table, "dp-001")  # only 1
+
+        result = run_compositing_sweep(_NOVA_ID, table, s3, _BUCKET_NAME)
+        assert result["groups_found"] == 0
+        assert result["built"] == 0
+
+    @mock_aws
+    def test_no_groups_all_singletons(self) -> None:
+        """Two spectra on different nights produce no compositing groups."""
+        dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+        table = _create_table(dynamodb)
+        s3 = boto3.client("s3", region_name=_REGION)
+
+        _put_spectrum(table, "dp-001", observation_date_mjd=60000.3)
+        _put_spectrum(table, "dp-002", observation_date_mjd=60001.3)
+
+        result = run_compositing_sweep(_NOVA_ID, table, s3, _BUCKET_NAME)
+        assert result["groups_found"] == 0
+
+    @mock_aws
+    def test_builds_real_composite(self) -> None:
+        """Two same-night spectra above threshold produce a real composite."""
+        dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+        table = _create_table(dynamodb)
+        s3 = boto3.client("s3", region_name=_REGION)
+        _create_bucket(s3)
+
+        _put_spectrum(table, "dp-001", observation_date_mjd=60000.3, sha256="sha_1")
+        _put_spectrum(table, "dp-002", observation_date_mjd=60000.4, sha256="sha_2")
+
+        for p in _sweep_patches():
+            p.start()
+        try:
+            result = run_compositing_sweep(_NOVA_ID, table, s3, _BUCKET_NAME)
+        finally:
+            patch.stopall()
+
+        assert result["groups_found"] == 1
+        assert result["built"] == 1
+        assert result["skipped"] == 0
+
+        # Verify composite DDB item was written.
+        composites = table.query(
+            KeyConditionExpression=(
+                boto3.dynamodb.conditions.Key("PK").eq(_NOVA_ID)
+                & boto3.dynamodb.conditions.Key("SK").begins_with("PRODUCT#SPECTRA#ESO#COMPOSITE#")
+            ),
+        )["Items"]
+        assert len(composites) == 1
+        comp = composites[0]
+        assert sorted(comp["constituent_data_product_ids"]) == ["dp-001", "dp-002"]
+        assert comp["composite_s3_key"] is not None
+        assert comp["web_ready_s3_key"] is not None
+
+    @mock_aws
+    def test_fingerprint_match_skips(self) -> None:
+        """Unchanged group is skipped when fingerprint matches."""
+        dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+        table = _create_table(dynamodb)
+        s3 = boto3.client("s3", region_name=_REGION)
+        _create_bucket(s3)
+
+        _put_spectrum(table, "dp-001", observation_date_mjd=60000.3, sha256="sha_1")
+        _put_spectrum(table, "dp-002", observation_date_mjd=60000.4, sha256="sha_2")
+
+        # Pre-compute the fingerprint that the sweep would generate.
+        from generators.compositing import compute_composite_fingerprint
+
+        expected_fp = compute_composite_fingerprint(
+            ["dp-001", "dp-002"],
+            {"dp-001": "sha_1", "dp-002": "sha_2"},
+        )
+
+        _put_existing_composite(
+            table,
+            "existing-comp",
+            expected_fp,
+            constituent_ids=["dp-001", "dp-002"],
+        )
+
+        result = run_compositing_sweep(_NOVA_ID, table, s3, _BUCKET_NAME)
+        assert result["groups_found"] == 1
+        assert result["skipped"] == 1
+        assert result["built"] == 0
+
+    @mock_aws
+    def test_fingerprint_mismatch_rebuilds(self) -> None:
+        """Changed sha256 causes fingerprint mismatch → rebuild."""
+        dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+        table = _create_table(dynamodb)
+        s3 = boto3.client("s3", region_name=_REGION)
+        _create_bucket(s3)
+
+        _put_spectrum(table, "dp-001", observation_date_mjd=60000.3, sha256="sha_CHANGED")
+        _put_spectrum(table, "dp-002", observation_date_mjd=60000.4, sha256="sha_2")
+
+        _put_existing_composite(
+            table,
+            "old-comp",
+            "stale-fingerprint",
+            constituent_ids=["dp-001", "dp-002"],
+        )
+
+        for p in _sweep_patches():
+            p.start()
+        try:
+            result = run_compositing_sweep(_NOVA_ID, table, s3, _BUCKET_NAME)
+        finally:
+            patch.stopall()
+
+        assert result["skipped"] == 0
+        assert result["built"] == 1
+
+    @mock_aws
+    def test_degenerate_composite(self) -> None:
+        """Group where only 1 spectrum passes threshold → degenerate composite."""
+        dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+        table = _create_table(dynamodb)
+        s3 = boto3.client("s3", region_name=_REGION)
+        _create_bucket(s3)
+
+        _put_spectrum(table, "dp-big", observation_date_mjd=60000.3, sha256="sha_big")
+        _put_spectrum(table, "dp-small", observation_date_mjd=60000.4, sha256="sha_small")
+
+        # dp-big has 3000 points (above threshold), dp-small has 500 (below).
+        reader = _mock_fits_reader_by_id({"dp-big": 3000, "dp-small": 500})
+
+        with (
+            patch("generators.fits_reader.read_fits_spectrum", side_effect=reader),
+            patch("generators.shared.trim_dead_edges", side_effect=_passthrough_clean),
+            patch("generators.shared.remove_interior_dead_runs", side_effect=_passthrough_clean),
+            patch("generators.shared.reject_chip_gap_artifacts", side_effect=_passthrough_clean),
+            patch("generators.shared.segment_aware_lttb", side_effect=lambda wl, fx: (wl, fx)),
+        ):
+            result = run_compositing_sweep(_NOVA_ID, table, s3, _BUCKET_NAME)
+
+        assert result["degenerate"] == 1
+        assert result["built"] == 0
+
+        # Verify degenerate DDB item.
+        composites = table.query(
+            KeyConditionExpression=(
+                boto3.dynamodb.conditions.Key("PK").eq(_NOVA_ID)
+                & boto3.dynamodb.conditions.Key("SK").begins_with("PRODUCT#SPECTRA#ESO#COMPOSITE#")
+            ),
+        )["Items"]
+        assert len(composites) == 1
+        comp = composites[0]
+        assert comp["constituent_data_product_ids"] == ["dp-big"]
+        assert "dp-small" in comp["rejected_data_product_ids"]
+        assert "composite_s3_key" not in comp
+        assert comp["web_ready_s3_key"] == f"derived/spectra/{_NOVA_ID}/dp-big/web_ready.csv"
+
+    @mock_aws
+    def test_all_rejected(self) -> None:
+        """Group where all spectra are below threshold → no composite written."""
+        dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+        table = _create_table(dynamodb)
+        s3 = boto3.client("s3", region_name=_REGION)
+        _create_bucket(s3)
+
+        _put_spectrum(table, "dp-tiny1", observation_date_mjd=60000.3, sha256="sha_1")
+        _put_spectrum(table, "dp-tiny2", observation_date_mjd=60000.4, sha256="sha_2")
+
+        reader = _mock_fits_reader_by_id({"dp-tiny1": 100, "dp-tiny2": 200})
+
+        with (
+            patch("generators.fits_reader.read_fits_spectrum", side_effect=reader),
+            patch("generators.shared.trim_dead_edges", side_effect=_passthrough_clean),
+            patch("generators.shared.remove_interior_dead_runs", side_effect=_passthrough_clean),
+            patch("generators.shared.reject_chip_gap_artifacts", side_effect=_passthrough_clean),
+        ):
+            result = run_compositing_sweep(_NOVA_ID, table, s3, _BUCKET_NAME)
+
+        assert result["groups_found"] == 1
+        assert result["built"] == 0
+        assert result["degenerate"] == 0
+
+        # No composite written.
+        composites = table.query(
+            KeyConditionExpression=(
+                boto3.dynamodb.conditions.Key("PK").eq(_NOVA_ID)
+                & boto3.dynamodb.conditions.Key("SK").begins_with("PRODUCT#SPECTRA#ESO#COMPOSITE#")
+            ),
+        )["Items"]
+        assert len(composites) == 0
+
+    @mock_aws
+    def test_new_spectrum_breaks_fingerprint(self) -> None:
+        """Adding a new spectrum to an existing group triggers a rebuild."""
+        dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+        table = _create_table(dynamodb)
+        s3 = boto3.client("s3", region_name=_REGION)
+        _create_bucket(s3)
+
+        # Existing composite was built from dp-001 + dp-002.
+        from generators.compositing import compute_composite_fingerprint
+
+        old_fp = compute_composite_fingerprint(
+            ["dp-001", "dp-002"],
+            {"dp-001": "sha_1", "dp-002": "sha_2"},
+        )
+        _put_existing_composite(
+            table,
+            "old-comp",
+            old_fp,
+            constituent_ids=["dp-001", "dp-002"],
+        )
+
+        # Same two spectra plus a new one on the same night.
+        _put_spectrum(table, "dp-001", observation_date_mjd=60000.3, sha256="sha_1")
+        _put_spectrum(table, "dp-002", observation_date_mjd=60000.4, sha256="sha_2")
+        _put_spectrum(table, "dp-003", observation_date_mjd=60000.35, sha256="sha_3")
+
+        for p in _sweep_patches():
+            p.start()
+        try:
+            result = run_compositing_sweep(_NOVA_ID, table, s3, _BUCKET_NAME)
+        finally:
+            patch.stopall()
+
+        assert result["skipped"] == 0
+        assert result["built"] == 1
+
+    @mock_aws
+    def test_error_in_one_group_doesnt_crash_sweep(self) -> None:
+        """An error in one group increments errors but processes others."""
+        dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+        table = _create_table(dynamodb)
+        s3 = boto3.client("s3", region_name=_REGION)
+        _create_bucket(s3)
+
+        # Group 1: night 1, UVES — will error (FITS reader returns None)
+        _put_spectrum(
+            table, "dp-err1", instrument="UVES", observation_date_mjd=60000.3, sha256="s1"
+        )
+        _put_spectrum(
+            table, "dp-err2", instrument="UVES", observation_date_mjd=60000.4, sha256="s2"
+        )
+
+        # Group 2: night 1, XSHOOTER — will succeed
+        _put_spectrum(
+            table, "dp-ok1", instrument="XSHOOTER", observation_date_mjd=60000.3, sha256="s3"
+        )
+        _put_spectrum(
+            table, "dp-ok2", instrument="XSHOOTER", observation_date_mjd=60000.4, sha256="s4"
+        )
+
+        call_count = 0
+
+        def _flaky_reader(
+            s3_client: Any,
+            bucket: str,
+            raw_s3_key: str,
+            data_product_id: str,
+        ) -> tuple[np.ndarray, np.ndarray] | None:
+            nonlocal call_count
+            call_count += 1
+            if data_product_id.startswith("dp-err"):
+                raise RuntimeError("Simulated FITS read failure")
+            wl = np.linspace(400.0, 700.0, 3000)
+            fx = np.ones(3000) + 1.0
+            return wl, fx
+
+        with (
+            patch("generators.fits_reader.read_fits_spectrum", side_effect=_flaky_reader),
+            patch("generators.shared.trim_dead_edges", side_effect=_passthrough_clean),
+            patch("generators.shared.remove_interior_dead_runs", side_effect=_passthrough_clean),
+            patch("generators.shared.reject_chip_gap_artifacts", side_effect=_passthrough_clean),
+            patch("generators.shared.segment_aware_lttb", side_effect=lambda wl, fx: (wl, fx)),
+        ):
+            result = run_compositing_sweep(_NOVA_ID, table, s3, _BUCKET_NAME)
+
+        assert result["groups_found"] == 2
+        assert result["errors"] == 1
+        assert result["built"] == 1
+
+    @mock_aws
+    def test_multiple_instruments_independent(self) -> None:
+        """Groups from different instruments are processed independently."""
+        dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+        table = _create_table(dynamodb)
+        s3 = boto3.client("s3", region_name=_REGION)
+        _create_bucket(s3)
+
+        # UVES pair on night 1
+        _put_spectrum(table, "dp-u1", instrument="UVES", observation_date_mjd=60000.3, sha256="su1")
+        _put_spectrum(table, "dp-u2", instrument="UVES", observation_date_mjd=60000.4, sha256="su2")
+
+        # XSHOOTER pair on night 1
+        _put_spectrum(
+            table, "dp-x1", instrument="XSHOOTER", observation_date_mjd=60000.3, sha256="sx1"
+        )
+        _put_spectrum(
+            table, "dp-x2", instrument="XSHOOTER", observation_date_mjd=60000.4, sha256="sx2"
+        )
+
+        for p in _sweep_patches():
+            p.start()
+        try:
+            result = run_compositing_sweep(_NOVA_ID, table, s3, _BUCKET_NAME)
+        finally:
+            patch.stopall()
+
+        assert result["groups_found"] == 2
+        assert result["built"] == 2
+
+        # Verify two distinct composites written.
+        composites = table.query(
+            KeyConditionExpression=(
+                boto3.dynamodb.conditions.Key("PK").eq(_NOVA_ID)
+                & boto3.dynamodb.conditions.Key("SK").begins_with("PRODUCT#SPECTRA#")
+            ),
+        )["Items"]
+        comp_items = [i for i in composites if "COMPOSITE" in str(i["SK"])]
+        assert len(comp_items) == 2
+        instruments = {c["instrument"] for c in comp_items}
+        assert instruments == {"UVES", "XSHOOTER"}
+
+    @mock_aws
+    def test_no_raw_s3_key_rejects_spectrum(self) -> None:
+        """Spectrum without raw_s3_key is treated as rejected."""
+        dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+        table = _create_table(dynamodb)
+        s3 = boto3.client("s3", region_name=_REGION)
+        _create_bucket(s3)
+
+        _put_spectrum(
+            table, "dp-good", observation_date_mjd=60000.3, sha256="s1", raw_s3_key="raw/good.fits"
+        )
+        _put_spectrum(table, "dp-nokey", observation_date_mjd=60000.4, sha256="s2", raw_s3_key=None)
+
+        reader = _mock_fits_reader(n_points=3000)
+
+        with (
+            patch("generators.fits_reader.read_fits_spectrum", side_effect=reader),
+            patch("generators.shared.trim_dead_edges", side_effect=_passthrough_clean),
+            patch("generators.shared.remove_interior_dead_runs", side_effect=_passthrough_clean),
+            patch("generators.shared.reject_chip_gap_artifacts", side_effect=_passthrough_clean),
+            patch("generators.shared.segment_aware_lttb", side_effect=lambda wl, fx: (wl, fx)),
+        ):
+            result = run_compositing_sweep(_NOVA_ID, table, s3, _BUCKET_NAME)
+
+        # Only 1 constituent → degenerate.
+        assert result["degenerate"] == 1
+        assert result["built"] == 0

--- a/tests/services/artifact_generator/test_main_compositing.py
+++ b/tests/services/artifact_generator/test_main_compositing.py
@@ -1,0 +1,224 @@
+"""Tests for compositing sweep integration in main._process_nova().
+
+Verifies that run_compositing_sweep is called (or not) based on
+dirty_types, and that failures do not abort the nova.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from moto import mock_aws
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_TABLE_NAME = "NovaCat-Test"
+_PHOT_TABLE_NAME = "NovaCat-Photometry-Test"
+_BUCKET_PRIVATE = "nova-cat-private-test"
+_BUCKET_PUBLIC = "nova-cat-public-test"
+_REGION = "us-east-1"
+_PLAN_ID = "test-plan-00000000-0000-0000-0000-000000000001"
+
+_NOVA_A = "aaaaaaaa-0000-0000-0000-000000000001"
+
+_REGEN_PLAN_PK = "REGEN_PLAN"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def aws_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NOVA_CAT_TABLE_NAME", _TABLE_NAME)
+    monkeypatch.setenv("NOVA_CAT_PHOTOMETRY_TABLE_NAME", _PHOT_TABLE_NAME)
+    monkeypatch.setenv("NOVA_CAT_PRIVATE_BUCKET", _BUCKET_PRIVATE)
+    monkeypatch.setenv("NOVA_CAT_PUBLIC_SITE_BUCKET", _BUCKET_PUBLIC)
+    monkeypatch.setenv("PLAN_ID", _PLAN_ID)
+    monkeypatch.setenv("AWS_DEFAULT_REGION", _REGION)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+    monkeypatch.setenv("BAND_REGISTRY_PATH", "/nonexistent/band_registry.json")
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+
+
+@pytest.fixture()
+def table(aws_env: None) -> Any:
+    with mock_aws():
+        dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+        tbl = dynamodb.create_table(
+            TableName=_TABLE_NAME,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        dynamodb.create_table(
+            TableName=_PHOT_TABLE_NAME,
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        s3 = boto3.client("s3", region_name=_REGION)
+        s3.create_bucket(Bucket=_BUCKET_PUBLIC)
+        s3.create_bucket(Bucket=_BUCKET_PRIVATE)
+        yield tbl
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_module() -> types.ModuleType:
+    for key in list(sys.modules):
+        if key == "main" or key.startswith("main."):
+            del sys.modules[key]
+    return importlib.import_module("main")
+
+
+def _seed_nova(table: Any, nova_id: str) -> None:
+    table.put_item(
+        Item={
+            "PK": nova_id,
+            "SK": "NOVA",
+            "entity_type": "Nova",
+            "nova_id": nova_id,
+            "primary_name": "Test Nova",
+            "aliases": ["Alias A"],
+            "ra_deg": Decimal("52.799083"),
+            "dec_deg": Decimal("43.904667"),
+            "status": "ACTIVE",
+            "discovery_date": "2000-01-01",
+        }
+    )
+
+
+def _noop_generate(
+    nova_id: str,
+    artifact: Any,
+    nova_context: dict[str, Any],
+    publisher: Any = None,
+) -> None:
+    artifact_val = artifact.value if hasattr(artifact, "value") else str(artifact)
+    if artifact_val == "spectra.json":
+        nova_context["spectra_count"] = 0
+    elif artifact_val == "photometry.json":
+        nova_context["photometry_count"] = 0
+        nova_context["photometry_raw_items"] = []
+        nova_context["photometry_observations"] = []
+        nova_context["photometry_bands"] = []
+    elif artifact_val == "references.json":
+        nova_context["references_count"] = 0
+        nova_context["references_output"] = []
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompositingSweepIntegration:
+    """Verify compositing sweep wiring in _process_nova()."""
+
+    def test_compositing_runs_for_spectra_dirty_type(self, table: Any) -> None:
+        """run_compositing_sweep is called when dirty_types includes 'spectra'."""
+        _seed_nova(table, _NOVA_A)
+        mod = _load_module()
+
+        manifest = {
+            "dirty_types": ["spectra"],
+            "artifacts": ["spectra.json", "nova.json"],
+        }
+        publisher = MagicMock()
+        publisher.copy_forward_missing_artifacts.return_value = []
+
+        sweep_result = {
+            "groups_found": 2,
+            "skipped": 1,
+            "built": 1,
+            "degenerate": 0,
+            "errors": 0,
+        }
+
+        with (
+            patch.object(mod, "_generate_and_publish", side_effect=_noop_generate),
+            patch(
+                "generators.compositing.run_compositing_sweep",
+                return_value=sweep_result,
+            ) as mock_sweep,
+        ):
+            result = mod._process_nova(_NOVA_A, manifest, publisher)
+
+        assert result.success is True
+        mock_sweep.assert_called_once_with(_NOVA_A, mod._table, mod._s3, _BUCKET_PRIVATE)
+
+    def test_compositing_skipped_for_non_spectra_dirty_types(self, table: Any) -> None:
+        """run_compositing_sweep is NOT called for non-spectra dirty types."""
+        _seed_nova(table, _NOVA_A)
+        mod = _load_module()
+
+        manifest = {
+            "dirty_types": ["photometry"],
+            "artifacts": ["photometry.json", "nova.json"],
+        }
+        publisher = MagicMock()
+        publisher.copy_forward_missing_artifacts.return_value = []
+
+        with (
+            patch.object(mod, "_generate_and_publish", side_effect=_noop_generate),
+            patch(
+                "generators.compositing.run_compositing_sweep",
+            ) as mock_sweep,
+        ):
+            result = mod._process_nova(_NOVA_A, manifest, publisher)
+
+        assert result.success is True
+        mock_sweep.assert_not_called()
+
+    def test_compositing_failure_does_not_fail_nova(self, table: Any) -> None:
+        """A compositing sweep exception does not prevent artifact generation."""
+        _seed_nova(table, _NOVA_A)
+        mod = _load_module()
+
+        manifest = {
+            "dirty_types": ["spectra"],
+            "artifacts": ["spectra.json", "nova.json"],
+        }
+        publisher = MagicMock()
+        publisher.copy_forward_missing_artifacts.return_value = []
+
+        with (
+            patch.object(mod, "_generate_and_publish", side_effect=_noop_generate) as mock_gen,
+            patch(
+                "generators.compositing.run_compositing_sweep",
+                side_effect=RuntimeError("S3 timeout"),
+            ) as mock_sweep,
+        ):
+            result = mod._process_nova(_NOVA_A, manifest, publisher)
+
+            assert result.success is True
+            mock_sweep.assert_called_once()
+            # Verify artifact generation still ran despite compositing failure.
+            assert mock_gen.call_count >= 1

--- a/tests/services/artifact_generator/test_spectra_composite_filtering.py
+++ b/tests/services/artifact_generator/test_spectra_composite_filtering.py
@@ -1,0 +1,256 @@
+"""Unit tests for composite filtering in generators/spectra.py.
+
+Covers:
+  - Composites replace their constituent spectra in the display set.
+  - Rejected spectra from composites are suppressed.
+  - Non-composited spectra pass through unchanged.
+  - Composite web-ready S3 key is used instead of constructed path.
+  - Mixed composites and individuals produce the correct display set.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock
+
+from generators.spectra import (
+    _filter_composites,
+    _process_spectrum_stage1,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_individual_product(
+    data_product_id: str,
+    provider: str = "ESO",
+    mjd: float = 59000.0,
+) -> dict[str, Any]:
+    """Build a minimal individual spectra DataProduct item."""
+    return {
+        "PK": "nova-test",
+        "SK": f"PRODUCT#SPECTRA#{provider}#{data_product_id}",
+        "data_product_id": data_product_id,
+        "validation_status": "VALID",
+        "instrument": "X-Shooter",
+        "telescope": "VLT",
+        "provider": provider,
+        "observation_date_mjd": Decimal(str(mjd)),
+        "wavelength_min_nm": Decimal("350"),
+        "wavelength_max_nm": Decimal("900"),
+        "flux_unit": "erg/s/cm2/A",
+    }
+
+
+def _make_composite_product(
+    composite_id: str,
+    constituent_ids: list[str],
+    rejected_ids: list[str] | None = None,
+    provider: str = "ESO",
+    mjd: float = 59000.0,
+    web_ready_s3_key: str | None = None,
+) -> dict[str, Any]:
+    """Build a minimal composite spectra DataProduct item."""
+    if web_ready_s3_key is None:
+        web_ready_s3_key = f"derived/spectra/nova-test/composites/{composite_id}/web_ready.csv"
+    return {
+        "PK": "nova-test",
+        "SK": f"PRODUCT#SPECTRA#{provider}#COMPOSITE#{composite_id}",
+        "data_product_id": composite_id,
+        "validation_status": "VALID",
+        "instrument": "X-Shooter",
+        "telescope": "VLT",
+        "provider": provider,
+        "observation_date_mjd": Decimal(str(mjd)),
+        "wavelength_min_nm": Decimal("350"),
+        "wavelength_max_nm": Decimal("900"),
+        "flux_unit": "erg/s/cm2/A",
+        "constituent_data_product_ids": constituent_ids,
+        "rejected_data_product_ids": rejected_ids or [],
+        "web_ready_s3_key": web_ready_s3_key,
+    }
+
+
+def _make_csv_body(n_points: int = 100) -> str:
+    """Generate a simple web-ready CSV body."""
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(["wavelength_nm", "flux"])
+    for i in range(n_points):
+        wl = 400.0 + i * 5.0
+        fx = 1.0 + 0.5 * (i % 10)
+        writer.writerow([wl, fx])
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Test: _filter_composites
+# ---------------------------------------------------------------------------
+
+
+class TestFilterComposites:
+    """Post-query filtering logic for composite spectra."""
+
+    def test_composite_replaces_constituents(self) -> None:
+        """Composite's constituent spectra are excluded from display set."""
+        individual_a = _make_individual_product("dp-a")
+        individual_b = _make_individual_product("dp-b")
+        composite = _make_composite_product(
+            "comp-1",
+            constituent_ids=["dp-a", "dp-b"],
+        )
+
+        products = [individual_a, individual_b, composite]
+        result = _filter_composites(products)
+
+        result_ids = [p["data_product_id"] for p in result]
+        assert "comp-1" in result_ids
+        assert "dp-a" not in result_ids
+        assert "dp-b" not in result_ids
+
+    def test_rejected_spectra_suppressed(self) -> None:
+        """Composite's rejected spectra are also excluded from display set."""
+        individual_a = _make_individual_product("dp-a")
+        individual_rejected = _make_individual_product("dp-rejected")
+        individual_unrelated = _make_individual_product("dp-unrelated")
+        composite = _make_composite_product(
+            "comp-1",
+            constituent_ids=["dp-a"],
+            rejected_ids=["dp-rejected"],
+        )
+
+        products = [individual_a, individual_rejected, individual_unrelated, composite]
+        result = _filter_composites(products)
+
+        result_ids = [p["data_product_id"] for p in result]
+        assert "comp-1" in result_ids
+        assert "dp-unrelated" in result_ids
+        assert "dp-a" not in result_ids
+        assert "dp-rejected" not in result_ids
+
+    def test_non_composited_spectra_pass_through(self) -> None:
+        """Spectra not referenced by any composite remain unchanged."""
+        individual_a = _make_individual_product("dp-a")
+        individual_b = _make_individual_product("dp-b")
+        individual_c = _make_individual_product("dp-c")
+
+        products = [individual_a, individual_b, individual_c]
+        result = _filter_composites(products)
+
+        result_ids = [p["data_product_id"] for p in result]
+        assert result_ids == ["dp-a", "dp-b", "dp-c"]
+
+    def test_mixed_composites_and_individuals(self) -> None:
+        """Nova with both composited and non-composited spectra."""
+        # Night 1: dp-a + dp-b composited into comp-1
+        individual_a = _make_individual_product("dp-a", mjd=59000.0)
+        individual_b = _make_individual_product("dp-b", mjd=59000.0)
+        composite_1 = _make_composite_product(
+            "comp-1",
+            constituent_ids=["dp-a", "dp-b"],
+            mjd=59000.0,
+        )
+        # Night 2: dp-c stands alone (no composite)
+        individual_c = _make_individual_product("dp-c", mjd=59001.0)
+        # Night 3: dp-d composited, dp-e rejected
+        individual_d = _make_individual_product("dp-d", mjd=59002.0)
+        individual_e = _make_individual_product("dp-e", mjd=59002.0)
+        composite_2 = _make_composite_product(
+            "comp-2",
+            constituent_ids=["dp-d"],
+            rejected_ids=["dp-e"],
+            mjd=59002.0,
+        )
+
+        products = [
+            individual_a,
+            individual_b,
+            individual_c,
+            individual_d,
+            individual_e,
+            composite_1,
+            composite_2,
+        ]
+        result = _filter_composites(products)
+
+        result_ids = [p["data_product_id"] for p in result]
+        # Composites present
+        assert "comp-1" in result_ids
+        assert "comp-2" in result_ids
+        # Non-composited individual present
+        assert "dp-c" in result_ids
+        # Suppressed individuals absent
+        assert "dp-a" not in result_ids
+        assert "dp-b" not in result_ids
+        assert "dp-d" not in result_ids
+        assert "dp-e" not in result_ids
+        # Total: 2 composites + 1 individual = 3
+        assert len(result) == 3
+
+
+# ---------------------------------------------------------------------------
+# Test: Composite web-ready path
+# ---------------------------------------------------------------------------
+
+
+class TestCompositeWebReadyPath:
+    """Composite items use their stored web_ready_s3_key for S3 reads."""
+
+    def test_composite_uses_web_ready_s3_key(self) -> None:
+        """_process_spectrum_stage1 reads from the composite's web_ready_s3_key."""
+        composite_s3_key = "derived/spectra/nova-test/composites/comp-1/web_ready.csv"
+        composite = _make_composite_product(
+            "comp-1",
+            constituent_ids=["dp-a", "dp-b"],
+            web_ready_s3_key=composite_s3_key,
+        )
+
+        csv_body = _make_csv_body()
+        s3_client = MagicMock()
+        s3_client.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=csv_body.encode("utf-8")))
+        }
+
+        result = _process_spectrum_stage1(
+            "nova-test",
+            composite,
+            s3_client,
+            "test-bucket",
+        )
+
+        # Verify S3 was called with the composite's key, not the constructed one
+        s3_client.get_object.assert_called_once_with(
+            Bucket="test-bucket",
+            Key=composite_s3_key,
+        )
+        assert result is not None
+        assert result["product"]["data_product_id"] == "comp-1"
+
+    def test_individual_uses_constructed_path(self) -> None:
+        """Non-composite items still use the conventional S3 key construction."""
+        individual = _make_individual_product("dp-a")
+
+        csv_body = _make_csv_body()
+        s3_client = MagicMock()
+        s3_client.get_object.return_value = {
+            "Body": MagicMock(read=MagicMock(return_value=csv_body.encode("utf-8")))
+        }
+
+        result = _process_spectrum_stage1(
+            "nova-test",
+            individual,
+            s3_client,
+            "test-bucket",
+        )
+
+        expected_key = "derived/spectra/nova-test/dp-a/web_ready.csv"
+        s3_client.get_object.assert_called_once_with(
+            Bucket="test-bucket",
+            Key=expected_key,
+        )
+        assert result is not None

--- a/tools/refresh_artifacts.py
+++ b/tools/refresh_artifacts.py
@@ -199,6 +199,25 @@ def _build_nova_context(
 # ---------------------------------------------------------------------------
 
 
+def _print_sweep_summary(result: dict) -> None:
+    """Print a one-line compositing sweep summary."""
+    parts = []
+    if result.get("groups_found", 0):
+        parts.append(f"{result['groups_found']} groups")
+    if result.get("built", 0):
+        parts.append(f"{result['built']} built")
+    if result.get("degenerate", 0):
+        parts.append(f"{result['degenerate']} degenerate")
+    if result.get("skipped", 0):
+        parts.append(f"{result['skipped']} skipped")
+    if result.get("errors", 0):
+        parts.append(f"{result['errors']} errors")
+    if parts:
+        print(f"    [compositing] {', '.join(parts)}")
+    else:
+        print("    [compositing] no compositable groups")
+
+
 def _generate_and_upload(
     nova_item: dict,
     artifacts: list[str],
@@ -215,6 +234,18 @@ def _generate_and_upload(
     stats = {"generated": 0, "failed": 0}
 
     ctx = _build_nova_context(nova_item, table, aws["photometry_table"])
+
+    # --- Phase 1: Compositing sweep (ADR-033) ---
+    # Run before the spectra generator so composites are available.
+    if "spectra" in artifacts and not dry_run:
+        try:
+            from generators.compositing import run_compositing_sweep
+
+            sweep_result = run_compositing_sweep(nova_id, table, s3, private_bucket)
+            _print_sweep_summary(sweep_result)
+        except Exception as exc:
+            print(f"    [WARN] Compositing sweep failed: {exc}")
+            print("    Continuing with individual spectra...")
 
     prefix = f"releases/{release_id}/nova/{nova_id}/"
 
@@ -494,6 +525,21 @@ def main() -> None:
         print()
 
     print(f"Done. Generated: {totals['generated']}, Failed: {totals['failed']}")
+    # Invalidate CloudFront cache for refreshed artifacts
+    if not args.dry_run:
+        dist_id = os.environ.get("NOVACAT_CF_DISTRIBUTION_ID")
+        if dist_id:
+            cf = boto3.client("cloudfront")
+            cf.create_invalidation(
+                DistributionId=dist_id,
+                InvalidationBatch={
+                    "Paths": {"Quantity": 1, "Items": ["/*"]},
+                    "CallerReference": release_id,
+                },
+            )
+            print(f"CloudFront invalidation submitted for {dist_id}")
+        else:
+            print("Skipping CloudFront invalidation (NOVACAT_CF_DISTRIBUTION_ID not set)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Spectra compositing pipeline (ADR-033) — same-instrument, same-night
  spectra are cleaned at full FITS resolution, resampled onto a common
  grid, and median-combined into single composite display spectra
- Three-strategy FITS reader handles primary HDU, first extension, and
  binary table layouts across ESO instruments
- Fingerprint-based rebuild avoidance skips unchanged groups without
  reading FITS
- Degenerate composites (single survivor after threshold filtering)
  reference the original spectrum's web-ready CSV — no special-case
  logic needed downstream
- Observation table preserved: all individual spectra remain visible
  in the table even when replaced by composites in the waterfall plot
- Compositing wired into both the Fargate task (main.py) and the local
  refresh tool (refresh_artifacts.py)

## Why

- Dense same-night coverage (e.g., V906 Car with dozens of UVES spectra
  per night) cluttered the waterfall plot without adding scientific
  information
- Compositing produces higher-SNR display spectra while preserving the
  original data in bundles and the observation table
- Cleaning at full FITS resolution catches artifacts that the
  web-ready CSV resolution misses

## Testing

- 120+ new tests across 9 test files covering clustering, grid
  determination, fingerprinting, composite IDs, cleaning, resampling,
  combination, CSV serialization, FITS parsing (synthetic data),
  DDB queries/writes (moto), S3 persistence (moto), sweep
  orchestration (end-to-end with mocked FITS), spectra generator
  filtering, main.py wiring, and observation table preservation
- Local end-to-end verification: ran refresh_artifacts.py against
  V906 Car, confirmed composites built, waterfall plot rendered
  correctly on the live site
- All existing tests pass (1400+)

## Notes

- ADR-033 Decision 10 was updated during implementation: degenerate
  composites now carry the survivor's web_ready_s3_key rather than
  None, eliminating pass-through logic in the spectra generator
- The fingerprint covers all evaluated spectra (constituents + rejected)
  so rejected spectra changes also trigger rebuilds
- fits_reader.py uses a median-wavelength heuristic (>100 = Angstrom)
  as a last-resort unit detection when FITS headers lack CUNIT/TUNIT
- Orphaned composites (whose constituents are all removed) are not
  cleaned up by the sweep — deferred per the DDB item model docs

## Out of Scope

- Cross-instrument compositing
- Inverse-variance weighted combination
- Composite spectra in research bundles
- Orphaned composite cleanup
- ADR-014 schema version bump to 1.2 (prereq item, not yet done)
- DESIGN-003 Phase 1 documentation update (prereq item, not yet done)
- IAM verification on Fargate task role (prereq item, not yet done)

## Next Steps

- Complete remaining ADR-033 prereqs (ADR-014 amendment, DESIGN-003
  docs, IAM verification)
- Run full sweep with --all to composite across the entire catalog
- Monitor for FITS layouts not covered by the three-strategy reader
- Clean up stale CloudWatch log groups (separate task)