### PR TITLE
feat(discovery): add MAST HASP spectra discovery and validation

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/infra/workflows/discover_spectra_products.asl.json
+++ b/infra/workflows/discover_spectra_products.asl.json
@@ -104,10 +104,13 @@
         },
         "PrepareProviderList": {
             "Type": "Pass",
-            "Comment": "Inject the hardcoded provider list into state. To onboard a new provider (e.g. MAST), add an entry here \u2014 no other ASL changes required.",
+            "Comment": "Inject the hardcoded provider list into state. To onboard a new provider, add an entry here \u2014 no other ASL changes required.",
             "Result": [
                 {
                     "provider": "ESO"
+                },
+                {
+                    "provider": "MAST"
                 }
             ],
             "ResultPath": "$.providers",

--- a/services/spectra_discoverer/adapters/__init__.py
+++ b/services/spectra_discoverer/adapters/__init__.py
@@ -15,9 +15,11 @@ To register a new provider:
 
 from .base import SpectraDiscoveryAdapter
 from .eso import ESOAdapter
+from .mast import MASTAdapter
 
 _PROVIDER_ADAPTERS: dict[str, SpectraDiscoveryAdapter] = {
     "ESO": ESOAdapter(),
+    "MAST": MASTAdapter(),
 }
 
 __all__ = ["SpectraDiscoveryAdapter", "_PROVIDER_ADAPTERS"]

--- a/services/spectra_discoverer/adapters/base.py
+++ b/services/spectra_discoverer/adapters/base.py
@@ -67,7 +67,7 @@ class SpectraDiscoveryAdapter(Protocol):
       - DataProduct.provider
       - LocatorAlias PK construction ("LOCATOR#<provider>#...")
       - DataProduct SK construction ("PRODUCT#SPECTRA#<provider>#...")
-    Example: "ESO"
+    Example: "ESO", "MAST"
     """
 
     def query(
@@ -76,16 +76,25 @@ class SpectraDiscoveryAdapter(Protocol):
         nova_id: str,
         ra_deg: float,
         dec_deg: float,
+        primary_name: str | None = None,
+        aliases: list[str] | None = None,
     ) -> list[dict]:
         """
         Query the provider archive for spectra products associated with
-        the given sky position.
+        the given sky position and/or target names.
 
         Args:
-            nova_id:  Nova UUID string (for logging/tracing only — not sent
-                      to the provider; the provider does not know nova_ids).
-            ra_deg:   Right ascension in decimal degrees (ICRS).
-            dec_deg:  Declination in decimal degrees (ICRS).
+            nova_id:      Nova UUID string (for logging/tracing only — not sent
+                          to the provider; the provider does not know nova_ids).
+            ra_deg:       Right ascension in decimal degrees (ICRS).
+            dec_deg:      Declination in decimal degrees (ICRS).
+            primary_name: Nova primary name (e.g. "V339 Del"). Optional —
+                          coordinate-based adapters (ESO) ignore this.
+                          Name-based adapters (MAST) use it for query_object.
+            aliases:      Additional known names / designations for the nova
+                          (e.g. ["Nova Del 2013", "NOVADEL2013"]). Used as
+                          fallback query terms when primary_name yields no
+                          results. Optional — may be None or empty.
 
         Returns:
             List of raw provider-native record dicts. Each dict contains

--- a/services/spectra_discoverer/adapters/eso.py
+++ b/services/spectra_discoverer/adapters/eso.py
@@ -104,9 +104,14 @@ class ESOAdapter:
         nova_id: str,
         ra_deg: float,
         dec_deg: float,
+        primary_name: str | None = None,
+        aliases: list[str] | None = None,
     ) -> list[dict]:
         """
         Execute an ESO SSAP cone search and return raw result records.
+
+        ESO uses coordinate-based cone search exclusively; primary_name and
+        aliases are accepted for Protocol compatibility but not used.
 
         Raises RetryableError on any network or service failure so the
         handler's retry policy can engage.
@@ -227,10 +232,10 @@ def _sanitize_value(value: Any) -> Any:
     """
     Convert a pyvo/astropy SSAP field value to a JSON-safe Python type.
 
-      bytes        → decode to str (strip whitespace)
-      numpy scalar → .item() to Python native
-      nan/inf      → None (not JSON-serializable)
-      everything else → unchanged
+    bytes        → decode to str (strip whitespace)
+    numpy scalar → .item() to Python native
+    nan/inf      → None (not JSON-serializable)
+    everything else → unchanged
     """
     if isinstance(value, bytes):
         return value.decode("utf-8", errors="replace").strip() or None

--- a/services/spectra_discoverer/adapters/mast.py
+++ b/services/spectra_discoverer/adapters/mast.py
@@ -1,0 +1,453 @@
+"""
+adapters/mast.py
+
+MAST (Mikulski Archive for Space Telescopes) adapter for spectra discovery.
+
+Implements SpectraDiscoveryAdapter for HST HASP (Hubble Advanced Spectral
+Products) co-added spectra served via the MAST archive at mast.stsci.edu.
+
+Query strategy:
+    Name-based object search via astroquery.mast.Observations.query_object()
+    with a 1-arcmin search radius. MAST internally resolves the target name
+    to coordinates (via SIMBAD/NED) and performs a cone search. This approach
+    is required because HST Target-of-Opportunity (ToO) observations often
+    have significant coordinate offsets from SIMBAD positions, causing pure
+    coordinate-based queries to miss targets.
+
+    Fallback: if the primary name yields zero HASP observations, each alias
+    is tried in order. The first name that produces results wins. This handles
+    cases where HST proposals used a pre-designation name (e.g. "NOVADEL2013"
+    instead of "V339 Del").
+
+    Two-step discovery:
+      1. query_object() → observation-level results
+         Filter: obs_collection == "HST", dataproduct_type == "spectrum",
+                 project == "HASP"
+      2. get_product_list() → data-product-level results
+         Filter: productFilename ends with "_cspec.fits"
+
+    HASP cspec files are per-visit co-added spectra — safe for transient
+    science because all constituent exposures are from the same epoch
+    (single HST visit = single scheduling block).
+
+Identity strategy (per ADR-003):
+    NATIVE_ID — productFilename is a stable, unique identifier assigned by
+    the HASP pipeline. Example:
+      "hst_13388_stis_novadel2013_e140m_oc7r06_cspec.fits"
+
+    The filename encodes: program ID, instrument, target, grating, visit ID.
+    It is deterministic and does not change across re-queries.
+
+Hints preserved for downstream FITS profile selection:
+    instrument       — HST instrument name (e.g. "STIS", "COS/FUV")
+    target_name      — MAST target name (as used by the HST proposal)
+    proposal_id      — HST program number
+    obs_id           — MAST observation ID
+    t_min_mjd        — observation start (MJD)
+    t_max_mjd        — observation end (MJD)
+
+Dependencies:
+    astroquery >= 0.4 — MAST query client (Observations)
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from decimal import Decimal
+from typing import Any
+
+from astroquery.mast import Observations  # type: ignore[import-untyped]
+from nova_common.errors import RetryableError
+from nova_common.logging import logger
+
+# MAST download URL template. dataURI is the unique file identifier returned
+# by get_product_list(). No authentication required for public HST data.
+_MAST_DOWNLOAD_URL_TEMPLATE = "https://mast.stsci.edu/api/v0.1/Download/file?uri={data_uri}"
+
+# Search radius for query_object. 1 arcmin accommodates HST ToO coordinate
+# offsets while remaining tight enough to avoid unrelated sources.
+_SEARCH_RADIUS = "1 arcmin"
+
+# Application-level retry parameters for MAST queries.
+_MAX_QUERY_ATTEMPTS = 3
+_QUERY_RETRY_DELAY_S = 3
+
+# Polite delay between successive MAST API calls (seconds).
+_INTER_CALL_DELAY_S = 0.5
+
+
+class MASTAdapter:
+    """
+    MAST HASP spectra discovery adapter.
+
+    Satisfies SpectraDiscoveryAdapter Protocol.
+    """
+
+    provider: str = "MAST"
+
+    # ------------------------------------------------------------------
+    # Protocol implementation
+    # ------------------------------------------------------------------
+
+    def query(
+        self,
+        *,
+        nova_id: str,
+        ra_deg: float,
+        dec_deg: float,
+        primary_name: str | None = None,
+        aliases: list[str] | None = None,
+    ) -> list[dict]:
+        """
+        Query MAST for HASP cspec data products associated with the nova.
+
+        Uses name-based search (query_object) with primary_name, falling
+        back to aliases if the primary name yields zero HASP observations.
+        Coordinates (ra_deg, dec_deg) are accepted for Protocol compatibility
+        but not used directly — MAST resolves names to coordinates internally.
+
+        Returns a list of raw product dicts, each enriched with observation-
+        level metadata (instrument, target_name, proposal_id, t_min, t_max).
+
+        Raises RetryableError on transient MAST service failures.
+        Raises ValueError if no names are available for querying.
+        """
+        if not primary_name:
+            raise ValueError(
+                f"MAST adapter requires primary_name for nova_id={nova_id!r}. "
+                "Coordinate-only queries are not supported."
+            )
+
+        # Build ordered list of names to try: primary first, then aliases.
+        names_to_try = [primary_name]
+        if aliases:
+            names_to_try.extend(alias for alias in aliases if alias != primary_name)
+
+        # Try each name until we get HASP observations.
+        hasp_obs = None
+        matched_name: str | None = None
+        for name in names_to_try:
+            obs = self._query_mast_observations(nova_id=nova_id, name=name)
+            if obs is not None and len(obs) > 0:
+                hasp_obs = obs
+                matched_name = name
+                logger.info(
+                    "MAST query matched on name",
+                    extra={
+                        "nova_id": nova_id,
+                        "matched_name": name,
+                        "hasp_obs_count": len(obs),
+                    },
+                )
+                break
+
+            logger.info(
+                "MAST query returned no HASP observations for name",
+                extra={"nova_id": nova_id, "tried_name": name},
+            )
+            time.sleep(_INTER_CALL_DELAY_S)
+
+        if hasp_obs is None or len(hasp_obs) == 0:
+            logger.info(
+                "MAST: no HASP observations found for any name",
+                extra={
+                    "nova_id": nova_id,
+                    "names_tried": names_to_try,
+                },
+            )
+            return []
+
+        # Step 2: Get data products for the matched HASP observations.
+        products = self._get_cspec_products(nova_id=nova_id, observations=hasp_obs)
+
+        # Enrich each product with observation-level metadata by joining
+        # on obsID. Build an obs_id → observation-metadata lookup first.
+        obs_lookup: dict[str, dict[str, Any]] = {}
+        for row in hasp_obs:
+            obs_id_key = str(row["obsid"])
+            obs_lookup[obs_id_key] = {
+                "instrument_name": str(row["instrument_name"]),
+                "target_name": str(row["target_name"]),
+                "proposal_id": str(row["proposal_id"]),
+                "obs_id": str(row["obs_id"]),
+                "t_min": _safe_float(row.get("t_min")),
+                "t_max": _safe_float(row.get("t_max")),
+            }
+
+        raw_products: list[dict[str, Any]] = []
+        for prod in products:
+            product_filename = str(prod["productFilename"])
+            data_uri = str(prod["dataURI"])
+            obs_id_key = str(prod["obsID"])
+
+            raw: dict[str, Any] = {
+                "productFilename": product_filename,
+                "dataURI": data_uri,
+                "obsID": obs_id_key,
+                "size": _safe_int(prod.get("size")),
+                "productSubGroupDescription": str(prod.get("productSubGroupDescription", "")),
+            }
+
+            # Merge observation-level metadata.
+            obs_meta = obs_lookup.get(obs_id_key, {})
+            raw.update(obs_meta)
+
+            raw_products.append(raw)
+
+        logger.info(
+            "MAST discovery complete",
+            extra={
+                "nova_id": nova_id,
+                "matched_name": matched_name,
+                "hasp_obs_count": len(hasp_obs),
+                "cspec_product_count": len(raw_products),
+            },
+        )
+        return raw_products
+
+    def normalize(
+        self,
+        *,
+        nova_id: str,
+        raw: dict,
+    ) -> dict | None:
+        """
+        Normalize one raw MAST product record into Nova Cat's internal
+        discovered-product shape.
+
+        Returns None for records that cannot be safely normalized.
+        """
+        product_filename: str | None = raw.get("productFilename")
+        data_uri: str | None = raw.get("dataURI")
+
+        if not product_filename:
+            logger.warning(
+                "MAST record missing productFilename — skipping",
+                extra={"nova_id": nova_id, "raw_keys": list(raw.keys())},
+            )
+            return None
+
+        if not data_uri:
+            logger.warning(
+                "MAST record missing dataURI — skipping",
+                extra={
+                    "nova_id": nova_id,
+                    "productFilename": product_filename,
+                },
+            )
+            return None
+
+        # Identity: NATIVE_ID using productFilename as the stable key.
+        provider_product_key = product_filename
+        locator_identity = f"provider_product_id:{product_filename}"
+        identity_strategy = "NATIVE_ID"
+
+        # Construct download URL from dataURI.
+        download_url = _MAST_DOWNLOAD_URL_TEMPLATE.format(data_uri=data_uri)
+        locators = [{"kind": "URL", "role": "PRIMARY", "value": download_url}]
+
+        hints = _extract_hints(raw)
+
+        return {
+            "provider": self.provider,
+            "nova_id": nova_id,
+            "provider_product_key": provider_product_key,
+            "locator_identity": locator_identity,
+            "identity_strategy": identity_strategy,
+            "locators": locators,
+            "hints": hints,
+        }
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _query_mast_observations(
+        self,
+        *,
+        nova_id: str,
+        name: str,
+    ) -> Any | None:
+        """
+        Query MAST for HST HASP spectral observations of the named target.
+
+        Returns an astropy Table of matching observations, or None on failure.
+        Retries transient errors up to _MAX_QUERY_ATTEMPTS times.
+        """
+        last_exc: Exception | None = None
+        for attempt in range(1, _MAX_QUERY_ATTEMPTS + 1):
+            try:
+                all_obs = Observations.query_object(name, radius=_SEARCH_RADIUS)
+                break
+            except Exception as exc:
+                last_exc = exc
+                if attempt < _MAX_QUERY_ATTEMPTS:
+                    logger.warning(
+                        "MAST query_object attempt %d/%d failed, retrying in %ds",
+                        attempt,
+                        _MAX_QUERY_ATTEMPTS,
+                        _QUERY_RETRY_DELAY_S,
+                        extra={
+                            "nova_id": nova_id,
+                            "name": name,
+                            "error": str(exc),
+                        },
+                    )
+                    time.sleep(_QUERY_RETRY_DELAY_S)
+        else:
+            raise RetryableError(
+                f"MAST query_object failed for nova_id={nova_id!r} name={name!r}: {last_exc}"
+            ) from last_exc
+
+        if all_obs is None or len(all_obs) == 0:
+            return None
+
+        # Filter to HST spectral HASP observations.
+        mask = (
+            (all_obs["obs_collection"] == "HST")
+            & (all_obs["dataproduct_type"] == "spectrum")
+            & (_str_upper_col(all_obs["project"]) == "HASP")
+        )
+        hasp_obs = all_obs[mask]
+
+        return hasp_obs if len(hasp_obs) > 0 else None
+
+    def _get_cspec_products(
+        self,
+        *,
+        nova_id: str,
+        observations: Any,
+    ) -> list[Any]:
+        """
+        Retrieve data products for the given observations and filter to
+        HASP cspec FITS files only.
+
+        Returns a list of product rows (astropy Table rows or similar).
+        """
+        time.sleep(_INTER_CALL_DELAY_S)
+
+        last_exc: Exception | None = None
+        for attempt in range(1, _MAX_QUERY_ATTEMPTS + 1):
+            try:
+                products = Observations.get_product_list(observations)
+                break
+            except Exception as exc:
+                last_exc = exc
+                if attempt < _MAX_QUERY_ATTEMPTS:
+                    logger.warning(
+                        "MAST get_product_list attempt %d/%d failed, retrying in %ds",
+                        attempt,
+                        _MAX_QUERY_ATTEMPTS,
+                        _QUERY_RETRY_DELAY_S,
+                        extra={"nova_id": nova_id, "error": str(exc)},
+                    )
+                    time.sleep(_QUERY_RETRY_DELAY_S)
+        else:
+            raise RetryableError(
+                f"MAST get_product_list failed for nova_id={nova_id!r}: {last_exc}"
+            ) from last_exc
+
+        if products is None or len(products) == 0:
+            logger.info(
+                "MAST: no data products returned",
+                extra={"nova_id": nova_id},
+            )
+            return []
+
+        # Filter to cspec FITS files (HASP co-added spectra).
+        cspec_products = [
+            row
+            for row in products
+            if str(row.get("productFilename", "")).lower().endswith("_cspec.fits")
+        ]
+
+        logger.info(
+            "MAST product filtering complete",
+            extra={
+                "nova_id": nova_id,
+                "total_products": len(products),
+                "cspec_products": len(cspec_products),
+            },
+        )
+        return cspec_products
+
+
+# ------------------------------------------------------------------
+# Module-level helpers (private)
+# ------------------------------------------------------------------
+
+
+def _str_upper_col(col: Any) -> Any:
+    """
+    Convert an astropy Table column to uppercase strings for comparison.
+    Handles masked/null values gracefully.
+    """
+    import numpy as np
+
+    result = np.array([str(v).upper() if v is not None else "" for v in col])
+    return result
+
+
+def _safe_float(value: Any) -> float | None:
+    """Convert a value to float, returning None for non-finite or missing values."""
+    if value is None:
+        return None
+    try:
+        f = float(value)
+        if math.isnan(f) or math.isinf(f):
+            return None
+        return f
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_int(value: Any) -> int | None:
+    """Convert a value to int, returning None for missing values."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_hints(raw: dict[str, Any]) -> dict[str, Any]:
+    """
+    Extract provider metadata hints for downstream FITS profile selection
+    and operator visibility.
+
+    Float values are converted to Decimal for DynamoDB compatibility.
+    """
+    hints: dict[str, Any] = {}
+
+    _maybe_set_str(hints, "instrument", raw.get("instrument_name"))
+    _maybe_set_str(hints, "target_name", raw.get("target_name"))
+    _maybe_set_str(hints, "proposal_id", raw.get("proposal_id"))
+    _maybe_set_str(hints, "obs_id", raw.get("obs_id"))
+    _maybe_set_numeric(hints, "t_min_mjd", raw.get("t_min"))
+    _maybe_set_numeric(hints, "t_max_mjd", raw.get("t_max"))
+
+    return hints
+
+
+def _maybe_set_str(hints: dict[str, Any], key: str, value: Any) -> None:
+    """Set hints[key] = str(value) if value is truthy."""
+    if value is not None and str(value).strip():
+        hints[key] = str(value).strip()
+
+
+def _maybe_set_numeric(hints: dict[str, Any], key: str, value: Any) -> None:
+    """
+    Set hints[key] = Decimal(value) if value is a finite number.
+    DynamoDB's boto3 resource layer rejects raw Python floats.
+    """
+    if value is None:
+        return
+    try:
+        f = float(value)
+        if math.isnan(f) or math.isinf(f):
+            return
+        hints[key] = Decimal(str(f))
+    except (TypeError, ValueError):
+        pass

--- a/services/spectra_discoverer/adapters/mast.py
+++ b/services/spectra_discoverer/adapters/mast.py
@@ -290,7 +290,7 @@ class MASTAdapter:
                         _QUERY_RETRY_DELAY_S,
                         extra={
                             "nova_id": nova_id,
-                            "name": name,
+                            "query_name": name,
                             "error": str(exc),
                         },
                     )

--- a/services/spectra_discoverer/handler.py
+++ b/services/spectra_discoverer/handler.py
@@ -148,7 +148,11 @@ def _handle_query_provider_for_products(event: dict[str, Any], context: object) 
     ra_deg = float(str(ra_deg_raw))
     dec_deg = float(str(dec_deg_raw))
 
-    primary_name: str = event.get("primary_name", "unknown")
+    # Read names from the Nova DDB item (authoritative source).
+    # Falls back to event for logging if Nova item lacks primary_name.
+    primary_name: str = str(nova_item.get("primary_name") or event.get("primary_name") or "unknown")
+    raw_aliases: Any = nova_item.get("aliases")
+    aliases: list[str] = [str(a) for a in raw_aliases] if isinstance(raw_aliases, list) else []
 
     logger.info(
         "Querying provider for spectra products",
@@ -156,12 +160,19 @@ def _handle_query_provider_for_products(event: dict[str, Any], context: object) 
             "provider": provider,
             "nova_id": nova_id,
             "primary_name": primary_name,
+            "alias_count": len(aliases),
             "ra_deg": ra_deg,
             "dec_deg": dec_deg,
         },
     )
 
-    raw_products = adapter.query(nova_id=nova_id, ra_deg=ra_deg, dec_deg=dec_deg)
+    raw_products = adapter.query(
+        nova_id=nova_id,
+        ra_deg=ra_deg,
+        dec_deg=dec_deg,
+        primary_name=primary_name,
+        aliases=aliases,
+    )
 
     logger.info(
         "Provider query complete",

--- a/services/spectra_validator/profiles/__init__.py
+++ b/services/spectra_validator/profiles/__init__.py
@@ -25,6 +25,7 @@ from .base import FitsProfile, NormalizedSpectrum, ProfileResult
 from .eso_fallback import EsoFallbackProfile
 from .eso_uves import EsoUvesProfile
 from .eso_xshooter import EsoXShooterProfile
+from .mast_stis_hasp import MastStisHaspProfile
 
 # ---------------------------------------------------------------------------
 # Profile registry
@@ -33,9 +34,12 @@ from .eso_xshooter import EsoXShooterProfile
 # Instrument-specific profiles must appear before provider-level fallbacks.
 
 _PROFILE_REGISTRY: list[FitsProfile] = [
+    # ESO profiles
     EsoUvesProfile(),
     EsoXShooterProfile(),
-    EsoFallbackProfile(),  # catch-all — must be last
+    EsoFallbackProfile(),  # ESO catch-all — must be last among ESO profiles
+    # MAST profiles
+    MastStisHaspProfile(),
 ]
 
 # ---------------------------------------------------------------------------

--- a/services/spectra_validator/profiles/mast_stis_hasp.py
+++ b/services/spectra_validator/profiles/mast_stis_hasp.py
@@ -1,0 +1,573 @@
+"""
+profiles/mast_stis_hasp.py — MAST STIS HASP FITS profile.
+
+Validates HASP (Hubble Advanced Spectral Products) co-added spectra from
+HST/STIS served via the MAST archive.
+
+Validated against real data:
+  hst_13388_stis_novadel2013_e140m_oc7r06_cspec.fits    (single grating, HLSP_LVL=1)
+  hst_13388_stis_novadel2013_e140m-e230h_oc7r01_cspec.fits  (multi-grating, HLSP_LVL=2)
+  hst_13828_stis_v339-del_e140m_ocoj08_cspec.fits       (single grating, HLSP_LVL=1)
+
+FITS structure (confirmed from real data):
+  HDU[0]: PrimaryHDU — NAXIS=0 (no data); observation metadata in header
+  HDU[1]: BinTableHDU named "SCI" — 1 row, variable-length array columns
+  HDU[2]: BinTableHDU named "PROVENANCE" — one row per constituent exposure
+
+  Key HDU[0] header keywords:
+    TELESCOP  = 'HST'
+    INSTRUME  = 'STIS' (or 'COS' — this profile handles STIS only)
+    DETECTOR  = 'FUV-MAMA' | 'NUV-MAMA' | 'CCD' | 'MULTI'
+    APERTURE  = '0.2X0.2' (etc.)
+    TARGNAME  = target name as used in HST proposal (e.g. 'NOVADEL2013')
+    PROPOSID  = HST program number (integer)
+    CENTRWV   = central wavelength (float, Angstrom)
+    MINWAVE   = wavelength minimum (float, Angstrom)
+    MAXWAVE   = wavelength maximum (float, Angstrom)
+    FILENAME  = HASP product filename (e.g. 'hst_13388_stis_..._cspec.fits')
+    HLSP_LVL  = 1 or 2 (HASP high-level science product level)
+    CAL_VER   = HASP calibration version string
+    ORIGIN    = 'Space Telescope Science Institute'
+    NUM_EXP   = number of constituent exposures (integer)
+
+    NOTE: No MJD-OBS or DATE-OBS with observation time — observation time
+    must be derived from the PROVENANCE table (HDU[2]).
+
+  HDU[1] "SCI" columns (all arrays of shape (1, N), float32):
+    WAVELENGTH    Angstrom           spectral axis
+    FLUX          erg/s/cm**2/Angstrom  absolute calibrated flux
+    ERROR         erg/s/cm**2/Angstrom  1-sigma uncertainty
+    SNR           dimensionless      signal-to-noise per pixel
+    EFF_EXPTIME   seconds            effective exposure time per pixel
+
+  HDU[2] "PROVENANCE" columns (one row per constituent x1d exposure):
+    FILENAME, EXPNAME, PROPOSID, TELESCOPE, INSTRUMENT, DETECTOR,
+    DISPERSER, CENWAVE, APERTURE, LIFE_ADJ, SPECRES, CAL_VER,
+    MJD_BEG, MJD_MID, MJD_END, XPOSURE, MINWAVE, MAXWAVE
+
+Observation time derivation:
+  min(PROVENANCE.MJD_BEG) across all provenance rows → MJD → ISO-8601 UTC.
+  This gives the start of the earliest constituent exposure, which is the
+  correct epoch for a per-visit co-add in transient science.
+
+Exposure time derivation:
+  sum(PROVENANCE.XPOSURE) across all provenance rows — total on-source time.
+
+SNR derivation:
+  Median of finite, positive values in the SNR column of HDU[1].
+
+Wavelength units:
+  Always Angstrom for HASP STIS products (confirmed from TUNIT1).
+
+Flux calibration:
+  Always absolute (erg/s/cm²/Å) for HASP cspec products.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+from datetime import UTC, datetime
+from typing import Any
+
+import numpy as np
+
+from .base import NormalizedSpectrum, ProfileResult
+
+# ---------------------------------------------------------------------------
+# Sanity check thresholds
+# ---------------------------------------------------------------------------
+
+_MAX_NAN_INF_FRACTION = 0.20  # >20% bad pixels → QUARANTINE
+_WAVE_MIN_ANGSTROM = 800.0  # generous UV cutoff (Lyman limit ~912 Å)
+_WAVE_MAX_ANGSTROM = 12_000.0  # STIS red limit ~10000 Å, generous
+
+
+class MastStisHaspProfile:
+    """
+    FITS profile for MAST HASP co-added STIS spectra (_cspec.fits).
+
+    Handles per-visit and per-visit-multi-grating co-adds (HLSP_LVL 1 and 2).
+    """
+
+    @property
+    def profile_id(self) -> str:
+        return "MAST_STIS_HASP"
+
+    def matches(self, provider: str, hdulist: Any) -> bool:
+        """
+        Match MAST STIS HASP cspec files.
+
+        Checks:
+          - provider == "MAST"
+          - INSTRUME == "STIS" (case-insensitive, whitespace-stripped)
+          - ORIGIN contains "Space Telescope Science Institute"
+        """
+        if provider != "MAST":
+            return False
+        instrume = str(hdulist[0].header.get("INSTRUME", "")).strip().upper()
+        if instrume != "STIS":
+            return False
+        origin = str(hdulist[0].header.get("ORIGIN", ""))
+        return "Space Telescope Science Institute" in origin
+
+    def validate(
+        self,
+        hdulist: Any,
+        product_metadata: dict[str, Any],
+    ) -> ProfileResult:
+        """
+        Validate and normalize a MAST STIS HASP FITS HDUList.
+
+        Extracts WAVELENGTH and FLUX from the SCI BinTable (HDU[1]).
+        Derives observation_time from PROVENANCE table (HDU[2]).
+        Runs mandatory sanity checks.
+
+        Returns ProfileResult(success=True) with a populated NormalizedSpectrum,
+        or ProfileResult(success=False) with quarantine_reason_code on any
+        deterministic failure.
+
+        Transient I/O exceptions are NOT caught — they propagate to
+        ValidateBytes which converts them to RetryableError.
+        """
+        data_product_id: str = product_metadata["data_product_id"]
+        provider: str = product_metadata["provider"]
+        notes: list[str] = []
+
+        # ----------------------------------------------------------------
+        # 1. Locate SCI extension
+        # ----------------------------------------------------------------
+        sci_hdu = _find_sci_hdu(hdulist)
+        if sci_hdu is None:
+            return ProfileResult(
+                success=False,
+                quarantine_reason=(
+                    "No SCI BinTable HDU found. "
+                    "Expected HDU named 'SCI' with WAVELENGTH and FLUX columns."
+                ),
+                quarantine_reason_code="MISSING_CRITICAL_METADATA",
+                normalization_notes=notes,
+                profile_id=self.profile_id,
+            )
+
+        # ----------------------------------------------------------------
+        # 2. Extract spectral and flux arrays
+        # ----------------------------------------------------------------
+        wave, flux, flux_units, extraction_notes = _extract_arrays(sci_hdu)
+        notes.extend(extraction_notes)
+
+        if wave is None or flux is None:
+            return ProfileResult(
+                success=False,
+                quarantine_reason=("Could not extract WAVELENGTH or FLUX from SCI HDU."),
+                quarantine_reason_code="MISSING_CRITICAL_METADATA",
+                normalization_notes=notes,
+                profile_id=self.profile_id,
+            )
+
+        spectral_units = "Angstrom"
+
+        # --- SNR extraction (best-effort) ---
+        snr_value: float | None = None
+        try:
+            snr_col = np.asarray(sci_hdu.data["SNR"], dtype=np.float64).squeeze()
+            finite_positive = snr_col[np.isfinite(snr_col) & (snr_col > 0)]
+            if len(finite_positive) > 0:
+                snr_value = float(np.median(finite_positive))
+        except Exception:
+            notes.append("SNR column not found or unreadable; SNR will be None.")
+
+        # ----------------------------------------------------------------
+        # 3. Extract observation metadata from PROVENANCE table
+        # ----------------------------------------------------------------
+        metadata_result = _extract_metadata(hdulist, notes)
+        if not metadata_result["ok"]:
+            return ProfileResult(
+                success=False,
+                quarantine_reason=metadata_result["reason"],
+                quarantine_reason_code="MISSING_CRITICAL_METADATA",
+                normalization_notes=notes,
+                profile_id=self.profile_id,
+            )
+
+        # ----------------------------------------------------------------
+        # 4. Sanity checks
+        # ----------------------------------------------------------------
+        check_result = _run_sanity_checks(
+            wave=wave,
+            flux=flux,
+            notes=notes,
+        )
+        if not check_result["ok"]:
+            return ProfileResult(
+                success=False,
+                quarantine_reason=check_result["reason"],
+                quarantine_reason_code="OTHER",
+                normalization_notes=notes,
+                profile_id=self.profile_id,
+            )
+
+        # ----------------------------------------------------------------
+        # 5. Header signature hash
+        # ----------------------------------------------------------------
+        primary_header = hdulist[0].header
+        sig_fields = "|".join(
+            [
+                provider,
+                str(primary_header.get("INSTRUME", "")).strip(),
+                str(primary_header.get("TELESCOP", "")).strip(),
+                str(metadata_result["observation_mjd"]),
+                str(primary_header.get("PROPOSID", "")),
+                str(primary_header.get("FILENAME", "")),
+            ]
+        )
+        header_signature_hash = hashlib.sha256(sig_fields.encode()).hexdigest()[:16]
+
+        # ----------------------------------------------------------------
+        # 6. Assemble NormalizedSpectrum
+        # ----------------------------------------------------------------
+        m = metadata_result
+        spectrum = NormalizedSpectrum(
+            spectral_axis=wave,
+            flux_axis=flux,
+            spectral_units=spectral_units,
+            flux_units=flux_units,
+            observation_time=m["observation_time"],
+            observation_mjd=m["observation_mjd"],
+            provider=provider,
+            data_product_id=data_product_id,
+            target_ra_deg=m["ra_deg"],
+            target_dec_deg=m["dec_deg"],
+            instrument=m["instrument"],
+            telescope=m["telescope"],
+            exposure_time_s=m["exposure_time_s"],
+            spectral_resolution=m["spectral_resolution"],
+            snr=snr_value,
+            raw_header=dict(primary_header),
+            normalization_notes=notes,
+        )
+
+        return ProfileResult(
+            success=True,
+            spectrum=spectrum,
+            normalization_notes=notes,
+            header_signature_hash=header_signature_hash,
+            profile_id=self.profile_id,
+        )
+
+
+# ---------------------------------------------------------------------------
+# HDU location
+# ---------------------------------------------------------------------------
+
+
+def _find_sci_hdu(hdulist: Any) -> Any | None:
+    """
+    Return the SCI BinTable HDU.
+
+    Search order:
+      1. HDU named 'SCI'
+      2. First BinTableHDU with WAVELENGTH and FLUX columns
+      3. None (caller quarantines)
+    """
+    from astropy.io.fits import BinTableHDU
+
+    # Strategy 1: by name
+    for hdu in hdulist:
+        if hdu.name == "SCI" and isinstance(hdu, BinTableHDU):
+            return hdu
+
+    # Strategy 2: by column presence
+    for hdu in hdulist:
+        if isinstance(hdu, BinTableHDU) and hdu.columns is not None:
+            col_names = [c.upper() for c in hdu.columns.names]
+            if "WAVELENGTH" in col_names and "FLUX" in col_names:
+                return hdu
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Array extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_arrays(
+    sci_hdu: Any,
+) -> tuple[Any | None, Any | None, str, list[str]]:
+    """
+    Extract WAVELENGTH and FLUX arrays from the SCI BinTable HDU.
+
+    HASP cspec files have shape (1, N) — a single-row BinTable with
+    variable-length array columns. Arrays are squeezed to 1D.
+
+    Returns (wavelength, flux, flux_units, notes).
+    wavelength and flux are None on failure.
+    """
+    notes: list[str] = []
+    col_names = [c.upper() for c in sci_hdu.columns.names]
+
+    if "WAVELENGTH" not in col_names:
+        notes.append("WAVELENGTH column not found in SCI HDU.")
+        return None, None, "", notes
+
+    if "FLUX" not in col_names:
+        notes.append("FLUX column not found in SCI HDU.")
+        return None, None, "", notes
+
+    # Read and flatten from (1, N) to (N,)
+    wave = np.asarray(sci_hdu.data["WAVELENGTH"], dtype=np.float64).squeeze()
+    flux = np.asarray(sci_hdu.data["FLUX"], dtype=np.float64).squeeze()
+
+    if wave.ndim != 1:
+        wave = wave.flatten()
+        notes.append("WAVELENGTH array was not 1D after squeeze; flattened.")
+    if flux.ndim != 1:
+        flux = flux.flatten()
+        notes.append("FLUX array was not 1D after squeeze; flattened.")
+
+    if len(wave) != len(flux):
+        notes.append(
+            f"WAVELENGTH length ({len(wave)}) != FLUX length ({len(flux)}). "
+            "Cannot produce aligned spectrum."
+        )
+        return None, None, "", notes
+
+    if len(wave) == 0:
+        notes.append("WAVELENGTH array is empty.")
+        return None, None, "", notes
+
+    # Flux unit from TUNIT of the FLUX column
+    flux_col_idx = col_names.index("FLUX")
+    tunit_key = f"TUNIT{flux_col_idx + 1}"
+    flux_units = str(sci_hdu.header.get(tunit_key, "")).strip()
+    if not flux_units:
+        flux_units = "erg /s /cm**2 /Angstrom"
+        notes.append(f"FLUX TUNIT ({tunit_key}) absent; assumed 'erg /s /cm**2 /Angstrom'.")
+
+    return wave, flux, flux_units, notes
+
+
+# ---------------------------------------------------------------------------
+# Metadata extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_metadata(
+    hdulist: Any,
+    notes: list[str],
+) -> dict[str, Any]:
+    """
+    Extract observation metadata from primary header and PROVENANCE table.
+
+    Observation time is derived from min(MJD_BEG) in the PROVENANCE table
+    (HDU[2]), NOT from the primary header (which lacks MJD-OBS/DATE-OBS
+    with observation time for HASP products).
+
+    Exposure time is sum(XPOSURE) from PROVENANCE.
+    Spectral resolution is median(SPECRES) from PROVENANCE.
+
+    Returns a dict with ok=True and populated fields, or ok=False with reason.
+    """
+    result: dict[str, Any] = {
+        "ok": True,
+        "reason": None,
+        "observation_time": None,
+        "observation_mjd": None,
+        "ra_deg": None,
+        "dec_deg": None,
+        "instrument": None,
+        "telescope": None,
+        "exposure_time_s": None,
+        "spectral_resolution": None,
+    }
+
+    primary_header = hdulist[0].header
+
+    # --- Observation time from PROVENANCE (required) ---
+    prov_hdu = _find_provenance_hdu(hdulist)
+    if prov_hdu is None or prov_hdu.data is None or len(prov_hdu.data) == 0:
+        result["ok"] = False
+        result["reason"] = (
+            "No PROVENANCE table found or it is empty. "
+            "Cannot determine observation time for HASP cspec product."
+        )
+        return result
+
+    prov_data = prov_hdu.data
+
+    try:
+        mjd_beg_values = np.asarray(prov_data["MJD_BEG"], dtype=np.float64)
+        finite_mjd = mjd_beg_values[np.isfinite(mjd_beg_values)]
+        if len(finite_mjd) == 0:
+            result["ok"] = False
+            result["reason"] = "All MJD_BEG values in PROVENANCE are NaN/Inf."
+            return result
+        observation_mjd = float(np.min(finite_mjd))
+        result["observation_mjd"] = observation_mjd
+        result["observation_time"] = _mjd_to_iso(observation_mjd)
+    except Exception as exc:
+        result["ok"] = False
+        result["reason"] = f"Failed to extract MJD_BEG from PROVENANCE: {exc}"
+        return result
+
+    # --- Exposure time from PROVENANCE (optional) ---
+    try:
+        xposure_values = np.asarray(prov_data["XPOSURE"], dtype=np.float64)
+        finite_xposure = xposure_values[np.isfinite(xposure_values)]
+        if len(finite_xposure) > 0:
+            result["exposure_time_s"] = float(np.sum(finite_xposure))
+    except Exception:
+        notes.append("XPOSURE column not found in PROVENANCE; exposure_time_s will be None.")
+
+    # --- Spectral resolution from PROVENANCE (optional) ---
+    try:
+        specres_values = np.asarray(prov_data["SPECRES"], dtype=np.float64)
+        finite_specres = specres_values[np.isfinite(specres_values) & (specres_values > 0)]
+        if len(finite_specres) > 0:
+            result["spectral_resolution"] = float(np.median(finite_specres))
+    except Exception:
+        notes.append("SPECRES column not found in PROVENANCE; spectral_resolution will be None.")
+
+    # --- Standard metadata from primary header (optional) ---
+    instrume = str(primary_header.get("INSTRUME", "")).strip() or None
+    result["instrument"] = instrume
+
+    telescop = str(primary_header.get("TELESCOP", "")).strip() or None
+    result["telescope"] = telescop
+
+    # RA/DEC — HASP uses TARG_RA / TARG_DEC (not RA_TARG / DEC_TARG)
+    ra_targ = primary_header.get("TARG_RA")
+    dec_targ = primary_header.get("TARG_DEC")
+    if ra_targ is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            result["ra_deg"] = float(ra_targ)
+    if dec_targ is not None:
+        with contextlib.suppress(TypeError, ValueError):
+            result["dec_deg"] = float(dec_targ)
+
+    return result
+
+
+def _find_provenance_hdu(hdulist: Any) -> Any | None:
+    """
+    Return the PROVENANCE BinTable HDU.
+
+    Search order:
+      1. HDU named 'PROVENANCE'
+      2. Third HDU (index 2) if it is a BinTableHDU with MJD_BEG column
+      3. None
+    """
+    from astropy.io.fits import BinTableHDU
+
+    for hdu in hdulist:
+        if hdu.name == "PROVENANCE" and isinstance(hdu, BinTableHDU):
+            return hdu
+
+    if len(hdulist) > 2:
+        hdu = hdulist[2]
+        if isinstance(hdu, BinTableHDU) and hdu.columns is not None:
+            col_names = [c.upper() for c in hdu.columns.names]
+            if "MJD_BEG" in col_names:
+                return hdu
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Sanity checks
+# ---------------------------------------------------------------------------
+
+
+def _run_sanity_checks(
+    *,
+    wave: Any,
+    flux: Any,
+    notes: list[str],
+) -> dict[str, Any]:
+    """
+    Run mandatory sanity checks on extracted arrays.
+
+    Checks:
+      1. Wavelength monotonically increasing
+      2. NaN/Inf fraction below threshold
+      3. Wavelength within plausible range for STIS
+      4. Flux array has at least some finite values
+
+    Returns dict with ok=True or ok=False + reason.
+    """
+    result: dict[str, Any] = {"ok": True, "reason": None}
+
+    # 1. Monotonicity
+    finite_wave = wave[np.isfinite(wave)]
+    if len(finite_wave) > 1:
+        diffs = np.diff(finite_wave)
+        if not np.all(diffs > 0):
+            # Allow monotonically decreasing (reverse it)
+            if np.all(diffs < 0):
+                notes.append("Wavelength axis is monotonically decreasing; accepted.")
+            else:
+                result["ok"] = False
+                result["reason"] = (
+                    "Wavelength axis is not monotonic. "
+                    f"Positive diffs: {np.sum(diffs > 0)}, "
+                    f"negative diffs: {np.sum(diffs < 0)}, "
+                    f"zero diffs: {np.sum(diffs == 0)}."
+                )
+                return result
+
+    # 2. NaN/Inf fraction
+    total = len(flux)
+    bad_count = np.sum(~np.isfinite(flux))
+    if total > 0:
+        bad_frac = bad_count / total
+        if bad_frac > _MAX_NAN_INF_FRACTION:
+            result["ok"] = False
+            result["reason"] = (
+                f"NaN/Inf fraction in flux array is {bad_frac:.2%} "
+                f"(threshold: {_MAX_NAN_INF_FRACTION:.0%}). "
+                f"Bad pixels: {bad_count}/{total}."
+            )
+            return result
+
+    # 3. Wavelength range
+    if len(finite_wave) > 0:
+        wl_min = float(np.min(finite_wave))
+        wl_max = float(np.max(finite_wave))
+        if wl_min < _WAVE_MIN_ANGSTROM or wl_max > _WAVE_MAX_ANGSTROM:
+            result["ok"] = False
+            result["reason"] = (
+                f"Wavelength range [{wl_min:.1f}, {wl_max:.1f}] Å "
+                f"outside plausible bounds [{_WAVE_MIN_ANGSTROM}, {_WAVE_MAX_ANGSTROM}] Å."
+            )
+            return result
+
+    # 4. Flux has finite values
+    finite_flux = flux[np.isfinite(flux)]
+    if len(finite_flux) == 0:
+        result["ok"] = False
+        result["reason"] = "Flux array contains no finite values."
+        return result
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mjd_to_iso(mjd: float) -> str:
+    """
+    Convert MJD to ISO-8601 UTC string.
+
+    Uses the standard epoch: MJD 0 = 1858-11-17T00:00:00Z.
+    """
+    jd = mjd + 2_400_000.5
+    # Astropy-free conversion: JD 2451545.0 = 2000-01-01T12:00:00Z
+    delta_days = jd - 2_451_545.0
+    epoch = datetime(2000, 1, 1, 12, 0, 0, tzinfo=UTC)
+    from datetime import timedelta
+
+    obs_dt = epoch + timedelta(days=delta_days)
+    return obs_dt.strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/tests/services/spectra_validator/test_mast_stis_hasp_profile.py
+++ b/tests/services/spectra_validator/test_mast_stis_hasp_profile.py
@@ -1,0 +1,662 @@
+"""
+tests/spectra_validator/test_mast_stis_hasp_profile.py
+
+Unit tests for MastStisHaspProfile and validate_spectrum dispatch.
+
+All tests use synthetic astropy HDULists — no binary test fixtures on disk.
+The _make_hdulist() helper produces a minimal but structurally valid HASP
+cspec file matching the confirmed real-file shape:
+  HDU[0]: PrimaryHDU (metadata only)
+  HDU[1]: BinTableHDU "SCI" (1 row, variable-length array columns)
+  HDU[2]: BinTableHDU "PROVENANCE" (one row per constituent exposure)
+
+Test groups:
+  TestMastStisHaspMatches          — matches() accept/reject logic
+  TestMastStisHaspHappyPath        — successful validation; output shape and values
+  TestMastStisHaspMissingColumns   — WAVELENGTH/FLUX absence → quarantine
+  TestMastStisHaspProvenance       — observation time, exposure time from PROVENANCE
+  TestMastStisHaspSanityChecks     — mandatory sanity checks
+  TestMastStisHaspSnr              — SNR extraction
+  TestValidateSpectrumDispatch     — registry dispatch to MAST_STIS_HASP
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+
+import numpy as np
+import pytest
+
+
+# Bootstrap astropy cache dirs before import (mirrors handler.py behaviour)
+def _bootstrap() -> None:
+    base = "/tmp/test_astropy"
+    os.environ.setdefault("ASTROPY_CONFIGDIR", f"{base}/config")
+    os.environ.setdefault("ASTROPY_CACHE_DIR", f"{base}/cache")
+    os.environ.setdefault("XDG_CACHE_HOME", f"{base}/.cache")
+    os.environ.setdefault("HOME", base)
+    for p in (os.environ["ASTROPY_CONFIGDIR"], os.environ["ASTROPY_CACHE_DIR"]):
+        pathlib.Path(p).mkdir(parents=True, exist_ok=True)
+
+
+_bootstrap()
+
+import astropy.io.fits as fits  # noqa: E402
+from spectra_validator.profiles import validate_spectrum  # noqa: E402
+from spectra_validator.profiles.mast_stis_hasp import MastStisHaspProfile  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_N = 200  # synthetic spectrum length
+
+
+def _make_primary_header(**overrides: object) -> fits.Header:
+    """
+    Build a minimal HASP STIS primary header with all expected fields.
+    Use a value of None to delete a key (simulates missing header field).
+    """
+    defaults: dict[str, object] = {
+        "SIMPLE": True,
+        "BITPIX": 16,
+        "NAXIS": 0,
+        "TELESCOP": "HST",
+        "INSTRUME": "STIS",
+        "DETECTOR": "FUV-MAMA",
+        "APERTURE": "0.2X0.2",
+        "TARGNAME": "V339-DEL",
+        "PROPOSID": 13828,
+        "CENTRWV": 1437.5,
+        "MINWAVE": 1140.0,
+        "MAXWAVE": 1735.0,
+        "FILENAME": "hst_13828_stis_v339-del_e140m_ocoj08_cspec.fits",
+        "HLSP_LVL": 1,
+        "CAL_VER": "HSLA Cal 1.2.4",
+        "ORIGIN": "Space Telescope Science Institute",
+        "NUM_EXP": 1,
+        "TARG_RA": 305.8778,
+        "TARG_DEC": 20.7677,
+    }
+    defaults.update(overrides)
+
+    header = fits.Header()
+    for key, val in defaults.items():
+        if val is None:
+            continue
+        header[key] = val
+    return header
+
+
+def _make_wave(n: int = _N) -> np.ndarray:
+    """Strictly monotonic wavelength array in Angstrom (STIS FUV range)."""
+    return np.linspace(1143.0, 1710.0, n)
+
+
+def _make_flux(n: int = _N, nan_fraction: float = 0.0) -> np.ndarray:
+    """Flux array with optional NaN injection."""
+    rng = np.random.default_rng(42)
+    flux = rng.uniform(1e-13, 5e-13, n)
+    if nan_fraction > 0:
+        n_nan = int(n * nan_fraction)
+        flux[:n_nan] = np.nan
+    return flux
+
+
+def _make_snr(n: int = _N) -> np.ndarray:
+    """SNR array with realistic values (mix of positive and negative)."""
+    rng = np.random.default_rng(99)
+    return rng.uniform(-5.0, 15.0, n)
+
+
+def _make_sci_hdu(
+    wave: np.ndarray | None = None,
+    flux: np.ndarray | None = None,
+    include_wave: bool = True,
+    include_flux: bool = True,
+    include_snr: bool = True,
+    hdu_name: str = "SCI",
+) -> fits.BinTableHDU:
+    """
+    Build a BinTableHDU matching the real HASP cspec SCI shape:
+      1 row, variable-length array columns (shape 1 × N).
+    """
+    if wave is None:
+        wave = _make_wave()
+    if flux is None:
+        flux = _make_flux()
+
+    n = len(wave)
+    cols = []
+
+    if include_wave:
+        cols.append(
+            fits.Column(
+                name="WAVELENGTH",
+                format=f"{n}E",
+                unit="Angstrom",
+                array=wave.reshape(1, n).astype(np.float32),
+            )
+        )
+
+    if include_flux:
+        flux_unit = "erg /s /cm**2 /Angstrom"
+        cols.append(
+            fits.Column(
+                name="FLUX",
+                format=f"{n}E",
+                unit=flux_unit,
+                array=flux.reshape(1, n).astype(np.float32),
+            )
+        )
+        cols.append(
+            fits.Column(
+                name="ERROR",
+                format=f"{n}E",
+                unit=flux_unit,
+                array=(flux * 0.1).reshape(1, n).astype(np.float32),
+            )
+        )
+
+    if include_snr and include_flux:
+        snr = _make_snr(n)
+        cols.append(
+            fits.Column(
+                name="SNR",
+                format=f"{n}E",
+                unit="",
+                array=snr.reshape(1, n).astype(np.float32),
+            )
+        )
+
+    if not cols:
+        # Need at least one column to create a BinTableHDU
+        cols.append(fits.Column(name="DUMMY", format="1E", array=np.array([[0.0]])))
+
+    hdu = fits.BinTableHDU.from_columns(cols)
+    hdu.name = hdu_name
+    return hdu
+
+
+def _make_provenance_hdu(
+    rows: list[dict] | None = None,
+    hdu_name: str = "PROVENANCE",
+) -> fits.BinTableHDU:
+    """
+    Build a PROVENANCE BinTableHDU matching real HASP structure.
+    Each row represents one constituent x1d exposure.
+    """
+    if rows is None:
+        rows = [_prov_row()]
+
+    filenames = [r.get("FILENAME", "oc7r06010_x1d.fits") for r in rows]
+    dispersers = [r.get("DISPERSER", "E140M") for r in rows]
+    mjd_begs = [r.get("MJD_BEG", 57153.916) for r in rows]
+    mjd_ends = [r.get("MJD_END", 57153.920) for r in rows]
+    xposures = [r.get("XPOSURE", 2455.0) for r in rows]
+    specress = [r.get("SPECRES", 45800.0) for r in rows]
+    cenwaves = [r.get("CENWAVE", 1425) for r in rows]
+
+    cols = [
+        fits.Column(name="FILENAME", format="50A", array=filenames),
+        fits.Column(name="DISPERSER", format="10A", array=dispersers),
+        fits.Column(name="MJD_BEG", format="D", array=mjd_begs),
+        fits.Column(name="MJD_END", format="D", array=mjd_ends),
+        fits.Column(name="XPOSURE", format="D", array=xposures),
+        fits.Column(name="SPECRES", format="D", array=specress),
+        fits.Column(name="CENWAVE", format="J", array=cenwaves),
+    ]
+
+    hdu = fits.BinTableHDU.from_columns(cols)
+    hdu.name = hdu_name
+    return hdu
+
+
+def _prov_row(**overrides: object) -> dict:
+    """Build a single PROVENANCE row dict."""
+    defaults = {
+        "FILENAME": "ocoj08010_x1d.fits",
+        "DISPERSER": "E140M",
+        "MJD_BEG": 57153.916504,
+        "MJD_END": 57153.930000,
+        "XPOSURE": 2455.0,
+        "SPECRES": 45800.0,
+        "CENWAVE": 1425,
+    }
+    return {**defaults, **overrides}
+
+
+def _make_hdulist(
+    primary_header: fits.Header | None = None,
+    sci_hdu: fits.BinTableHDU | None = None,
+    provenance_hdu: fits.BinTableHDU | None = None,
+) -> fits.HDUList:
+    """Assemble a minimal HASP cspec HDUList."""
+    if primary_header is None:
+        primary_header = _make_primary_header()
+    if sci_hdu is None:
+        sci_hdu = _make_sci_hdu()
+    if provenance_hdu is None:
+        provenance_hdu = _make_provenance_hdu()
+
+    primary = fits.PrimaryHDU(header=primary_header)
+    return fits.HDUList([primary, sci_hdu, provenance_hdu])
+
+
+def _product_metadata(
+    data_product_id: str = "test-dpid-0001",
+    provider: str = "MAST",
+) -> dict:
+    return {"data_product_id": data_product_id, "provider": provider, "hints": {}}
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def profile() -> MastStisHaspProfile:
+    return MastStisHaspProfile()
+
+
+# ---------------------------------------------------------------------------
+# TestMastStisHaspMatches
+# ---------------------------------------------------------------------------
+
+
+class TestMastStisHaspMatches:
+    def test_matches_mast_stis(self, profile: MastStisHaspProfile) -> None:
+        hdulist = _make_hdulist()
+        assert profile.matches("MAST", hdulist) is True
+
+    def test_no_match_wrong_provider(self, profile: MastStisHaspProfile) -> None:
+        hdulist = _make_hdulist()
+        assert profile.matches("ESO", hdulist) is False
+
+    def test_no_match_wrong_instrument(self, profile: MastStisHaspProfile) -> None:
+        header = _make_primary_header(INSTRUME="COS")
+        hdulist = _make_hdulist(primary_header=header)
+        assert profile.matches("MAST", hdulist) is False
+
+    def test_no_match_missing_origin(self, profile: MastStisHaspProfile) -> None:
+        header = _make_primary_header(ORIGIN=None)
+        hdulist = _make_hdulist(primary_header=header)
+        assert profile.matches("MAST", hdulist) is False
+
+    def test_no_match_wrong_origin(self, profile: MastStisHaspProfile) -> None:
+        header = _make_primary_header(ORIGIN="European Southern Observatory")
+        hdulist = _make_hdulist(primary_header=header)
+        assert profile.matches("MAST", hdulist) is False
+
+    def test_matches_stis_with_whitespace(self, profile: MastStisHaspProfile) -> None:
+        """INSTRUME='STIS    ' (padded) must still match."""
+        header = _make_primary_header(INSTRUME="STIS    ")
+        hdulist = _make_hdulist(primary_header=header)
+        assert profile.matches("MAST", hdulist) is True
+
+
+# ---------------------------------------------------------------------------
+# TestMastStisHaspHappyPath
+# ---------------------------------------------------------------------------
+
+
+class TestMastStisHaspHappyPath:
+    def test_valid_spectrum_succeeds(self, profile: MastStisHaspProfile) -> None:
+        hdulist = _make_hdulist()
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.success is True
+        assert result.profile_id == "MAST_STIS_HASP"
+
+    def test_spectrum_has_correct_units(self, profile: MastStisHaspProfile) -> None:
+        hdulist = _make_hdulist()
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.spectrum is not None
+        assert result.spectrum.spectral_units == "Angstrom"
+        assert "erg" in result.spectrum.flux_units
+
+    def test_spectrum_arrays_are_1d(self, profile: MastStisHaspProfile) -> None:
+        hdulist = _make_hdulist()
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.spectrum is not None
+        assert result.spectrum.spectral_axis.ndim == 1
+        assert result.spectrum.flux_axis.ndim == 1
+        assert len(result.spectrum.spectral_axis) == _N
+
+    def test_data_product_id_propagated(self, profile: MastStisHaspProfile) -> None:
+        hdulist = _make_hdulist()
+        dpid = "propagation-test-uuid"
+        result = profile.validate(hdulist, _product_metadata(data_product_id=dpid))
+        assert result.spectrum is not None
+        assert result.spectrum.data_product_id == dpid
+
+    def test_provider_propagated(self, profile: MastStisHaspProfile) -> None:
+        hdulist = _make_hdulist()
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.spectrum is not None
+        assert result.spectrum.provider == "MAST"
+
+    def test_instrument_extracted(self, profile: MastStisHaspProfile) -> None:
+        hdulist = _make_hdulist()
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.spectrum is not None
+        assert result.spectrum.instrument == "STIS"
+
+    def test_telescope_extracted(self, profile: MastStisHaspProfile) -> None:
+        hdulist = _make_hdulist()
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.spectrum is not None
+        assert result.spectrum.telescope == "HST"
+
+    def test_coordinates_extracted(self, profile: MastStisHaspProfile) -> None:
+        hdulist = _make_hdulist()
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.spectrum is not None
+        assert result.spectrum.target_ra_deg == pytest.approx(305.8778, abs=0.001)
+        assert result.spectrum.target_dec_deg == pytest.approx(20.7677, abs=0.001)
+
+    def test_header_signature_hash_present(self, profile: MastStisHaspProfile) -> None:
+        hdulist = _make_hdulist()
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.header_signature_hash is not None
+        assert len(result.header_signature_hash) == 16  # 16-char hex prefix
+
+
+# ---------------------------------------------------------------------------
+# TestMastStisHaspMissingColumns
+# ---------------------------------------------------------------------------
+
+
+class TestMastStisHaspMissingColumns:
+    def test_missing_wavelength_quarantines(self, profile: MastStisHaspProfile) -> None:
+        sci_hdu = _make_sci_hdu(include_wave=False)
+        hdulist = _make_hdulist(sci_hdu=sci_hdu)
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.success is False
+        assert result.quarantine_reason_code == "MISSING_CRITICAL_METADATA"
+
+    def test_missing_flux_quarantines(self, profile: MastStisHaspProfile) -> None:
+        sci_hdu = _make_sci_hdu(include_flux=False)
+        hdulist = _make_hdulist(sci_hdu=sci_hdu)
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.success is False
+        assert result.quarantine_reason_code == "MISSING_CRITICAL_METADATA"
+
+    def test_missing_sci_hdu_quarantines(self, profile: MastStisHaspProfile) -> None:
+        """HDUList without a SCI extension → quarantine."""
+        primary = fits.PrimaryHDU(header=_make_primary_header())
+        provenance = _make_provenance_hdu()
+        hdulist = fits.HDUList([primary, provenance])
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.success is False
+        assert result.quarantine_reason_code == "MISSING_CRITICAL_METADATA"
+
+    def test_wrong_sci_hdu_name_still_found(self, profile: MastStisHaspProfile) -> None:
+        """SCI HDU with non-standard name but correct columns is still found."""
+        sci_hdu = _make_sci_hdu(hdu_name="SCIENCE")
+        hdulist = _make_hdulist(sci_hdu=sci_hdu)
+        result = profile.validate(hdulist, _product_metadata())
+        # Should still validate — _find_sci_hdu falls back to column search
+        assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# TestMastStisHaspProvenance
+# ---------------------------------------------------------------------------
+
+
+class TestMastStisHaspProvenance:
+    def test_observation_time_from_min_mjd_beg(self, profile: MastStisHaspProfile) -> None:
+        """Observation time = min(MJD_BEG) across provenance rows."""
+        rows = [
+            _prov_row(MJD_BEG=57153.916),
+            _prov_row(MJD_BEG=57153.900, FILENAME="earlier_x1d.fits"),  # earlier
+        ]
+        hdulist = _make_hdulist(provenance_hdu=_make_provenance_hdu(rows))
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.spectrum is not None
+        assert result.spectrum.observation_mjd == pytest.approx(57153.900, abs=0.001)
+
+    def test_observation_time_is_iso8601(self, profile: MastStisHaspProfile) -> None:
+        hdulist = _make_hdulist()
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.spectrum is not None
+        assert "T" in result.spectrum.observation_time
+        assert result.spectrum.observation_time.endswith("Z")
+
+    def test_exposure_time_summed_from_provenance(self, profile: MastStisHaspProfile) -> None:
+        """Exposure time = sum(XPOSURE) across provenance rows."""
+        rows = [
+            _prov_row(XPOSURE=100.0),
+            _prov_row(XPOSURE=200.0, FILENAME="second_x1d.fits"),
+        ]
+        hdulist = _make_hdulist(provenance_hdu=_make_provenance_hdu(rows))
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.spectrum is not None
+        assert result.spectrum.exposure_time_s == pytest.approx(300.0)
+
+    def test_spectral_resolution_from_provenance(self, profile: MastStisHaspProfile) -> None:
+        """Spectral resolution = median(SPECRES) from provenance."""
+        rows = [
+            _prov_row(SPECRES=45800.0),
+            _prov_row(SPECRES=114000.0, FILENAME="second_x1d.fits"),
+        ]
+        hdulist = _make_hdulist(provenance_hdu=_make_provenance_hdu(rows))
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.spectrum is not None
+        expected = float(np.median([45800.0, 114000.0]))
+        assert result.spectrum.spectral_resolution == pytest.approx(expected)
+
+    def test_missing_provenance_quarantines(self, profile: MastStisHaspProfile) -> None:
+        """No PROVENANCE HDU → quarantine (cannot determine observation time)."""
+        primary = fits.PrimaryHDU(header=_make_primary_header())
+        sci = _make_sci_hdu()
+        hdulist = fits.HDUList([primary, sci])
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.success is False
+        assert result.quarantine_reason_code == "MISSING_CRITICAL_METADATA"
+        assert "PROVENANCE" in (result.quarantine_reason or "")
+
+    def test_empty_provenance_quarantines(self, profile: MastStisHaspProfile) -> None:
+        """PROVENANCE HDU with zero rows → quarantine."""
+        # Build with explicit empty arrays
+        cols = [
+            fits.Column(name="FILENAME", format="50A", array=[]),
+            fits.Column(name="MJD_BEG", format="D", array=[]),
+            fits.Column(name="MJD_END", format="D", array=[]),
+            fits.Column(name="XPOSURE", format="D", array=[]),
+            fits.Column(name="SPECRES", format="D", array=[]),
+        ]
+        empty_prov = fits.BinTableHDU.from_columns(cols)
+        empty_prov.name = "PROVENANCE"
+        hdulist = _make_hdulist(provenance_hdu=empty_prov)
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.success is False
+
+
+# ---------------------------------------------------------------------------
+# TestMastStisHaspSanityChecks
+# ---------------------------------------------------------------------------
+
+
+class TestMastStisHaspSanityChecks:
+    def test_non_monotonic_quarantines(self, profile: MastStisHaspProfile) -> None:
+        """Non-monotonic wavelength axis → quarantine."""
+        wave = _make_wave()
+        wave[50], wave[51] = wave[51], wave[50]  # swap two elements
+        hdulist = _make_hdulist(sci_hdu=_make_sci_hdu(wave=wave))
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.success is False
+        assert "monoton" in (result.quarantine_reason or "").lower()
+
+    def test_descending_wave_accepted(self, profile: MastStisHaspProfile) -> None:
+        """Monotonically decreasing wavelength is accepted with a note."""
+        wave = _make_wave()[::-1]
+        hdulist = _make_hdulist(sci_hdu=_make_sci_hdu(wave=wave))
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.success is True
+        assert any("decreasing" in n.lower() for n in result.normalization_notes)
+
+    def test_high_nan_fraction_quarantines(self, profile: MastStisHaspProfile) -> None:
+        """Flux with >20% NaN → quarantine."""
+        flux = _make_flux(nan_fraction=0.25)
+        hdulist = _make_hdulist(sci_hdu=_make_sci_hdu(flux=flux))
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.success is False
+        assert "nan" in (result.quarantine_reason or "").lower()
+
+    def test_acceptable_nan_fraction_passes(self, profile: MastStisHaspProfile) -> None:
+        """Flux with <20% NaN → passes."""
+        flux = _make_flux(nan_fraction=0.10)
+        hdulist = _make_hdulist(sci_hdu=_make_sci_hdu(flux=flux))
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.success is True
+
+    def test_wave_out_of_range_quarantines(self, profile: MastStisHaspProfile) -> None:
+        """Wavelength in nm instead of Angstrom looks out-of-range."""
+        wave = np.linspace(114.3, 171.0, _N)  # nm, not Angstrom
+        hdulist = _make_hdulist(sci_hdu=_make_sci_hdu(wave=wave))
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.success is False
+        assert "range" in (result.quarantine_reason or "").lower()
+
+    def test_all_nan_flux_quarantines(self, profile: MastStisHaspProfile) -> None:
+        """Flux array with all NaN → quarantine."""
+        flux = np.full(_N, np.nan)
+        hdulist = _make_hdulist(sci_hdu=_make_sci_hdu(flux=flux))
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.success is False
+
+    def test_empty_arrays_quarantine(self, profile: MastStisHaspProfile) -> None:
+        wave = np.array([])
+        flux = np.array([])
+        hdulist = _make_hdulist(sci_hdu=_make_sci_hdu(wave=wave, flux=flux))
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.success is False
+
+
+# ---------------------------------------------------------------------------
+# TestMastStisHaspSnr
+# ---------------------------------------------------------------------------
+
+
+class TestMastStisHaspSnr:
+    def test_snr_extracted_as_median_positive(self, profile: MastStisHaspProfile) -> None:
+        """SNR = median of finite, positive SNR values."""
+        wave = _make_wave()
+        flux = _make_flux()
+        n = len(wave)
+        snr_data = np.linspace(1.0, 20.0, n)
+        expected_median = float(np.median(snr_data))
+
+        cols = [
+            fits.Column(
+                name="WAVELENGTH",
+                format=f"{n}E",
+                unit="Angstrom",
+                array=wave.reshape(1, n).astype(np.float32),
+            ),
+            fits.Column(
+                name="FLUX",
+                format=f"{n}E",
+                unit="erg /s /cm**2 /Angstrom",
+                array=flux.reshape(1, n).astype(np.float32),
+            ),
+            fits.Column(
+                name="ERROR",
+                format=f"{n}E",
+                unit="erg /s /cm**2 /Angstrom",
+                array=(flux * 0.1).reshape(1, n).astype(np.float32),
+            ),
+            fits.Column(
+                name="SNR", format=f"{n}E", unit="", array=snr_data.reshape(1, n).astype(np.float32)
+            ),
+        ]
+        sci = fits.BinTableHDU.from_columns(cols)
+        sci.name = "SCI"
+        hdulist = _make_hdulist(sci_hdu=sci)
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.success is True
+        assert result.spectrum is not None
+        assert result.spectrum.snr is not None
+        assert abs(result.spectrum.snr - expected_median) < 0.1
+
+    def test_snr_none_when_column_absent(self, profile: MastStisHaspProfile) -> None:
+        """No SNR column → snr is None."""
+        sci = _make_sci_hdu(include_snr=False)
+        hdulist = _make_hdulist(sci_hdu=sci)
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.success is True
+        assert result.spectrum is not None
+        assert result.spectrum.snr is None
+
+    def test_snr_ignores_negative_values(self, profile: MastStisHaspProfile) -> None:
+        """Negative SNR values are excluded from the median."""
+        wave = _make_wave()
+        flux = _make_flux()
+        n = len(wave)
+        snr_data = np.full(n, -10.0)
+        snr_data[0:10] = 5.0  # only 10 positive values
+
+        cols = [
+            fits.Column(
+                name="WAVELENGTH",
+                format=f"{n}E",
+                unit="Angstrom",
+                array=wave.reshape(1, n).astype(np.float32),
+            ),
+            fits.Column(
+                name="FLUX",
+                format=f"{n}E",
+                unit="erg /s /cm**2 /Angstrom",
+                array=flux.reshape(1, n).astype(np.float32),
+            ),
+            fits.Column(
+                name="ERROR",
+                format=f"{n}E",
+                unit="erg /s /cm**2 /Angstrom",
+                array=(flux * 0.1).reshape(1, n).astype(np.float32),
+            ),
+            fits.Column(
+                name="SNR", format=f"{n}E", unit="", array=snr_data.reshape(1, n).astype(np.float32)
+            ),
+        ]
+        sci = fits.BinTableHDU.from_columns(cols)
+        sci.name = "SCI"
+        hdulist = _make_hdulist(sci_hdu=sci)
+        result = profile.validate(hdulist, _product_metadata())
+        assert result.success is True
+        assert result.spectrum is not None
+        assert result.spectrum.snr == pytest.approx(5.0, abs=0.1)
+
+
+# ---------------------------------------------------------------------------
+# TestValidateSpectrumDispatch
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSpectrumDispatch:
+    def test_dispatches_to_mast_stis_hasp(self) -> None:
+        hdulist = _make_hdulist()
+        result = validate_spectrum(
+            hdulist,
+            provider="MAST",
+            data_product_id="test-dpid-9999",
+            hints={},
+        )
+        assert result.success is True
+        assert result.profile_id == "MAST_STIS_HASP"
+
+    def test_data_product_id_propagated(self) -> None:
+        hdulist = _make_hdulist()
+        dpid = "propagation-test-uuid"
+        result = validate_spectrum(
+            hdulist,
+            provider="MAST",
+            data_product_id=dpid,
+            hints={},
+        )
+        assert result.success is True
+        assert result.spectrum is not None
+        assert result.spectrum.data_product_id == dpid

--- a/tests/services/test_mast_adapter.py
+++ b/tests/services/test_mast_adapter.py
@@ -1,0 +1,586 @@
+"""
+Unit tests for services/spectra_discoverer/adapters/mast.py
+
+Pure unit tests — no AWS calls, no real HTTP requests.
+astroquery.mast.Observations is mocked to prevent network access.
+
+Covers:
+  - _safe_float: finite conversion, nan/inf → None, missing → None
+  - _safe_int: integer conversion, missing → None
+  - _extract_hints: Decimal conversion, nan/inf dropped, missing keys graceful
+  - _maybe_set_str: truthy check, whitespace stripping
+  - _maybe_set_numeric: Decimal conversion, nan/inf dropped
+  - MASTAdapter.normalize: NATIVE_ID identity, locator URL, hints, skip branches
+  - MASTAdapter.query: name search, alias fallback, filtering, retries, error handling
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from astropy.table import Table  # type: ignore[import-untyped]
+from spectra_discoverer.adapters.mast import (  # type: ignore[import-not-found]
+    MASTAdapter,
+    _extract_hints,
+    _maybe_set_numeric,
+    _maybe_set_str,
+    _safe_float,
+    _safe_int,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_NOVA_ID = "test-nova-uuid-1234"
+_PRIMARY_NAME = "V339 Del"
+_ALIASES = ["Nova Del 2013", "NOVADEL2013"]
+_RA_DEG = 305.878
+_DEC_DEG = 20.768
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build astropy Tables mimicking MAST query results
+# ---------------------------------------------------------------------------
+
+
+def _obs_table(rows: list[dict[str, Any]] | None = None) -> Table:
+    """Build an astropy Table mimicking Observations.query_object() output."""
+    if rows is None:
+        rows = [_obs_row()]
+    if not rows:
+        return Table(
+            names=[
+                "obs_collection",
+                "dataproduct_type",
+                "project",
+                "instrument_name",
+                "target_name",
+                "proposal_id",
+                "obs_id",
+                "obsid",
+                "t_min",
+                "t_max",
+            ],
+            dtype=["U16", "U16", "U16", "U16", "U32", "i4", "U64", "i8", "f8", "f8"],
+        )
+    return Table(rows=rows)
+
+
+def _obs_row(**overrides: Any) -> dict[str, Any]:
+    """Build a single observation row dict."""
+    defaults: dict[str, Any] = {
+        "obs_collection": "HST",
+        "dataproduct_type": "spectrum",
+        "project": "HASP",
+        "instrument_name": "STIS",
+        "target_name": "V339-DEL",
+        "proposal_id": 13828,
+        "obs_id": "hst_13828_stis_v339-del_e140m",
+        "obsid": 99001,
+        "t_min": 57153.9,
+        "t_max": 57154.1,
+    }
+    return {**defaults, **overrides}
+
+
+def _prod_table(rows: list[dict[str, Any]] | None = None) -> Table:
+    """Build an astropy Table mimicking Observations.get_product_list() output."""
+    if rows is None:
+        rows = [_prod_row()]
+    if not rows:
+        return Table(
+            names=["productFilename", "dataURI", "obsID", "size", "productSubGroupDescription"],
+            dtype=["U128", "U128", "i8", "i8", "U16"],
+        )
+    return Table(rows=rows)
+
+
+def _prod_row(**overrides: Any) -> dict[str, Any]:
+    """Build a single product row dict."""
+    defaults: dict[str, Any] = {
+        "productFilename": "hst_13828_stis_v339-del_e140m_ocoj08_cspec.fits",
+        "dataURI": "mast:HST/product/hst_13828_stis_v339-del_e140m_ocoj08_cspec.fits",
+        "obsID": 99001,
+        "size": 614400,
+        "productSubGroupDescription": "CSPEC",
+    }
+    return {**defaults, **overrides}
+
+
+def _raw(**overrides: Any) -> dict[str, Any]:
+    """Build a complete raw product record as returned by query() for normalize tests."""
+    defaults: dict[str, Any] = {
+        "productFilename": "hst_13828_stis_v339-del_e140m_ocoj08_cspec.fits",
+        "dataURI": "mast:HST/product/hst_13828_stis_v339-del_e140m_ocoj08_cspec.fits",
+        "obsID": "99001",
+        "size": 614400,
+        "productSubGroupDescription": "CSPEC",
+        "instrument_name": "STIS",
+        "target_name": "V339-DEL",
+        "proposal_id": "13828",
+        "obs_id": "hst_13828_stis_v339-del_e140m",
+        "t_min": 57153.9,
+        "t_max": 57154.1,
+    }
+    return {**defaults, **overrides}
+
+
+# ---------------------------------------------------------------------------
+# _safe_float
+# ---------------------------------------------------------------------------
+
+
+class TestSafeFloat:
+    def test_normal_float(self) -> None:
+        assert _safe_float(3.14) == 3.14
+
+    def test_int_converted(self) -> None:
+        assert _safe_float(42) == 42.0
+
+    def test_string_converted(self) -> None:
+        assert _safe_float("3.14") == 3.14
+
+    def test_nan_returns_none(self) -> None:
+        assert _safe_float(float("nan")) is None
+
+    def test_inf_returns_none(self) -> None:
+        assert _safe_float(float("inf")) is None
+
+    def test_neg_inf_returns_none(self) -> None:
+        assert _safe_float(float("-inf")) is None
+
+    def test_none_returns_none(self) -> None:
+        assert _safe_float(None) is None
+
+    def test_non_numeric_string_returns_none(self) -> None:
+        assert _safe_float("not-a-number") is None
+
+
+# ---------------------------------------------------------------------------
+# _safe_int
+# ---------------------------------------------------------------------------
+
+
+class TestSafeInt:
+    def test_normal_int(self) -> None:
+        assert _safe_int(42) == 42
+
+    def test_float_truncated(self) -> None:
+        assert _safe_int(3.9) == 3
+
+    def test_string_converted(self) -> None:
+        assert _safe_int("99") == 99
+
+    def test_none_returns_none(self) -> None:
+        assert _safe_int(None) is None
+
+    def test_non_numeric_returns_none(self) -> None:
+        assert _safe_int("xyz") is None
+
+
+# ---------------------------------------------------------------------------
+# _maybe_set_str
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeSetStr:
+    def test_sets_value(self) -> None:
+        h: dict[str, Any] = {}
+        _maybe_set_str(h, "key", "value")
+        assert h["key"] == "value"
+
+    def test_strips_whitespace(self) -> None:
+        h: dict[str, Any] = {}
+        _maybe_set_str(h, "key", "  padded  ")
+        assert h["key"] == "padded"
+
+    def test_none_skipped(self) -> None:
+        h: dict[str, Any] = {}
+        _maybe_set_str(h, "key", None)
+        assert "key" not in h
+
+    def test_empty_string_skipped(self) -> None:
+        h: dict[str, Any] = {}
+        _maybe_set_str(h, "key", "")
+        assert "key" not in h
+
+    def test_whitespace_only_skipped(self) -> None:
+        h: dict[str, Any] = {}
+        _maybe_set_str(h, "key", "   ")
+        assert "key" not in h
+
+
+# ---------------------------------------------------------------------------
+# _maybe_set_numeric
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeSetNumeric:
+    def test_converts_to_decimal(self) -> None:
+        h: dict[str, Any] = {}
+        _maybe_set_numeric(h, "key", 3.14)
+        assert isinstance(h["key"], Decimal)
+
+    def test_nan_dropped(self) -> None:
+        h: dict[str, Any] = {}
+        _maybe_set_numeric(h, "key", float("nan"))
+        assert "key" not in h
+
+    def test_inf_dropped(self) -> None:
+        h: dict[str, Any] = {}
+        _maybe_set_numeric(h, "key", float("inf"))
+        assert "key" not in h
+
+    def test_none_dropped(self) -> None:
+        h: dict[str, Any] = {}
+        _maybe_set_numeric(h, "key", None)
+        assert "key" not in h
+
+
+# ---------------------------------------------------------------------------
+# _extract_hints
+# ---------------------------------------------------------------------------
+
+
+class TestExtractHints:
+    def test_empty_raw_returns_empty_dict(self) -> None:
+        assert _extract_hints({}) == {}
+
+    def test_instrument_extracted(self) -> None:
+        hints = _extract_hints(_raw())
+        assert hints["instrument"] == "STIS"
+
+    def test_target_name_extracted(self) -> None:
+        hints = _extract_hints(_raw())
+        assert hints["target_name"] == "V339-DEL"
+
+    def test_proposal_id_extracted(self) -> None:
+        hints = _extract_hints(_raw())
+        assert hints["proposal_id"] == "13828"
+
+    def test_numeric_hints_converted_to_decimal(self) -> None:
+        hints = _extract_hints(_raw())
+        assert isinstance(hints["t_min_mjd"], Decimal)
+        assert isinstance(hints["t_max_mjd"], Decimal)
+
+    def test_nan_times_dropped(self) -> None:
+        hints = _extract_hints(_raw(t_min=float("nan"), t_max=float("inf")))
+        assert "t_min_mjd" not in hints
+        assert "t_max_mjd" not in hints
+
+    def test_all_hints_populated(self) -> None:
+        hints = _extract_hints(_raw())
+        assert set(hints.keys()) == {
+            "instrument",
+            "target_name",
+            "proposal_id",
+            "obs_id",
+            "t_min_mjd",
+            "t_max_mjd",
+        }
+
+
+# ---------------------------------------------------------------------------
+# MASTAdapter.normalize
+# ---------------------------------------------------------------------------
+
+
+class TestNormalize:
+    def setup_method(self) -> None:
+        self.adapter = MASTAdapter()
+
+    def test_native_id_strategy(self) -> None:
+        result = self.adapter.normalize(nova_id=_NOVA_ID, raw=_raw())
+        assert result is not None
+        assert result["identity_strategy"] == "NATIVE_ID"
+
+    def test_provider_product_key_is_filename(self) -> None:
+        result = self.adapter.normalize(nova_id=_NOVA_ID, raw=_raw())
+        assert result is not None
+        assert result["provider_product_key"] == ("hst_13828_stis_v339-del_e140m_ocoj08_cspec.fits")
+
+    def test_locator_identity_uses_product_id_prefix(self) -> None:
+        result = self.adapter.normalize(nova_id=_NOVA_ID, raw=_raw())
+        assert result is not None
+        assert result["locator_identity"].startswith("provider_product_id:")
+
+    def test_locator_url_constructed_from_data_uri(self) -> None:
+        result = self.adapter.normalize(nova_id=_NOVA_ID, raw=_raw())
+        assert result is not None
+        locators = result["locators"]
+        assert len(locators) == 1
+        assert locators[0]["kind"] == "URL"
+        assert locators[0]["role"] == "PRIMARY"
+        assert "mast.stsci.edu" in locators[0]["value"]
+        assert "mast:HST/product/" in locators[0]["value"]
+
+    def test_provider_is_mast(self) -> None:
+        result = self.adapter.normalize(nova_id=_NOVA_ID, raw=_raw())
+        assert result is not None
+        assert result["provider"] == "MAST"
+
+    def test_nova_id_propagated(self) -> None:
+        result = self.adapter.normalize(nova_id="nova-xyz", raw=_raw())
+        assert result is not None
+        assert result["nova_id"] == "nova-xyz"
+
+    def test_hints_populated(self) -> None:
+        result = self.adapter.normalize(nova_id=_NOVA_ID, raw=_raw())
+        assert result is not None
+        assert result["hints"]["instrument"] == "STIS"
+        assert "t_min_mjd" in result["hints"]
+
+    def test_returns_none_when_product_filename_missing(self) -> None:
+        result = self.adapter.normalize(nova_id=_NOVA_ID, raw=_raw(productFilename=None))
+        assert result is None
+
+    def test_returns_none_when_product_filename_empty(self) -> None:
+        result = self.adapter.normalize(nova_id=_NOVA_ID, raw=_raw(productFilename=""))
+        assert result is None
+
+    def test_returns_none_when_data_uri_missing(self) -> None:
+        result = self.adapter.normalize(nova_id=_NOVA_ID, raw=_raw(dataURI=None))
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# MASTAdapter.query
+# ---------------------------------------------------------------------------
+
+
+class TestQuery:
+    def setup_method(self) -> None:
+        self.adapter = MASTAdapter()
+
+    @patch("spectra_discoverer.adapters.mast.Observations")
+    @patch("spectra_discoverer.adapters.mast.time.sleep")
+    def test_returns_cspec_products_for_primary_name(self, mock_sleep: Any, mock_obs: Any) -> None:
+        mock_obs.query_object.return_value = _obs_table()
+        mock_obs.get_product_list.return_value = _prod_table()
+
+        result = self.adapter.query(
+            nova_id=_NOVA_ID,
+            ra_deg=_RA_DEG,
+            dec_deg=_DEC_DEG,
+            primary_name=_PRIMARY_NAME,
+            aliases=_ALIASES,
+        )
+
+        assert len(result) == 1
+        assert result[0]["productFilename"].endswith("_cspec.fits")
+        mock_obs.query_object.assert_called_once_with(_PRIMARY_NAME, radius="1 arcmin")
+
+    @patch("spectra_discoverer.adapters.mast.Observations")
+    @patch("spectra_discoverer.adapters.mast.time.sleep")
+    def test_alias_fallback_when_primary_has_no_hasp(self, mock_sleep: Any, mock_obs: Any) -> None:
+        """Primary name finds non-HASP obs; first alias finds HASP."""
+        non_hasp = _obs_table([_obs_row(project="HST")])  # raw, not HASP
+        hasp = _obs_table()
+
+        mock_obs.query_object.side_effect = [non_hasp, hasp]
+        mock_obs.get_product_list.return_value = _prod_table()
+
+        result = self.adapter.query(
+            nova_id=_NOVA_ID,
+            ra_deg=_RA_DEG,
+            dec_deg=_DEC_DEG,
+            primary_name=_PRIMARY_NAME,
+            aliases=_ALIASES,
+        )
+
+        assert len(result) == 1
+        assert mock_obs.query_object.call_count == 2
+        mock_obs.query_object.assert_called_with(_ALIASES[0], radius="1 arcmin")
+
+    @patch("spectra_discoverer.adapters.mast.Observations")
+    @patch("spectra_discoverer.adapters.mast.time.sleep")
+    def test_empty_results_from_all_names(self, mock_sleep: Any, mock_obs: Any) -> None:
+        mock_obs.query_object.return_value = _obs_table([])
+
+        result = self.adapter.query(
+            nova_id=_NOVA_ID,
+            ra_deg=_RA_DEG,
+            dec_deg=_DEC_DEG,
+            primary_name=_PRIMARY_NAME,
+            aliases=_ALIASES,
+        )
+
+        assert result == []
+        # primary + 2 aliases = 3 calls
+        assert mock_obs.query_object.call_count == 3
+
+    def test_raises_value_error_when_no_primary_name(self) -> None:
+        with pytest.raises(ValueError, match="primary_name"):
+            self.adapter.query(
+                nova_id=_NOVA_ID,
+                ra_deg=_RA_DEG,
+                dec_deg=_DEC_DEG,
+                primary_name=None,
+                aliases=_ALIASES,
+            )
+
+    @patch("spectra_discoverer.adapters.mast.Observations")
+    @patch("spectra_discoverer.adapters.mast.time.sleep")
+    def test_filters_non_hst_and_non_hasp(self, mock_sleep: Any, mock_obs: Any) -> None:
+        """Only HST + spectrum + HASP observations pass the filter."""
+        rows = [
+            _obs_row(),  # valid
+            _obs_row(obs_collection="JWST", obsid=99002),  # wrong collection
+            _obs_row(dataproduct_type="image", obsid=99003),  # wrong type
+            _obs_row(project="HST", obsid=99004),  # raw, not HASP
+        ]
+        mock_obs.query_object.return_value = _obs_table(rows)
+        mock_obs.get_product_list.return_value = _prod_table()
+
+        result = self.adapter.query(
+            nova_id=_NOVA_ID,
+            ra_deg=_RA_DEG,
+            dec_deg=_DEC_DEG,
+            primary_name=_PRIMARY_NAME,
+        )
+
+        assert len(result) == 1
+
+    @patch("spectra_discoverer.adapters.mast.Observations")
+    @patch("spectra_discoverer.adapters.mast.time.sleep")
+    def test_filters_non_cspec_products(self, mock_sleep: Any, mock_obs: Any) -> None:
+        products = [
+            _prod_row(),  # valid cspec
+            _prod_row(
+                productFilename="oc7r06010_x1d.fits",
+                dataURI="mast:HST/product/oc7r06010_x1d.fits",
+            ),  # raw x1d
+        ]
+        mock_obs.query_object.return_value = _obs_table()
+        mock_obs.get_product_list.return_value = _prod_table(products)
+
+        result = self.adapter.query(
+            nova_id=_NOVA_ID,
+            ra_deg=_RA_DEG,
+            dec_deg=_DEC_DEG,
+            primary_name=_PRIMARY_NAME,
+        )
+
+        assert len(result) == 1
+        assert result[0]["productFilename"].endswith("_cspec.fits")
+
+    @patch("spectra_discoverer.adapters.mast.Observations")
+    @patch("spectra_discoverer.adapters.mast.time.sleep")
+    def test_retryable_error_after_all_attempts_fail(self, mock_sleep: Any, mock_obs: Any) -> None:
+        from nova_common.errors import RetryableError
+
+        mock_obs.query_object.side_effect = ConnectionError("MAST down")
+
+        with pytest.raises(RetryableError, match="MAST query_object failed"):
+            self.adapter.query(
+                nova_id=_NOVA_ID,
+                ra_deg=_RA_DEG,
+                dec_deg=_DEC_DEG,
+                primary_name=_PRIMARY_NAME,
+            )
+
+        assert mock_obs.query_object.call_count == 3
+        assert mock_sleep.call_count == 2
+
+    @patch("spectra_discoverer.adapters.mast.Observations")
+    @patch("spectra_discoverer.adapters.mast.time.sleep")
+    def test_retry_then_succeed(self, mock_sleep: Any, mock_obs: Any) -> None:
+        """query_object fails on first attempt, succeeds on second."""
+        mock_obs.query_object.side_effect = [
+            ConnectionError("timeout"),
+            _obs_table(),
+        ]
+        mock_obs.get_product_list.return_value = _prod_table()
+
+        result = self.adapter.query(
+            nova_id=_NOVA_ID,
+            ra_deg=_RA_DEG,
+            dec_deg=_DEC_DEG,
+            primary_name=_PRIMARY_NAME,
+        )
+
+        assert len(result) == 1
+        assert mock_obs.query_object.call_count == 2
+        assert any(c.args == (3,) for c in mock_sleep.call_args_list)
+
+    @patch("spectra_discoverer.adapters.mast.Observations")
+    @patch("spectra_discoverer.adapters.mast.time.sleep")
+    def test_enriches_products_with_obs_metadata(self, mock_sleep: Any, mock_obs: Any) -> None:
+        mock_obs.query_object.return_value = _obs_table(
+            [
+                _obs_row(instrument_name="COS/FUV", proposal_id=15890),
+            ]
+        )
+        mock_obs.get_product_list.return_value = _prod_table()
+
+        result = self.adapter.query(
+            nova_id=_NOVA_ID,
+            ra_deg=_RA_DEG,
+            dec_deg=_DEC_DEG,
+            primary_name=_PRIMARY_NAME,
+        )
+
+        assert len(result) == 1
+        assert result[0]["instrument_name"] == "COS/FUV"
+        assert result[0]["proposal_id"] == "15890"
+
+    @patch("spectra_discoverer.adapters.mast.Observations")
+    @patch("spectra_discoverer.adapters.mast.time.sleep")
+    def test_duplicate_alias_skipped(self, mock_sleep: Any, mock_obs: Any) -> None:
+        """Alias identical to primary_name is not queried again."""
+        mock_obs.query_object.return_value = _obs_table([])
+
+        self.adapter.query(
+            nova_id=_NOVA_ID,
+            ra_deg=_RA_DEG,
+            dec_deg=_DEC_DEG,
+            primary_name=_PRIMARY_NAME,
+            aliases=[_PRIMARY_NAME, "Other Name"],
+        )
+
+        # primary + "Other Name" = 2 (duplicate skipped)
+        assert mock_obs.query_object.call_count == 2
+
+    @patch("spectra_discoverer.adapters.mast.Observations")
+    @patch("spectra_discoverer.adapters.mast.time.sleep")
+    def test_warning_logged_on_retry(
+        self, mock_sleep: Any, mock_obs: Any, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A WARNING log is emitted for each failed attempt that will be retried."""
+        mock_obs.query_object.side_effect = [
+            ConnectionError("oops"),
+            _obs_table(),
+        ]
+        mock_obs.get_product_list.return_value = _prod_table()
+
+        with caplog.at_level(logging.WARNING):
+            self.adapter.query(
+                nova_id=_NOVA_ID,
+                ra_deg=_RA_DEG,
+                dec_deg=_DEC_DEG,
+                primary_name=_PRIMARY_NAME,
+            )
+
+        warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("attempt 1/3 failed" in msg for msg in warning_messages)
+
+
+# ---------------------------------------------------------------------------
+# Protocol compliance
+# ---------------------------------------------------------------------------
+
+
+class TestProtocol:
+    def test_satisfies_protocol(self) -> None:
+        from spectra_discoverer.adapters.base import SpectraDiscoveryAdapter
+
+        adapter = MASTAdapter()
+        assert isinstance(adapter, SpectraDiscoveryAdapter)
+
+    def test_provider_string(self) -> None:
+        assert MASTAdapter().provider == "MAST"

--- a/tests/services/test_spectra_discoverer_handler.py
+++ b/tests/services/test_spectra_discoverer_handler.py
@@ -243,6 +243,8 @@ class TestQueryProviderForProducts:
             nova_id=_NOVA_ID,
             ra_deg=pytest.approx(271.5755),
             dec_deg=pytest.approx(-30.6558),
+            primary_name="unknown",
+            aliases=[],
         )
 
     def test_raises_value_error_when_nova_not_found(


### PR DESCRIPTION
## Summary
- Extended the `SpectraDiscoveryAdapter` Protocol with optional `primary_name` and `aliases` kwargs on `query()`, enabling name-based archive queries alongside coordinate-based ones
- Added `MASTAdapter` for discovering HASP co-added spectra (`_cspec.fits`) via `astroquery.mast`, using `query_object` with alias fallback
- Added `MastStisHaspProfile` for validating HASP STIS FITS files, deriving observation time from the PROVENANCE table and SNR from per-pixel values
- Registered both in their respective registries and added `"MAST"` to `PrepareProviderList` in the discovery ASL
- Updated handler to read `primary_name` and `aliases` from the Nova DDB item and pass them through to adapters
- 90 new tests across adapter and profile test suites

## Why
- NovaCat's only spectra source was ESO. Adding MAST/HASP unlocks HST UV spectroscopy (STIS, eventually COS) for novae — science-ready co-added products that don't exist in any other public archive
- MAST requires name-based queries because HST ToO observations have significant coordinate offsets from SIMBAD positions, causing pure coordinate cone searches to miss targets entirely
- HASP `cspec` files are per-visit co-adds, making them safe for transient science (all constituent exposures are from the same HST scheduling block / epoch)

## Testing
- 52 adapter unit tests: private helpers, normalize (identity strategy, locators, hints, skip branches), query (name search, alias fallback, HASP/cspec filtering, retry logic, error handling, obs-product metadata join)
- 38 profile unit tests: matches logic, happy path output shape, missing columns/HDUs, PROVENANCE-based metadata extraction (observation time, exposure time, spectral resolution), sanity checks (monotonicity, NaN fraction, wavelength range), SNR extraction, `validate_spectrum` dispatch
- All tests use mocked MAST API calls and synthetic astropy HDULists — no network access or binary fixtures
- Validated profile against 3 real HASP FITS files (V339 Del, two programs/visits)

## Notes
- The ESO adapter's `query()` signature was updated to accept and ignore the new name kwargs — no behavioral change
- MAST download URLs are constructed from `dataURI` via `https://mast.stsci.edu/api/v0.1/Download/file?uri=<dataURI>` — no auth required for public HST data
- Identity strategy is `NATIVE_ID` using `productFilename` as the stable key (encodes program/instrument/target/grating/visit)
- HASP primary headers lack `MJD-OBS` / `DATE-OBS` with observation time — the profile derives it from `min(PROVENANCE.MJD_BEG)` instead
- Target coordinates use `TARG_RA` / `TARG_DEC` (not `RA_TARG` / `DEC_TARG`)

## Out of Scope
- COS HASP profile (similar FITS structure, separate instrument — future PR)
- Fallback to raw x1d/sx1 products when HASP cspec doesn't exist
- `spectra_acquirer` changes (it already downloads from URLs generically)
- Dockerfile dependency updates (astroquery is already bundled)

## Next Steps
- Smoke test against live MAST with a deployed stack
- Add COS HASP profile when ready to expand instrument coverage
- Update `current-architecture.md` and master task list to reflect MAST as an active provider