### PR TITLE
fix(spectra): per-regime wavelength trimming and xray/uv regime split (ADR-035)

### DIFF
--- a/docs/adr/ADR-034-spectra-wavelength-regime-model.md
+++ b/docs/adr/ADR-034-spectra-wavelength-regime-model.md
@@ -4,7 +4,7 @@
 **Date:** 2026-04-11
 **Author:** TF
 **Supersedes:** —
-**Superseded by:** —
+**Superseded by:** -
 **Amends:** ADR-013 (adds regime tabs to spectra viewer), ADR-014 (restructures
 `spectra.json` artifact schema to include regime metadata)
 **Relates to:**
@@ -14,6 +14,23 @@
   structural template)
 - `DESIGN-003` — Artifact regeneration pipeline (spectra generator §7)
 - `ADR-033` — Spectra Compositing Pipeline (composites carry regime like any spectrum)
+
+> **⚠ Amended by ADR-035** (2026-04-12)
+> ADR-035 (Spectra Regime Splitting and Per-Regime Display Range) amends this ADR
+> as follows:
+>
+> - **Regime split:** The combined `xuv` regime is replaced by two regimes:
+>   `xray` (λ_mid < 91 nm, Lyman limit) and `uv` (91 ≤ λ_mid < 320 nm).
+> - **Spectrum splitting:** Cross-boundary spectra (e.g., X-Shooter 350–2500 nm)
+>   are split at regime boundaries when the minor-side coverage meets both a
+>   15% fractional and 45 nm absolute threshold. Deferred in §5 of this ADR;
+>   now decided in ADR-035 Decision 2.
+> - **Per-regime trimming:** The median-based display wavelength range is computed
+>   independently per regime group, fixing a bug where UV spectra were truncated
+>   by the optical-dominated global median.
+> - **Schema version:** Bumped from `"1.3"` to `"1.4"`.
+>
+> See: `docs/adr/ADR-035-spectra-regime-splitting-and-per-regime-display-range.md`
 
 ---
 

--- a/docs/adr/ADR-035-spectra-regime-splitting-and-per-regime-display-range.md
+++ b/docs/adr/ADR-035-spectra-regime-splitting-and-per-regime-display-range.md
@@ -1,0 +1,346 @@
+# ADR-035: Spectra Regime Splitting and Per-Regime Display Range
+
+**Status:** Proposed
+**Date:** 2026-04-12
+**Author:** TF
+**Supersedes:** —
+**Superseded by:** —
+**Amends:** ADR-034 (splits `xuv` regime into `xray` + `uv`; promotes spectrum
+splitting and per-regime display range from Deferred to Decided)
+**Relates to:**
+- `ADR-013` — Visualization Design (spectra viewer, feature marker visibility)
+- `ADR-014` — Artifact Schemas (`spectra.json` schema)
+- `ADR-033` — Spectra Compositing Pipeline (composites carry regime like any spectrum)
+- `DESIGN-003` — Artifact regeneration pipeline (spectra generator §7)
+
+---
+
+## 1. Context
+
+ADR-034 introduced wavelength regime classification for spectra, defining four regimes
+(`xuv`, `optical`, `nir`, `mir`) with midpoint-based assignment, and restructured the
+`spectra.json` artifact to carry per-spectrum regime metadata. The frontend gained
+regime tabs for the spectra viewer.
+
+Three issues have emerged during implementation:
+
+### 1.1 Combined X-ray / UV regime is too coarse
+
+ADR-034 Decision 1 combined X-ray and UV into a single `xuv` regime, noting that X-ray
+grating spectra are rare. While this remains true, the wavelength gap between X-ray
+grating spectra (Chandra HETG/LETG: ~0.1–17 nm; XMM-Newton RGS: ~0.5–3.5 nm) and UV
+spectra (IUE/STIS/COS: ~91–320 nm) is enormous. No current or planned facility observes
+novae in the ~17–91 nm EUV range. Plotting a 2 nm Chandra spectrum on the same axis as
+a 150 nm STIS spectrum would produce the same unreadable result that motivated regime
+separation in the first place.
+
+The Lyman limit at 91.2 nm provides a clean physical boundary: everything below it is
+ionizing radiation observed by X-ray telescopes, everything above it is UV observed by
+UV-capable space telescopes.
+
+### 1.2 Cross-boundary spectra are truncated by global median trimming
+
+The spectra generator computes a single display wavelength range from the median of all
+spectra's min/max wavelengths, then trims outliers to that range. This was designed for
+a homogeneous optical population and works well when all spectra cover roughly the same
+wavelength domain.
+
+When UV spectra (~115–310 nm) are mixed with optical spectra (~300–900 nm), the median
+blue edge lands at ~305 nm. UV spectra are trimmed to just their red tail (305–310 nm),
+rendering them as a few nanometres of noise. This is the proximate bug that motivated
+this amendment.
+
+The fix requires computing display ranges **per regime** rather than globally.
+
+### 1.3 Wide-coverage spectra span regime boundaries
+
+Instruments like VLT/X-Shooter (~350–2500 nm) and HST/STIS CCD gratings (~290–1030 nm)
+produce spectra whose wavelength coverage spans a regime boundary. ADR-034 handles
+these by assigning the entire spectrum to the regime containing its midpoint, which
+works when the cross-boundary portion is small. However, when an X-Shooter spectrum
+has 650 nm of optical coverage and 1500 nm of NIR coverage, assigning the entire
+spectrum to NIR wastes the optical data — and assigning it to optical wastes the NIR.
+
+Splitting such spectra at the regime boundary allows each portion to participate in the
+correct regime's waterfall plot.
+
+---
+
+## 2. Decisions
+
+### Decision 1 — Split `xuv` Into `xray` and `uv`
+
+The ADR-034 `xuv` regime is replaced by two regimes:
+
+| `id` | `label` | Wavelength range | Boundary rationale |
+|---|---|---|---|
+| `xray` | X-ray | λ_mid < 91 nm | 91 nm ≈ Lyman limit (912 Å). All grating spectra below this boundary are X-ray telescopes (Chandra, XMM-Newton). |
+| `uv` | Ultraviolet | 91 nm ≤ λ_mid < 320 nm | Space-based UV window (STIS, COS, IUE). Upper boundary unchanged from ADR-034. |
+
+The remaining regimes (`optical`, `nir`, `mir`) are unchanged.
+
+**Updated complete regime table:**
+
+| `id` | `label` | Range | Sort order |
+|---|---|---|---|
+| `xray` | X-ray | λ_mid < 91 nm | 0 |
+| `uv` | Ultraviolet | 91 ≤ λ_mid < 320 nm | 1 |
+| `optical` | Optical | 320 ≤ λ_mid < 1000 nm | 2 |
+| `nir` | Near-IR | 1000 ≤ λ_mid < 5000 nm | 3 |
+| `mir` | Mid-IR | λ_mid ≥ 5000 nm | 4 |
+
+**Schema impact:** The `regimes` array in `spectra.json` carries the new `id` values.
+Existing artifacts with `xuv` regime IDs will not be produced after the generator is
+updated. The frontend backward-compatibility fallback (ADR-034 Decision 7) already
+handles missing `regimes` gracefully; no additional fallback is needed for the ID
+rename because all artifacts will be regenerated in the next sweep.
+
+**Frontend feature marker visibility:** ADR-034 Decision 5 hid feature markers for
+non-optical regimes. This remains correct — the toggle is hidden for both `xray` and
+`uv` tabs. UV spectral feature markers remain deferred.
+
+### Decision 2 — Cross-Boundary Spectrum Splitting
+
+Spectra whose wavelength coverage straddles a regime boundary are eligible for
+splitting. Splitting produces two (or, in rare cases, more) records from a single
+input spectrum, one per regime, each containing the subset of wavelength/flux data
+points that fall within that regime's domain.
+
+**Regime boundaries for splitting:** 91 nm, 320 nm, 1000 nm, 5000 nm.
+
+**Boundary point rule:** A data point whose wavelength exactly equals a boundary value
+is assigned to the **redder** (longer-wavelength) regime. For example, a point at
+exactly 320.0 nm goes to `optical`, not `uv`.
+
+**Splitting eligibility thresholds:** A spectrum is split only when the minor-side
+coverage (the portion of the spectrum on the smaller side of the boundary) meets
+**both** of the following criteria:
+
+1. **Fractional threshold:** The minor-side wavelength span is ≥ 15% of the total
+   wavelength span of the spectrum.
+2. **Absolute minimum:** The minor-side wavelength span is ≥ 45 nm.
+
+If either threshold is not met, the spectrum is assigned whole to the regime containing
+its midpoint (per ADR-034 Decision 2), and no splitting occurs.
+
+**Rationale for 45 nm absolute minimum:** The smallest scientifically useful UV spectra
+in the catalog are HST/STIS G140L products covering ~114–168 nm (~54 nm span). The
+45 nm floor ensures that split fragments are large enough to be independently useful on
+a waterfall plot while preventing creation of tiny slivers from spectra that barely
+cross a boundary (e.g., STIS G430L's ~30 nm of coverage below 320 nm).
+
+**Rationale for 15% fractional threshold:** Prevents splitting when the cross-boundary
+portion is negligible relative to the spectrum's total coverage, regardless of absolute
+width.
+
+**Split record identity:** Each split fragment inherits the parent spectrum's
+`data_product_id` and product metadata. To distinguish fragments in the output, the
+`spectrum_id` field receives a suffix: `{data_product_id}::{regime_id}`. For example,
+a spectrum `abc-123` split into optical and NIR portions becomes `abc-123::optical` and
+`abc-123::nir`. This ensures unique `spectrum_id` values in the artifact while
+preserving traceability to the source DataProduct.
+
+Non-split spectra continue to use `data_product_id` as their `spectrum_id`, unchanged
+from ADR-034.
+
+**Splitting execution point:** Splitting occurs in the spectra generator **after**
+Stage 1 processing (CSV parse, dead edge trimming, chip gap cleaning) and multi-arm
+merging, but **before** regime-grouped median display range computation and
+Stage 2 processing (LTTB, normalization). This ensures that:
+
+- Cleaning is applied to the full spectrum before splitting (chip gaps that span a
+  boundary are handled correctly).
+- Each split fragment participates in its regime's median display range pool.
+- LTTB downsampling and normalization are applied independently per fragment.
+
+**Worked examples:**
+
+| Spectrum | Coverage | Boundary | Minor side | Split? | Reason |
+|---|---|---|---|---|---|
+| X-Shooter | 350–2500 nm | 1000 nm | 650 nm optical (30%) | Yes | 650 nm > 45 nm, 30% > 15% |
+| STIS G430L | 290–570 nm | 320 nm | 30 nm UV (11%) | No | 30 nm < 45 nm |
+| STIS G750L | 525–1030 nm | 1000 nm | 30 nm NIR (6%) | No | 30 nm < 45 nm, 6% < 15% |
+| STIS CCD full | 290–1030 nm | 320 nm | 30 nm UV (4%) | No | 30 nm < 45 nm |
+| Hypothetical | 200–600 nm | 320 nm | 120 nm UV (30%) | Yes | 120 nm > 45 nm, 30% > 15% |
+
+### Decision 3 — Per-Regime Median Display Range Computation
+
+The existing median-based display wavelength range computation (DESIGN-003 §7,
+`spectra.py` Step 2b) is restructured to operate **independently per regime group**
+rather than globally across all spectra.
+
+**Algorithm (per regime):**
+
+1. After regime classification and splitting, group parsed spectra by regime.
+2. For each regime group with ≥ 2 spectra:
+   a. Compute `display_wavelength_min` = median of blue edges.
+   b. Compute `display_wavelength_max` = median of red edges.
+   c. Apply the existing trim logic (red-side and blue-side, with `_TRIM_TOLERANCE`)
+      scoped to that regime's spectra only.
+3. For regime groups with 0–1 spectra, no trimming is applied (consistent with existing
+   behavior for single-spectrum novae).
+
+**Rationale:** This is the minimal change to the existing trimming algorithm that fixes
+the cross-regime contamination bug. The algorithm itself is sound — it was designed to
+handle detector rolloff outliers within a homogeneous population. The bug was that UV
+and optical spectra were treated as a single population, causing the median to reflect
+the optical majority and trim the UV minority.
+
+**Bimodal data warning:** The existing >50% trim warnings are now computed per regime.
+A bimodal distribution *within* a single regime (e.g., two groups of optical spectra
+with very different wavelength ranges) would still trigger the warning, which is the
+correct behavior.
+
+### Decision 4 — Updated Spectra Generator Flow
+
+The spectra generator's processing pipeline is restructured as follows. Steps marked
+with ★ are new or modified; unmarked steps are unchanged.
+
+1. Query VALID spectra DataProduct items
+2. Post-query composite filtering (ADR-033)
+3. Stage 1: parse CSV + dead edge trimming + chip gap cleaning (per spectrum)
+4. Multi-arm merge
+5. ★ **Early regime classification** — assign each parsed spectrum a regime using the
+   midpoint rule (ADR-034 Decision 2), based on pre-trim wavelength bounds
+6. ★ **Cross-boundary splitting** — apply Decision 2 splitting logic; re-classify
+   each fragment (midpoint will now place fragments in the correct regime)
+7. ★ **Per-regime median display range + trim** — apply Decision 3 per-regime
+   grouping and trimming
+8. Stage 2: LTTB downsampling + normalization — regime already assigned; the
+   `_assign_spectra_regime` call in `_process_spectrum_stage2` is replaced by
+   passing through the pre-assigned regime from step 5/6
+9. Regime metadata assembly + sort *(unchanged)*
+
+### Decision 5 — Schema Version Bump
+
+The `spectra.json` schema version is bumped from `"1.3"` to `"1.4"` to reflect the
+regime ID changes (`xuv` → `xray` / `uv`) and the potential presence of split-spectrum
+`spectrum_id` values with `::` suffixes.
+
+The `regimes` array structure is unchanged — only the `id` and `label` values for the
+former `xuv` regime are affected.
+
+**Updated regime definitions for the artifact:**
+
+| `id` | `label` | `wavelength_range_nm` |
+|---|---|---|
+| `xray` | X-ray | `[0, 91]` |
+| `uv` | Ultraviolet | `[91, 320]` |
+| `optical` | Optical | `[320, 1000]` |
+| `nir` | Near-IR | `[1000, 5000]` |
+| `mir` | Mid-IR | `[5000, null]` |
+
+### Decision 6 — Frontend Backward Compatibility
+
+The frontend already handles missing `regimes` gracefully (ADR-034 Decision 7). For
+the `xuv` → `xray` / `uv` rename, no additional fallback is needed: all artifacts
+will be regenerated in the next sweep after deployment. During the brief window
+between deployment and regeneration, stale artifacts with `xuv` regime IDs may be
+served. The frontend should treat unrecognized regime IDs as a fallback to the
+single-regime (no tab bar) display mode, consistent with the existing missing-`regimes`
+fallback.
+
+---
+
+## 3. Consequences
+
+### Benefits
+
+- **Fixes UV spectra display bug.** Per-regime trimming ensures UV spectra are not
+  destroyed by the optical-dominated global median.
+- **Proper X-ray / UV separation.** If the catalog acquires Chandra or XMM grating
+  spectra, they will render on their own tab with an appropriate wavelength scale.
+- **Wide-coverage instruments supported.** X-Shooter optical+NIR spectra are split
+  so each portion appears in the correct regime with appropriate axis scaling.
+- **Minimal algorithmic change.** The median trimming algorithm itself is unchanged;
+  only its scope of application (per-regime vs. global) changes.
+
+### Costs
+
+- **Split-spectrum `spectrum_id` values.** The `::` suffix convention adds a new
+  pattern to the `spectrum_id` field. Frontend code that uses `spectrum_id` as a key
+  (legend strip, selection state) must handle the longer IDs, but no logic change is
+  required — they are still unique strings.
+- **Additional regime constants.** Five regimes instead of four, with one more
+  boundary (91 nm). Regime-related data structures in both backend and frontend gain
+  one entry.
+- **Generator restructuring.** Moving regime assignment upstream of trimming requires
+  reordering the processing pipeline. The individual functions are unchanged; the
+  control flow in `generate_spectra_json` is restructured.
+
+### Risks
+
+- **Split fragments with low SNR.** When a wide-coverage spectrum is split, the
+  minor-side fragment may have lower SNR than the parent. The 45 nm / 15% thresholds
+  mitigate this by preventing creation of scientifically useless slivers, but a split
+  fragment near the boundary may still be noisier than the rest of the spectrum. This
+  is acceptable — the fragment is genuine data, and low-SNR spectra are displayed as-is
+  throughout the system.
+- **Multi-boundary splits.** In theory, a spectrum could span two boundaries (e.g.,
+  200–6000 nm spanning UV/optical/NIR/MIR). The splitting logic should handle
+  arbitrary numbers of boundaries by iterating through them. In practice, no current
+  instrument produces single spectra this broad.
+
+---
+
+## 4. Implementation Plan
+
+### 4.1 Backend — Spectra Generator
+
+1. Update regime boundary constants: replace `xuv` entry with `xray` (91 nm) and
+   `uv` (320 nm) entries.
+2. Update regime definitions dict, sort order dict.
+3. Add `_split_cross_boundary_spectrum()` function implementing Decision 2.
+4. Add `_assign_and_split_regimes()` orchestration function implementing steps 5–6
+   of Decision 4.
+5. Add `_trim_per_regime()` function implementing Decision 3.
+6. Restructure `generate_spectra_json` control flow per Decision 4.
+7. Update `_process_spectrum_stage2` to accept pre-assigned regime rather than
+   computing it from post-trim wavelengths.
+8. Bump `_SCHEMA_VERSION` to `"1.4"`.
+
+### 4.2 Frontend — Types
+
+1. Update `SpectraRegimeRecord` usage — no structural change, but `id` values now
+   include `"xray"` and `"uv"` instead of `"xuv"`.
+2. Handle `::` suffixed `spectrum_id` values in legend strip and selection state
+   (no logic change expected — they are opaque string keys).
+
+### 4.3 Frontend — SpectraViewer
+
+1. Update any hardcoded `"xuv"` references to handle both `"xray"` and `"uv"`.
+2. Feature marker toggle hidden for `"xray"` and `"uv"` (same logic as before,
+   expanded to two IDs).
+3. Backward compatibility: treat unrecognized regime `id` values as single-regime
+   fallback.
+
+### 4.4 Tests
+
+1. Unit tests for `_split_cross_boundary_spectrum()`: X-Shooter case (split),
+   STIS G430L case (no split — below thresholds), boundary-point assignment.
+2. Unit tests for `_trim_per_regime()`: verify independent median computation
+   per regime group; verify UV spectra are not trimmed by optical median.
+3. Integration-style test: mixed UV + optical spectra population produces correct
+   per-regime display ranges in the artifact output.
+
+---
+
+## 5. Deferred
+
+- UV spectral feature markers (C IV 154.9 nm, Si IV 139.4/140.3 nm, Mg II 280.0 nm,
+  N V 124.0 nm, etc.)
+- X-ray spectral feature markers
+- Per-regime spectra counts in `nova.json` / `catalog.json`
+- Regime-specific waterfall plot styling (e.g., different color ramps per regime)
+
+---
+
+## 6. Links
+
+- Related ADRs: ADR-013, ADR-014, ADR-033, ADR-034
+- Design docs: DESIGN-003 (artifact regeneration pipeline, §7)
+- Lyman limit: 91.2 nm (912 Å) — hydrogen ionization edge
+- Chandra HETG wavelength range: 0.12–17 nm (1.2–170 Å)
+- XMM-Newton RGS wavelength range: 0.5–3.5 nm (5–35 Å)
+- HST/STIS wavelength coverage: 115–1030 nm across MAMA + CCD detectors
+- VLT/X-Shooter wavelength coverage: ~300–2500 nm across UVB + VIS + NIR arms

--- a/frontend/src/components/nova/SpectraViewer.tsx
+++ b/frontend/src/components/nova/SpectraViewer.tsx
@@ -740,7 +740,7 @@ export default function SpectraViewer({ data, onRetry }: SpectraViewerProps) {
   const regimes = data.regimes ?? [];
   const showRegimeTabs = regimes.length > 1;
 
-  const REGIME_ORDER: Record<string, number> = { xuv: 0, optical: 1, nir: 2, mir: 3 };
+  const REGIME_ORDER: Record<string, number> = { xray: 0, uv: 1, optical: 2, nir: 3, mir: 4 };
   const defaultRegimeId = useMemo(() => {
     if (regimes.length === 0) return 'optical';
     const counts = new Map<string, number>();

--- a/services/artifact_generator/generators/spectra.py
+++ b/services/artifact_generator/generators/spectra.py
@@ -27,6 +27,7 @@ import logging
 import statistics
 import time
 import uuid
+from collections import defaultdict
 from decimal import Decimal
 from typing import Any
 
@@ -43,7 +44,7 @@ from generators.shared import (
 
 _logger = logging.getLogger("artifact_generator")
 
-_SCHEMA_VERSION = "1.3"  # ADR-034: spectra wavelength regimes (1.2 was ADR-033)
+_SCHEMA_VERSION = "1.4"  # ADR-035: xray/uv split, per-regime trimming
 _WAVELENGTH_UNIT = "nm"
 
 _FLUX_FLOOR = 1e-4  # minimum normalized flux; prevents log(0) in frontend
@@ -52,27 +53,34 @@ _TRIM_TOLERANCE = 1.1  # 10% beyond median before wavelength trim kicks in
 _ARM_MJD_TOLERANCE = 0.333  # days (~8 hr) — grouping tolerance for arms
 _ARM_OVERLAP_MAX_NM = 100.0  # nm — max overlap before we reject a merge
 
-# ADR-034 spectra wavelength regime boundaries (nm).
+# ADR-035 spectra wavelength regime boundaries (nm).
 # Assignment is by wavelength midpoint: (wavelength_min + wavelength_max) / 2.
 _SPECTRA_REGIME_BOUNDARIES: list[tuple[str, float]] = [
-    ("xuv", 320.0),  # λ_mid < 320 nm
+    ("xray", 91.0),  # λ_mid < 91 nm  (Lyman limit)
+    ("uv", 320.0),  # 91 ≤ λ_mid < 320 nm
     ("optical", 1000.0),  # 320 ≤ λ_mid < 1000 nm
     ("nir", 5000.0),  # 1000 ≤ λ_mid < 5000 nm
-    # ("mir", ∞)  # λ_mid ≥ 5000 nm — fallback
+    # ("mir", ∞)        # λ_mid ≥ 5000 nm — fallback
 ]
 
 _SPECTRA_REGIME_SORT_ORDER: dict[str, int] = {
-    "xuv": 0,
-    "optical": 1,
-    "nir": 2,
-    "mir": 3,
+    "xray": 0,
+    "uv": 1,
+    "optical": 2,
+    "nir": 3,
+    "mir": 4,
 }
 
 _SPECTRA_REGIME_DEFINITIONS: dict[str, dict[str, Any]] = {
-    "xuv": {
-        "id": "xuv",
-        "label": "X-ray / UV",
-        "wavelength_range_nm": [0, 320],
+    "xray": {
+        "id": "xray",
+        "label": "X-ray",
+        "wavelength_range_nm": [0, 91],
+    },
+    "uv": {
+        "id": "uv",
+        "label": "Ultraviolet",
+        "wavelength_range_nm": [91, 320],
     },
     "optical": {
         "id": "optical",
@@ -91,6 +99,13 @@ _SPECTRA_REGIME_DEFINITIONS: dict[str, dict[str, Any]] = {
     },
 }
 
+# ADR-035: Cross-boundary spectrum splitting thresholds.
+_SPLIT_FRACTION_THRESHOLD = 0.15  # minor side must be ≥15% of total span
+_SPLIT_ABSOLUTE_MIN_NM = 45.0  # minor side must be ≥45 nm
+
+# Ordered list of regime boundary wavelengths for splitting checks.
+_REGIME_SPLIT_BOUNDARIES: list[float] = [91.0, 320.0, 1000.0, 5000.0]
+
 
 # ---------------------------------------------------------------------------
 # ADR-034: Regime assignment
@@ -104,6 +119,246 @@ def _assign_spectra_regime(wavelength_min: float, wavelength_max: float) -> str:
         if midpoint < upper_bound:
             return regime_id
     return "mir"
+
+
+# ---------------------------------------------------------------------------
+# ADR-035: Cross-boundary splitting and per-regime trimming
+# ---------------------------------------------------------------------------
+
+
+def _split_cross_boundary_spectrum(
+    rec: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Split a parsed stage-1 record at regime boundaries (ADR-035 Decision 2).
+
+    Returns a list of 1+ records. If no split is needed, returns a
+    single-element list containing the original record (unmodified).
+    When a split occurs, each fragment gets:
+      - Its own sliced wavelength/flux arrays
+      - A ``_regime`` key set by midpoint classification of the fragment
+      - A ``_split_suffix`` key with the regime id (for spectrum_id construction)
+
+    Boundary-point rule: a data point at exactly a boundary wavelength
+    goes to the redder (longer-wavelength) regime.
+    """
+    wavelengths: list[float] = rec["wavelengths"]
+    if not wavelengths:
+        return [rec]
+
+    wl_min = wavelengths[0]
+    wl_max = wavelengths[-1]
+    total_span = wl_max - wl_min
+
+    if total_span <= 0:
+        return [rec]
+
+    # Find all boundaries that fall strictly inside the spectrum's range.
+    # "Strictly inside" means wl_min < boundary < wl_max (a boundary at
+    # the edge doesn't create a split).
+    active_boundaries: list[float] = [b for b in _REGIME_SPLIT_BOUNDARIES if wl_min < b < wl_max]
+
+    if not active_boundaries:
+        return [rec]
+
+    # Check each boundary for splitting eligibility.
+    split_points: list[float] = []
+    for boundary in sorted(active_boundaries):
+        # Minor side is the smaller portion.
+        left_span = boundary - wl_min
+        right_span = wl_max - boundary
+        minor_span = min(left_span, right_span)
+
+        if (
+            minor_span >= _SPLIT_ABSOLUTE_MIN_NM
+            and minor_span / total_span >= _SPLIT_FRACTION_THRESHOLD
+        ):
+            split_points.append(boundary)
+
+    if not split_points:
+        return [rec]
+
+    # Perform the split. Build ordered list of cut points including edges.
+    cuts = [wl_min] + split_points + [wl_max + 1.0]  # +1 so last segment includes wl_max
+
+    fragments: list[dict[str, Any]] = []
+    for seg_idx in range(len(cuts) - 1):
+        seg_min = cuts[seg_idx]
+        seg_max = cuts[seg_idx + 1]
+
+        seg_wl: list[float] = []
+        seg_fx: list[float] = []
+        for wl, fx in zip(wavelengths, rec["fluxes"], strict=True):
+            # Boundary point goes to the redder regime: use >= for lower bound
+            # on all segments except the first (which owns the original blue edge).
+            if seg_idx == 0:
+                in_segment = wl >= seg_min and wl < seg_max
+            else:
+                in_segment = wl >= seg_min and wl < seg_max
+            if in_segment:
+                seg_wl.append(wl)
+                seg_fx.append(fx)
+
+        if not seg_wl:
+            continue
+
+        frag_regime = _assign_spectra_regime(seg_wl[0], seg_wl[-1])
+        fragment: dict[str, Any] = {
+            "wavelengths": seg_wl,
+            "fluxes": seg_fx,
+            "product": rec["product"],
+            "nova_id": rec["nova_id"],
+            "_regime": frag_regime,
+            "_split_suffix": frag_regime,
+        }
+        fragments.append(fragment)
+
+    dp_id = rec["product"]["data_product_id"]
+    _logger.info(
+        "Split cross-boundary spectrum",
+        extra={
+            "data_product_id": dp_id,
+            "nova_id": rec["nova_id"],
+            "original_range_nm": [wl_min, wl_max],
+            "split_points_nm": split_points,
+            "fragment_count": len(fragments),
+            "fragment_regimes": [f["_regime"] for f in fragments],
+        },
+    )
+
+    return fragments if fragments else [rec]
+
+
+def _assign_and_split_regimes(
+    parsed: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Classify each parsed spectrum by regime and split cross-boundary spectra.
+
+    ADR-035 Decision 4 steps 5–6. After this function:
+      - Every record has a ``_regime`` key.
+      - Records that were split have a ``_split_suffix`` key.
+      - Records that were NOT split have ``_regime`` set and no ``_split_suffix``.
+    """
+    result: list[dict[str, Any]] = []
+
+    for rec in parsed:
+        wavelengths = rec["wavelengths"]
+        if not wavelengths:
+            continue
+
+        # Try splitting first.
+        fragments = _split_cross_boundary_spectrum(rec)
+
+        if len(fragments) == 1 and "_regime" not in fragments[0]:
+            # No split occurred — assign regime to the original record.
+            wl_min = wavelengths[0]
+            wl_max = wavelengths[-1]
+            fragments[0]["_regime"] = _assign_spectra_regime(wl_min, wl_max)
+
+        result.extend(fragments)
+
+    return result
+
+
+def _trim_per_regime(
+    parsed: list[dict[str, Any]],
+    nova_id: str,
+) -> list[dict[str, Any]]:
+    """Apply median-based wavelength trimming independently per regime group.
+
+    ADR-035 Decision 3. This replaces the old global Step 2b trimming.
+    For each regime group with ≥ 2 spectra, compute the median blue/red
+    edges and trim outliers using the same tolerance as before.
+    """
+    by_regime: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for rec in parsed:
+        by_regime[rec["_regime"]].append(rec)
+
+    result: list[dict[str, Any]] = []
+
+    for regime_id, group in by_regime.items():
+        if len(group) < 2:
+            # Single spectrum or empty — no trimming, pass through.
+            result.extend(group)
+            continue
+
+        wl_mins = [s["wavelengths"][0] for s in group if s["wavelengths"]]
+        wl_maxes = [s["wavelengths"][-1] for s in group if s["wavelengths"]]
+
+        if not wl_mins or not wl_maxes:
+            result.extend(group)
+            continue
+
+        display_min = statistics.median(wl_mins)
+        display_max = statistics.median(wl_maxes)
+
+        # Warn if trim would affect >50% of spectra in this regime.
+        trim_count_red = sum(1 for wmax in wl_maxes if wmax > display_max * _TRIM_TOLERANCE)
+        if trim_count_red > len(group) / 2:
+            _logger.warning(
+                "Red-side wavelength trim affects >50%% of spectra in regime — data may be bimodal",
+                extra={
+                    "nova_id": nova_id,
+                    "regime": regime_id,
+                    "trim_count": trim_count_red,
+                    "total": len(group),
+                },
+            )
+
+        trim_count_blue = sum(1 for wmin in wl_mins if wmin < display_min / _TRIM_TOLERANCE)
+        if trim_count_blue > len(group) / 2:
+            _logger.warning(
+                "Blue-side wavelength trim affects >50%% of spectra in regime — data may be bimodal",
+                extra={
+                    "nova_id": nova_id,
+                    "regime": regime_id,
+                    "trim_count": trim_count_blue,
+                    "total": len(group),
+                },
+            )
+
+        # Red-side trim.
+        for rec in group:
+            if not rec["wavelengths"]:
+                continue
+            if rec["wavelengths"][-1] > display_max * _TRIM_TOLERANCE:
+                _trim_wavelength_range(rec, display_max)
+
+        # Drop empties after red-side trim.
+        for rec in group:
+            if not rec["wavelengths"]:
+                _logger.warning(
+                    "Spectrum empty after red-side wavelength trim — dropping",
+                    extra={
+                        "nova_id": nova_id,
+                        "regime": regime_id,
+                        "data_product_id": rec["product"]["data_product_id"],
+                    },
+                )
+        group = [rec for rec in group if rec["wavelengths"]]
+
+        # Blue-side trim.
+        for rec in group:
+            if not rec["wavelengths"]:
+                continue
+            if rec["wavelengths"][0] < display_min / _TRIM_TOLERANCE:
+                _trim_wavelength_range_min(rec, display_min)
+
+        # Drop empties after blue-side trim.
+        for rec in group:
+            if not rec["wavelengths"]:
+                _logger.warning(
+                    "Spectrum empty after blue-side wavelength trim — dropping",
+                    extra={
+                        "nova_id": nova_id,
+                        "regime": regime_id,
+                        "data_product_id": rec["product"]["data_product_id"],
+                    },
+                )
+        group = [rec for rec in group if rec["wavelengths"]]
+
+        result.extend(group)
+
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -168,81 +423,11 @@ def generate_spectra_json(
     # Step 2a½ — Detect multi-arm groups and merge.
     parsed = _merge_multi_arm_spectra(parsed, nova_id, s3_client, private_bucket)
 
-    # Step 2b — Compute display wavelength range from median bounds.
-    display_wavelength_min: float | None = None
-    display_wavelength_max: float | None = None
+    # Step 2b — Regime classification and cross-boundary splitting (ADR-035).
+    parsed = _assign_and_split_regimes(parsed)
 
-    if len(parsed) >= 2:
-        wl_mins = [s["wavelengths"][0] for s in parsed]
-        wl_maxes = [s["wavelengths"][-1] for s in parsed]
-        display_wavelength_min = statistics.median(wl_mins)
-        display_wavelength_max = statistics.median(wl_maxes)
-        assert display_wavelength_min is not None  # nosec: narrowing for mypy
-        assert display_wavelength_max is not None  # nosec: narrowing for mypy
-
-        # Warn if trim would affect >50% of spectra (bimodal data).
-        trim_count = sum(1 for wmax in wl_maxes if wmax > display_wavelength_max * _TRIM_TOLERANCE)
-        if trim_count > len(parsed) / 2:
-            _logger.warning(
-                "Wavelength trim affects >50%% of spectra — data may be bimodal",
-                extra={
-                    "nova_id": nova_id,
-                    "trim_count": trim_count,
-                    "total": len(parsed),
-                },
-            )
-
-        # Warn if blue-side trim would affect >50% of spectra (bimodal data).
-        trim_count_min = sum(
-            1 for wmin in wl_mins if wmin < display_wavelength_min / _TRIM_TOLERANCE
-        )
-        if trim_count_min > len(parsed) / 2:
-            _logger.warning(
-                "Blue-side wavelength trim affects >50%% of spectra — data may be bimodal",
-                extra={
-                    "nova_id": nova_id,
-                    "trim_count": trim_count_min,
-                    "total": len(parsed),
-                },
-            )
-
-        # Trim outlier spectra to the display range (red side).
-        for rec in parsed:
-            if not rec["wavelengths"]:
-                continue
-            if rec["wavelengths"][-1] > display_wavelength_max * _TRIM_TOLERANCE:
-                _trim_wavelength_range(rec, display_wavelength_max)
-
-        # Drop records that became empty after red-side trim.
-        for rec in parsed:
-            if not rec["wavelengths"]:
-                _logger.warning(
-                    "Spectrum empty after red-side wavelength trim — dropping",
-                    extra={
-                        "nova_id": nova_id,
-                        "data_product_id": rec["product"]["data_product_id"],
-                    },
-                )
-        parsed = [rec for rec in parsed if rec["wavelengths"]]
-
-        # Trim outlier spectra to the display range (blue side).
-        for rec in parsed:
-            if not rec["wavelengths"]:
-                continue
-            if rec["wavelengths"][0] < display_wavelength_min / _TRIM_TOLERANCE:
-                _trim_wavelength_range_min(rec, display_wavelength_min)
-
-        # Drop records that became empty after blue-side trim.
-        for rec in parsed:
-            if not rec["wavelengths"]:
-                _logger.warning(
-                    "Spectrum empty after blue-side wavelength trim — dropping",
-                    extra={
-                        "nova_id": nova_id,
-                        "data_product_id": rec["product"]["data_product_id"],
-                    },
-                )
-        parsed = [rec for rec in parsed if rec["wavelengths"]]
+    # Step 2b½ — Per-regime median display range computation and trimming (ADR-035).
+    parsed = _trim_per_regime(parsed, nova_id)
 
     # Step 2c — Second pass: LTTB downsampling + normalization.
     spectra: list[dict[str, Any]] = []
@@ -332,11 +517,6 @@ def generate_spectra_json(
         "observations": observations_list,
         "spectra": spectra,
     }
-    if display_wavelength_min is not None:
-        artifact["display_wavelength_min"] = display_wavelength_min
-    if display_wavelength_max is not None:
-        artifact["display_wavelength_max"] = display_wavelength_max
-
     return artifact
 
 
@@ -592,8 +772,10 @@ def _process_spectrum_stage2(
         days_since_outburst = round(epoch_mjd - outburst_mjd, 4)
 
     return {
-        "spectrum_id": data_product_id,
-        "regime": _assign_spectra_regime(min(wavelengths), max(wavelengths)),
+        "spectrum_id": f"{data_product_id}::{rec['_split_suffix']}"
+        if "_split_suffix" in rec
+        else data_product_id,
+        "regime": rec["_regime"],
         "epoch_mjd": epoch_mjd,
         "days_since_outburst": days_since_outburst,
         "instrument": product.get("instrument", "unknown"),

--- a/tests/services/artifact_generator/test_generators_spectra.py
+++ b/tests/services/artifact_generator/test_generators_spectra.py
@@ -383,7 +383,7 @@ class TestDisplayWavelengthFields:
         }
 
     def test_display_fields_present(self) -> None:
-        """Artifact includes display_wavelength_min and display_wavelength_max."""
+        """ADR-035: display_wavelength_min/max removed; artifact has regimes instead."""
         csvs = {
             "dp-1": self._make_csv(400, 900),
             "dp-2": self._make_csv(410, 920),
@@ -415,10 +415,10 @@ class TestDisplayWavelengthFields:
         ctx: dict[str, Any] = {"outburst_mjd": 58000.0, "outburst_mjd_is_estimated": False}
         artifact = generate_spectra_json("nova-test", FakeTable(), FakeS3(), "bucket", ctx)
 
-        assert "display_wavelength_min" in artifact
-        assert "display_wavelength_max" in artifact
-        assert isinstance(artifact["display_wavelength_min"], float)
-        assert isinstance(artifact["display_wavelength_max"], float)
+        # ADR-035: global display bounds removed, per-regime trimming instead.
+        assert "display_wavelength_min" not in artifact
+        assert "display_wavelength_max" not in artifact
+        assert "regimes" in artifact
         assert "total_data_products" in artifact
         assert artifact["total_data_products"] == 3
         assert "observations" in artifact
@@ -435,7 +435,7 @@ class TestDisplayWavelengthFields:
             assert "provider" in obs
 
     def test_display_min_trims_blue_outlier(self) -> None:
-        """End-to-end: blue outlier at 200nm trimmed to near median min (~400)."""
+        """ADR-035: per-regime trimming trims outlier within the optical regime."""
         csvs = {
             "dp-1": self._make_csv(390, 900),
             "dp-2": self._make_csv(400, 900),
@@ -468,14 +468,15 @@ class TestDisplayWavelengthFields:
         ctx: dict[str, Any] = {"outburst_mjd": 58000.0, "outburst_mjd_is_estimated": False}
         artifact = generate_spectra_json("nova-test", FakeTable(), FakeS3(), "bucket", ctx)
 
-        # median min of [390, 400, 410, 200] = (390+400)/2 = 395
-        display_min = artifact["display_wavelength_min"]
-
-        # Find the outlier spectrum (originally started at 200nm)
-        outlier = [s for s in artifact["spectra"] if s["spectrum_id"] == "dp-outlier"]
-        assert len(outlier) == 1
-        # Its wavelength_min should now be at or near the display_min, not 200
-        assert outlier[0]["wavelength_min"] >= display_min - 1.0
+        # ADR-035: dp-outlier (200–900nm) crosses the 320nm boundary and is
+        # split into uv (200–320) and optical (320–900) fragments.
+        # The optical fragment's spectrum_id has a ::optical suffix.
+        outlier_optical = [
+            s for s in artifact["spectra"] if s["spectrum_id"] == "dp-outlier::optical"
+        ]
+        assert len(outlier_optical) == 1
+        # The optical fragment starts at ~320nm, not 200nm.
+        assert outlier_optical[0]["wavelength_min"] >= 319.0
 
     def test_no_display_fields_for_single_spectrum(self) -> None:
         """Single spectrum: no display bounds in artifact."""
@@ -549,8 +550,8 @@ class TestDisplayWavelengthFields:
         assert obs_ids == {"dp-a", "dp-b", "dp-c"}
 
     def test_red_side_trim_empty_wavelengths_no_crash(self) -> None:
-        """Spectrum entirely above display max is dropped, not IndexError."""
-        # 3 normal spectra (400–900) + 1 entirely above the median max (~900).
+        """ADR-035: dp-bad is in a different regime (nir), so it survives per-regime trimming."""
+        # 3 normal spectra (400–900, optical) + 1 in NIR (5000–6000).
         csvs = {
             "dp-1": self._make_csv(400, 900),
             "dp-2": self._make_csv(400, 910),
@@ -583,13 +584,15 @@ class TestDisplayWavelengthFields:
         ctx: dict[str, Any] = {"outburst_mjd": 58000.0, "outburst_mjd_is_estimated": False}
         artifact = generate_spectra_json("nova-test", FakeTable(), FakeS3(), "bucket", ctx)
 
-        # dp-bad should be excluded — its entire range is above display max.
+        # ADR-035: dp-bad is alone in nir regime — no per-regime trimming applies.
+        # It survives and appears in the output.
         spectrum_ids = [s["spectrum_id"] for s in artifact["spectra"]]
-        assert "dp-bad" not in spectrum_ids
+        assert "dp-bad" in spectrum_ids
+        assert len(artifact["spectra"]) == 4
 
     def test_blue_side_trim_empty_wavelengths_no_crash(self) -> None:
-        """Spectrum entirely below display min is dropped, not IndexError."""
-        # 3 normal spectra (400–900) + 1 entirely below the median min (~400).
+        """ADR-035: dp-bad is in uv regime, optical spectra are separate — no cross-regime trim."""
+        # 3 normal spectra (400–900, optical) + 1 in UV (100–200).
         csvs = {
             "dp-1": self._make_csv(400, 900),
             "dp-2": self._make_csv(410, 900),
@@ -622,12 +625,14 @@ class TestDisplayWavelengthFields:
         ctx: dict[str, Any] = {"outburst_mjd": 58000.0, "outburst_mjd_is_estimated": False}
         artifact = generate_spectra_json("nova-test", FakeTable(), FakeS3(), "bucket", ctx)
 
-        # dp-bad should be excluded — its entire range is below display min.
+        # ADR-035: dp-bad is alone in uv regime — no per-regime trimming applies.
+        # It survives and appears in the output.
         spectrum_ids = [s["spectrum_id"] for s in artifact["spectra"]]
-        assert "dp-bad" not in spectrum_ids
+        assert "dp-bad" in spectrum_ids
+        assert len(artifact["spectra"]) == 4
 
     def test_single_bad_spectrum_does_not_block_others(self) -> None:
-        """One fully-trimmed spectrum doesn't prevent other spectra from appearing."""
+        """ADR-035: dp-bad in nir regime survives; good optical spectra unaffected."""
         csvs = {
             "dp-good-1": self._make_csv(400, 900),
             "dp-good-2": self._make_csv(410, 920),
@@ -658,11 +663,12 @@ class TestDisplayWavelengthFields:
         ctx: dict[str, Any] = {"outburst_mjd": 58000.0, "outburst_mjd_is_estimated": False}
         artifact = generate_spectra_json("nova-test", FakeTable(), FakeS3(), "bucket", ctx)
 
+        # ADR-035: dp-bad is alone in nir regime — survives per-regime trimming.
         spectrum_ids = {s["spectrum_id"] for s in artifact["spectra"]}
         assert "dp-good-1" in spectrum_ids
         assert "dp-good-2" in spectrum_ids
-        assert "dp-bad" not in spectrum_ids
-        assert len(artifact["spectra"]) == 2
+        assert "dp-bad" in spectrum_ids
+        assert len(artifact["spectra"]) == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/artifact_generator/test_spectra_regime.py
+++ b/tests/services/artifact_generator/test_spectra_regime.py
@@ -12,9 +12,9 @@ from generators.spectra import (
 # ---------------------------------------------------------------------------
 
 
-def test_assign_spectra_regime_xuv() -> None:
-    # midpoint = (100 + 200) / 2 = 150 → < 320 → xuv
-    assert _assign_spectra_regime(100.0, 200.0) == "xuv"
+def test_assign_spectra_regime_uv() -> None:
+    # midpoint = (115 + 170) / 2 = 142.5 → uv regime
+    assert _assign_spectra_regime(115.0, 170.0) == "uv"
 
 
 def test_assign_spectra_regime_optical() -> None:
@@ -69,12 +69,12 @@ def test_regime_records_single_regime() -> None:
 
 
 def test_regime_records_multiple_regimes() -> None:
-    """Mixed xuv + optical produces two sorted entries."""
+    """Mixed uv + optical produces two sorted entries."""
     from generators.spectra import _SPECTRA_REGIME_SORT_ORDER
 
     spectra = [
         {"regime": "optical", "epoch_mjd": 59000.0},
-        {"regime": "xuv", "epoch_mjd": 59001.0},
+        {"regime": "uv", "epoch_mjd": 59001.0},
     ]
 
     present: dict[str, dict] = {}
@@ -89,7 +89,7 @@ def test_regime_records_multiple_regimes() -> None:
     )
 
     assert len(regime_records) == 2
-    assert regime_records[0]["id"] == "xuv"
+    assert regime_records[0]["id"] == "uv"
     assert regime_records[1]["id"] == "optical"
 
 
@@ -99,9 +99,9 @@ def test_spectra_sorted_by_regime_then_epoch() -> None:
 
     spectra = [
         {"regime": "optical", "epoch_mjd": 59002.0},
-        {"regime": "xuv", "epoch_mjd": 59001.0},
+        {"regime": "uv", "epoch_mjd": 59001.0},
         {"regime": "optical", "epoch_mjd": 59000.0},
-        {"regime": "xuv", "epoch_mjd": 59003.0},
+        {"regime": "uv", "epoch_mjd": 59003.0},
     ]
 
     spectra.sort(
@@ -111,7 +111,7 @@ def test_spectra_sorted_by_regime_then_epoch() -> None:
         )
     )
 
-    assert spectra[0] == {"regime": "xuv", "epoch_mjd": 59001.0}
-    assert spectra[1] == {"regime": "xuv", "epoch_mjd": 59003.0}
+    assert spectra[0] == {"regime": "uv", "epoch_mjd": 59001.0}
+    assert spectra[1] == {"regime": "uv", "epoch_mjd": 59003.0}
     assert spectra[2] == {"regime": "optical", "epoch_mjd": 59000.0}
     assert spectra[3] == {"regime": "optical", "epoch_mjd": 59002.0}

--- a/tests/services/artifact_generator/test_spectra_regimes.py
+++ b/tests/services/artifact_generator/test_spectra_regimes.py
@@ -1,0 +1,637 @@
+"""Unit and integration tests for ADR-035 spectra regime features.
+
+Groups:
+  1 — Regime assignment (_assign_spectra_regime)
+  2 — Cross-boundary splitting (_split_cross_boundary_spectrum)
+  3 — Assign-and-split orchestration (_assign_and_split_regimes)
+  4 — Per-regime trimming (_trim_per_regime)
+  5 — End-to-end: mixed UV + optical (the original bug, now a regression test)
+  6 — End-to-end: wide-coverage splitting through generate_spectra_json
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from generators.spectra import (
+    _assign_and_split_regimes,
+    _assign_spectra_regime,
+    _split_cross_boundary_spectrum,
+    _trim_per_regime,
+    generate_spectra_json,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_stage1_rec(
+    wl_min: float,
+    wl_max: float,
+    *,
+    dp_id: str = "dp-1",
+    n_points: int = 50,
+    flux_val: float = 1.0,
+    instrument: str = "TestInstrument",
+    nova_id: str = "nova-test",
+) -> dict[str, Any]:
+    """Build a minimal stage-1 parsed record for unit tests."""
+    step = (wl_max - wl_min) / max(n_points - 1, 1)
+    wavelengths = [wl_min + i * step for i in range(n_points)]
+    fluxes = [flux_val] * n_points
+    return {
+        "wavelengths": wavelengths,
+        "fluxes": fluxes,
+        "product": {
+            "data_product_id": dp_id,
+            "instrument": instrument,
+            "observation_date_mjd": Decimal("59000"),
+            "telescope": "TestTelescope",
+            "provider": "TestProvider",
+            "flux_unit": "erg/s/cm2/A",
+            "PK": nova_id,
+            "SK": f"PRODUCT#SPECTRA#{dp_id}",
+            "validation_status": "VALID",
+        },
+        "nova_id": nova_id,
+    }
+
+
+def _make_csv(wl_min: float, wl_max: float, n: int = 50) -> str:
+    """Generate a web-ready CSV string."""
+    step = (wl_max - wl_min) / max(n - 1, 1)
+    rows = ["wavelength_nm,flux"]
+    for i in range(n):
+        rows.append(f"{wl_min + i * step:.4f},1.0")
+    return "\n".join(rows)
+
+
+def _make_product(
+    dp_id: str,
+    *,
+    mjd: str = "59000",
+    instrument: str = "TestInstrument",
+    telescope: str = "TestTelescope",
+    provider: str = "TestProvider",
+) -> dict[str, Any]:
+    """Build a DataProduct dict for end-to-end tests."""
+    return {
+        "data_product_id": dp_id,
+        "observation_date_mjd": Decimal(mjd),
+        "instrument": instrument,
+        "telescope": telescope,
+        "provider": provider,
+        "flux_unit": "erg/s/cm2/A",
+        "PK": "nova-test",
+        "SK": f"PRODUCT#SPECTRA#{dp_id}",
+        "validation_status": "VALID",
+    }
+
+
+class _FakeBody:
+    def __init__(self, content: str) -> None:
+        self._content = content
+
+    def read(self) -> bytes:
+        return self._content.encode()
+
+
+class _FakeS3ByDpId:
+    """S3 mock that returns pre-loaded CSV bodies keyed by data_product_id."""
+
+    def __init__(self, csvs: dict[str, str]) -> None:
+        self._csvs = csvs
+
+    def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:  # noqa: N803
+        dp_id = Key.split("/")[-2]
+        return {"Body": _FakeBody(self._csvs[dp_id])}
+
+
+class _FakeTable:
+    """DynamoDB Table mock returning a fixed list of items."""
+
+    def __init__(self, items: list[dict[str, Any]]) -> None:
+        self._items = items
+
+    def query(self, **kwargs: Any) -> dict[str, Any]:
+        return {"Items": self._items}
+
+
+def _run_generator(
+    products: list[dict[str, Any]],
+    csvs: dict[str, str],
+    *,
+    outburst_mjd: float = 58000.0,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Run generate_spectra_json and return (artifact, nova_context)."""
+    ctx: dict[str, Any] = {
+        "outburst_mjd": outburst_mjd,
+        "outburst_mjd_is_estimated": False,
+    }
+    artifact = generate_spectra_json(
+        "nova-test",
+        _FakeTable(products),
+        _FakeS3ByDpId(csvs),
+        "test-bucket",
+        ctx,
+    )
+    return artifact, ctx
+
+
+# ---------------------------------------------------------------------------
+# Group 1 — Regime assignment (_assign_spectra_regime)
+# ---------------------------------------------------------------------------
+
+
+class TestAssignSpectraRegime:
+    """Midpoint-based regime assignment (ADR-034 Decision 2, ADR-035 Decision 1)."""
+
+    def test_xray_regime(self) -> None:
+        """Spectrum entirely below Lyman limit → xray."""
+        assert _assign_spectra_regime(0.5, 15.0) == "xray"
+
+    def test_uv_regime(self) -> None:
+        """Spectrum in UV window → uv."""
+        assert _assign_spectra_regime(115.0, 170.0) == "uv"
+
+    def test_optical_regime(self) -> None:
+        """Typical ground-based optical spectrum → optical."""
+        assert _assign_spectra_regime(400.0, 900.0) == "optical"
+
+    def test_nir_regime(self) -> None:
+        """J/H/K band spectrum → nir."""
+        assert _assign_spectra_regime(1000.0, 2500.0) == "nir"
+
+    def test_mir_regime(self) -> None:
+        """Mid-IR spectrum → mir."""
+        assert _assign_spectra_regime(5000.0, 15000.0) == "mir"
+
+    def test_uv_optical_boundary_midpoint_optical(self) -> None:
+        """STIS G430L (290–570 nm): midpoint 430 nm → optical, not uv."""
+        assert _assign_spectra_regime(290.0, 570.0) == "optical"
+
+    def test_lyman_limit_boundary(self) -> None:
+        """Midpoint exactly at 91 nm → uv (not xray, since 91 is the lower bound of uv)."""
+        # Spectrum from 82–100 nm: midpoint = 91 nm → uv
+        assert _assign_spectra_regime(82.0, 100.0) == "uv"
+
+    def test_optical_nir_boundary_midpoint(self) -> None:
+        """Spectrum straddling 1000 nm but midpoint above → nir."""
+        assert _assign_spectra_regime(800.0, 1400.0) == "nir"
+
+
+# ---------------------------------------------------------------------------
+# Group 2 — Cross-boundary splitting (_split_cross_boundary_spectrum)
+# ---------------------------------------------------------------------------
+
+
+class TestSplitCrossBoundarySpectrum:
+    """ADR-035 Decision 2: splitting wide-coverage spectra at regime boundaries."""
+
+    def test_no_split_entirely_within_optical(self) -> None:
+        """Spectrum fully within optical range → no split, one record returned."""
+        rec = _make_stage1_rec(400.0, 900.0)
+        result = _split_cross_boundary_spectrum(rec)
+        assert len(result) == 1
+        assert "_split_suffix" not in result[0]
+
+    def test_xshooter_splits_at_1000nm(self) -> None:
+        """X-Shooter 350–2500 nm: split at 1000 nm into optical + NIR."""
+        rec = _make_stage1_rec(350.0, 2500.0, n_points=200)
+        result = _split_cross_boundary_spectrum(rec)
+
+        assert len(result) == 2
+
+        optical_frag = [f for f in result if f["_regime"] == "optical"]
+        nir_frag = [f for f in result if f["_regime"] == "nir"]
+        assert len(optical_frag) == 1
+        assert len(nir_frag) == 1
+
+        # Optical fragment: 350 to <1000
+        assert optical_frag[0]["wavelengths"][0] == pytest.approx(350.0, abs=1.0)
+        assert optical_frag[0]["wavelengths"][-1] < 1000.0
+
+        # NIR fragment: >=1000 to 2500
+        assert nir_frag[0]["wavelengths"][0] >= 1000.0
+        assert nir_frag[0]["wavelengths"][-1] == pytest.approx(2500.0, abs=1.0)
+
+    def test_stis_g430l_no_split_below_threshold(self) -> None:
+        """STIS G430L (290–570 nm): 30 nm UV portion < 45 nm min → no split."""
+        rec = _make_stage1_rec(290.0, 570.0, n_points=100)
+        result = _split_cross_boundary_spectrum(rec)
+        assert len(result) == 1
+
+    def test_boundary_point_goes_to_redder_regime(self) -> None:
+        """A data point at exactly 1000.0 nm goes to NIR (the redder regime)."""
+        # Create spectrum with a point exactly at the boundary.
+        wavelengths = [float(w) for w in range(350, 2501, 10)]
+        fluxes = [1.0] * len(wavelengths)
+        rec: dict[str, Any] = {
+            "wavelengths": wavelengths,
+            "fluxes": fluxes,
+            "product": {
+                "data_product_id": "dp-boundary",
+                "instrument": "XSHOOTER",
+                "observation_date_mjd": Decimal("59000"),
+                "telescope": "VLT",
+                "provider": "ESO",
+                "flux_unit": "erg/s/cm2/A",
+                "PK": "nova-test",
+                "SK": "PRODUCT#SPECTRA#dp-boundary",
+                "validation_status": "VALID",
+            },
+            "nova_id": "nova-test",
+        }
+
+        result = _split_cross_boundary_spectrum(rec)
+        assert len(result) == 2
+
+        optical_frag = [f for f in result if f["_regime"] == "optical"][0]
+        nir_frag = [f for f in result if f["_regime"] == "nir"][0]
+
+        # 1000.0 must NOT be in the optical fragment
+        assert 1000.0 not in optical_frag["wavelengths"]
+        # 1000.0 must BE in the NIR fragment
+        assert 1000.0 in nir_frag["wavelengths"]
+
+    def test_fractional_threshold_prevents_split(self) -> None:
+        """Minor side is ≥45 nm absolute but <15% fractional → no split."""
+        # Spectrum 280–2500 nm. UV side = 320 - 280 = 40 nm... wait, that's <45.
+        # Let's use: 250–2500 nm. UV side = 320 - 250 = 70 nm. Total = 2250.
+        # Fraction = 70/2250 = 3.1%. Below 15% → no split at 320,
+        # even though 70 nm > 45 nm.
+        # But it WILL split at 1000 nm: minor = 250 nm optical / 1500 nm NIR.
+        # Actually minor side for 1000 boundary: left = 1000-250=750, right=2500-1000=1500
+        # minor = 750, fraction = 750/2250 = 33% → split at 1000.
+        # So this tests that we DON'T split at 320 but DO split at 1000.
+        rec = _make_stage1_rec(250.0, 2500.0, n_points=200)
+        result = _split_cross_boundary_spectrum(rec)
+
+        regimes = [f["_regime"] for f in result]
+        # Should NOT have a UV fragment (70 nm > 45 but 3.1% < 15%)
+        assert "uv" not in regimes
+        # Should have optical and NIR from the 1000 nm split
+        assert "optical" in regimes
+        assert "nir" in regimes
+
+    def test_split_preserves_product_metadata(self) -> None:
+        """All fragments inherit the parent's product dict."""
+        rec = _make_stage1_rec(350.0, 2500.0, dp_id="dp-meta", n_points=200)
+        result = _split_cross_boundary_spectrum(rec)
+
+        for frag in result:
+            assert frag["product"]["data_product_id"] == "dp-meta"
+            assert frag["product"]["instrument"] == "TestInstrument"
+            assert frag["nova_id"] == "nova-test"
+
+    def test_empty_wavelengths_returns_single_record(self) -> None:
+        """Edge case: empty wavelengths → returns original record."""
+        rec = _make_stage1_rec(400.0, 900.0)
+        rec["wavelengths"] = []
+        rec["fluxes"] = []
+        result = _split_cross_boundary_spectrum(rec)
+        assert len(result) == 1
+
+    def test_uv_optical_split_eligible(self) -> None:
+        """Spectrum from 200–600 nm: UV portion = 120 nm (30%) → split at 320."""
+        rec = _make_stage1_rec(200.0, 600.0, n_points=200)
+        result = _split_cross_boundary_spectrum(rec)
+
+        assert len(result) == 2
+        regimes = {f["_regime"] for f in result}
+        assert regimes == {"uv", "optical"}
+
+
+# ---------------------------------------------------------------------------
+# Group 3 — Assign-and-split orchestration (_assign_and_split_regimes)
+# ---------------------------------------------------------------------------
+
+
+class TestAssignAndSplitRegimes:
+    """ADR-035 Decision 4 steps 5–6 orchestration."""
+
+    def test_all_optical_no_splits(self) -> None:
+        """Homogeneous optical population → all assigned optical, no splits."""
+        recs = [
+            _make_stage1_rec(400.0, 900.0, dp_id="dp-1"),
+            _make_stage1_rec(380.0, 850.0, dp_id="dp-2"),
+            _make_stage1_rec(420.0, 920.0, dp_id="dp-3"),
+        ]
+        result = _assign_and_split_regimes(recs)
+
+        assert len(result) == 3
+        for rec in result:
+            assert rec["_regime"] == "optical"
+            assert "_split_suffix" not in rec
+
+    def test_mixed_uv_optical_classified_separately(self) -> None:
+        """UV and optical spectra get different regime labels."""
+        recs = [
+            _make_stage1_rec(115.0, 170.0, dp_id="dp-uv"),
+            _make_stage1_rec(400.0, 900.0, dp_id="dp-opt"),
+        ]
+        result = _assign_and_split_regimes(recs)
+
+        assert len(result) == 2
+        regimes = {r["product"]["data_product_id"]: r["_regime"] for r in result}
+        assert regimes["dp-uv"] == "uv"
+        assert regimes["dp-opt"] == "optical"
+
+    def test_wide_spectrum_split_increases_count(self) -> None:
+        """One wide spectrum + one narrow → split produces 3 total records."""
+        recs = [
+            _make_stage1_rec(350.0, 2500.0, dp_id="dp-wide", n_points=200),
+            _make_stage1_rec(400.0, 900.0, dp_id="dp-narrow"),
+        ]
+        result = _assign_and_split_regimes(recs)
+
+        # dp-wide splits into optical + NIR = 2; dp-narrow stays = 1; total = 3
+        assert len(result) == 3
+        dp_ids = [r["product"]["data_product_id"] for r in result]
+        assert dp_ids.count("dp-wide") == 2
+        assert dp_ids.count("dp-narrow") == 1
+
+    def test_empty_wavelengths_skipped(self) -> None:
+        """Records with empty wavelengths are dropped."""
+        recs = [
+            _make_stage1_rec(400.0, 900.0, dp_id="dp-good"),
+            _make_stage1_rec(400.0, 900.0, dp_id="dp-empty"),
+        ]
+        recs[1]["wavelengths"] = []
+        recs[1]["fluxes"] = []
+
+        result = _assign_and_split_regimes(recs)
+        assert len(result) == 1
+        assert result[0]["product"]["data_product_id"] == "dp-good"
+
+
+# ---------------------------------------------------------------------------
+# Group 4 — Per-regime trimming (_trim_per_regime)
+# ---------------------------------------------------------------------------
+
+
+class TestTrimPerRegime:
+    """ADR-035 Decision 3: per-regime median display range computation."""
+
+    def test_uv_not_trimmed_by_optical_median(self) -> None:
+        """Core regression test: UV spectra survive when mixed with optical."""
+        uv_recs = [
+            _make_stage1_rec(115.0, 170.0, dp_id="dp-uv-1"),
+            _make_stage1_rec(115.0, 310.0, dp_id="dp-uv-2"),
+            _make_stage1_rec(160.0, 320.0, dp_id="dp-uv-3"),
+        ]
+        opt_recs = [
+            _make_stage1_rec(350.0, 900.0, dp_id="dp-opt-1"),
+            _make_stage1_rec(360.0, 910.0, dp_id="dp-opt-2"),
+            _make_stage1_rec(340.0, 890.0, dp_id="dp-opt-3"),
+        ]
+
+        for rec in uv_recs:
+            rec["_regime"] = "uv"
+        for rec in opt_recs:
+            rec["_regime"] = "optical"
+
+        all_recs = uv_recs + opt_recs
+        result = _trim_per_regime(all_recs, "nova-test")
+
+        # All 6 spectra should survive — UV spectra are NOT trimmed by
+        # the optical median.
+        assert len(result) == 6
+
+        # UV spectra should retain their full wavelength coverage.
+        uv_results = [r for r in result if r["_regime"] == "uv"]
+        for rec in uv_results:
+            assert rec["wavelengths"][0] < 170.0, "UV spectrum blue edge was incorrectly trimmed"
+
+    def test_single_spectrum_regime_no_trim(self) -> None:
+        """Regime with only one spectrum → no trimming applied."""
+        rec = _make_stage1_rec(115.0, 170.0, dp_id="dp-solo-uv")
+        rec["_regime"] = "uv"
+
+        result = _trim_per_regime([rec], "nova-test")
+        assert len(result) == 1
+        # Wavelengths unchanged
+        assert result[0]["wavelengths"][0] == pytest.approx(115.0, abs=0.1)
+        assert result[0]["wavelengths"][-1] == pytest.approx(170.0, abs=0.1)
+
+    def test_intra_regime_outlier_still_trimmed(self) -> None:
+        """An outlier WITHIN a regime is still trimmed by the regime's median."""
+        recs = [
+            _make_stage1_rec(400.0, 900.0, dp_id="dp-1"),
+            _make_stage1_rec(410.0, 910.0, dp_id="dp-2"),
+            _make_stage1_rec(390.0, 890.0, dp_id="dp-3"),
+            _make_stage1_rec(200.0, 900.0, dp_id="dp-blue-outlier", n_points=200),
+        ]
+        for rec in recs:
+            rec["_regime"] = "optical"
+
+        result = _trim_per_regime(recs, "nova-test")
+
+        # The blue outlier should have its blue side trimmed to near the
+        # median min (~400 nm), not kept at 200 nm.
+        outlier = [r for r in result if r["product"]["data_product_id"] == "dp-blue-outlier"]
+        assert len(outlier) == 1
+        assert outlier[0]["wavelengths"][0] >= 350.0
+
+    def test_independent_regime_medians(self) -> None:
+        """UV and optical groups compute independent medians."""
+        uv_recs = [
+            _make_stage1_rec(115.0, 170.0, dp_id="dp-uv-1"),
+            _make_stage1_rec(120.0, 175.0, dp_id="dp-uv-2"),
+            _make_stage1_rec(130.0, 310.0, dp_id="dp-uv-outlier", n_points=100),
+        ]
+        opt_recs = [
+            _make_stage1_rec(400.0, 900.0, dp_id="dp-opt-1"),
+            _make_stage1_rec(410.0, 910.0, dp_id="dp-opt-2"),
+        ]
+
+        for rec in uv_recs:
+            rec["_regime"] = "uv"
+        for rec in opt_recs:
+            rec["_regime"] = "optical"
+
+        result = _trim_per_regime(uv_recs + opt_recs, "nova-test")
+
+        # UV outlier (130–310) should be trimmed to the UV median red edge
+        # (~175), not the optical median red edge (~905).
+        uv_outlier = [r for r in result if r["product"]["data_product_id"] == "dp-uv-outlier"]
+        assert len(uv_outlier) == 1
+        assert uv_outlier[0]["wavelengths"][-1] < 250.0
+
+
+# ---------------------------------------------------------------------------
+# Group 5 — End-to-end: mixed UV + optical (regression test for the bug)
+# ---------------------------------------------------------------------------
+
+
+class TestMixedUvOpticalEndToEnd:
+    """End-to-end tests through generate_spectra_json with mixed regimes."""
+
+    def test_uv_spectra_survive_with_optical_majority(self) -> None:
+        """THE REGRESSION TEST: UV spectra are not destroyed by optical median.
+
+        Before ADR-035, UV spectra covering 115–310 nm were trimmed to
+        just 305–307 nm by the global median. After ADR-035, per-regime
+        trimming preserves the full UV wavelength range.
+        """
+        csvs = {
+            "dp-uv-1": _make_csv(115.0, 170.0),
+            "dp-uv-2": _make_csv(160.0, 310.0),
+            "dp-opt-1": _make_csv(350.0, 900.0),
+            "dp-opt-2": _make_csv(360.0, 910.0),
+            "dp-opt-3": _make_csv(340.0, 890.0),
+            "dp-opt-4": _make_csv(370.0, 920.0),
+            "dp-opt-5": _make_csv(380.0, 900.0),
+        }
+        products = [
+            _make_product(
+                "dp-uv-1", mjd="59000", instrument="STIS", telescope="HST", provider="MAST"
+            ),
+            _make_product(
+                "dp-uv-2", mjd="59001", instrument="STIS", telescope="HST", provider="MAST"
+            ),
+            _make_product("dp-opt-1", mjd="59002"),
+            _make_product("dp-opt-2", mjd="59003"),
+            _make_product("dp-opt-3", mjd="59004"),
+            _make_product("dp-opt-4", mjd="59005"),
+            _make_product("dp-opt-5", mjd="59006"),
+        ]
+
+        artifact, _ctx = _run_generator(products, csvs)
+
+        # Both regimes should be present.
+        regime_ids = {r["id"] for r in artifact["regimes"]}
+        assert "uv" in regime_ids
+        assert "optical" in regime_ids
+
+        # UV spectra should exist and have meaningful wavelength coverage.
+        uv_spectra = [s for s in artifact["spectra"] if s["regime"] == "uv"]
+        assert len(uv_spectra) >= 1
+
+        for sp in uv_spectra:
+            wl_range = sp["wavelength_max"] - sp["wavelength_min"]
+            assert wl_range > 10.0, (
+                f"UV spectrum {sp['spectrum_id']} has only {wl_range:.1f} nm "
+                f"coverage — likely trimmed by optical median"
+            )
+
+        # Optical spectra should also be present and unaffected.
+        opt_spectra = [s for s in artifact["spectra"] if s["regime"] == "optical"]
+        assert len(opt_spectra) >= 1
+
+    def test_single_regime_no_tab_bar_data(self) -> None:
+        """All-optical nova → single regime entry, no UV/NIR."""
+        csvs = {
+            "dp-1": _make_csv(400.0, 900.0),
+            "dp-2": _make_csv(410.0, 920.0),
+        }
+        products = [
+            _make_product("dp-1", mjd="59000"),
+            _make_product("dp-2", mjd="59001"),
+        ]
+
+        artifact, _ctx = _run_generator(products, csvs)
+
+        assert len(artifact["regimes"]) == 1
+        assert artifact["regimes"][0]["id"] == "optical"
+
+    def test_schema_version_is_1_4(self) -> None:
+        """Artifact carries schema version 1.4 per ADR-035."""
+        csvs = {"dp-1": _make_csv(400.0, 900.0)}
+        products = [_make_product("dp-1")]
+
+        artifact, _ctx = _run_generator(products, csvs)
+        assert artifact["schema_version"] == "1.4"
+
+
+# ---------------------------------------------------------------------------
+# Group 6 — End-to-end: wide-coverage splitting
+# ---------------------------------------------------------------------------
+
+
+class TestWideCoverageSplittingEndToEnd:
+    """End-to-end tests for cross-boundary spectrum splitting."""
+
+    def test_xshooter_split_produces_two_regimes(self) -> None:
+        """X-Shooter-like spectrum (350–2500 nm) splits into optical + NIR."""
+        csvs = {
+            "dp-xsh": _make_csv(350.0, 2500.0, n=200),
+            "dp-opt": _make_csv(400.0, 900.0),
+        }
+        products = [
+            _make_product("dp-xsh", mjd="59000", instrument="XSHOOTER"),
+            _make_product("dp-opt", mjd="59001"),
+        ]
+
+        artifact, _ctx = _run_generator(products, csvs)
+
+        regime_ids = {r["id"] for r in artifact["regimes"]}
+        assert "optical" in regime_ids
+        assert "nir" in regime_ids
+
+        # dp-xsh should appear as two spectra with :: suffixes.
+        xsh_spectra = [s for s in artifact["spectra"] if s["spectrum_id"].startswith("dp-xsh")]
+        assert len(xsh_spectra) == 2
+
+        xsh_ids = {s["spectrum_id"] for s in xsh_spectra}
+        assert "dp-xsh::optical" in xsh_ids
+        assert "dp-xsh::nir" in xsh_ids
+
+    def test_split_spectrum_id_format(self) -> None:
+        """Split fragments use {dp_id}::{regime} as spectrum_id."""
+        csvs = {"dp-wide": _make_csv(350.0, 2500.0, n=200)}
+        products = [_make_product("dp-wide", mjd="59000")]
+
+        artifact, _ctx = _run_generator(products, csvs)
+
+        for sp in artifact["spectra"]:
+            assert "::" in sp["spectrum_id"]
+            parts = sp["spectrum_id"].split("::")
+            assert parts[0] == "dp-wide"
+            assert parts[1] in ("optical", "nir")
+
+    def test_non_split_spectrum_no_suffix(self) -> None:
+        """Normal optical spectrum has plain data_product_id as spectrum_id."""
+        csvs = {"dp-plain": _make_csv(400.0, 900.0)}
+        products = [_make_product("dp-plain")]
+
+        artifact, _ctx = _run_generator(products, csvs)
+
+        assert len(artifact["spectra"]) == 1
+        assert artifact["spectra"][0]["spectrum_id"] == "dp-plain"
+        assert "::" not in artifact["spectra"][0]["spectrum_id"]
+
+    def test_stis_g430l_not_split(self) -> None:
+        """STIS G430L (290–570 nm): minor UV side too small → no split."""
+        csvs = {"dp-g430l": _make_csv(290.0, 570.0, n=100)}
+        products = [_make_product("dp-g430l", mjd="59000", instrument="STIS")]
+
+        artifact, _ctx = _run_generator(products, csvs)
+
+        # Should be a single optical spectrum, not split.
+        assert len(artifact["spectra"]) == 1
+        assert artifact["spectra"][0]["regime"] == "optical"
+        assert "::" not in artifact["spectra"][0]["spectrum_id"]
+
+    def test_observations_count_unchanged_by_split(self) -> None:
+        """Splitting doesn't inflate the observations list or spectra_count."""
+        csvs = {
+            "dp-xsh": _make_csv(350.0, 2500.0, n=200),
+            "dp-opt": _make_csv(400.0, 900.0),
+        }
+        products = [
+            _make_product("dp-xsh", mjd="59000"),
+            _make_product("dp-opt", mjd="59001"),
+        ]
+
+        artifact, ctx = _run_generator(products, csvs)
+
+        # spectra_count reflects raw DataProducts, not display spectra.
+        assert ctx["spectra_count"] == 2
+        # observations list has one entry per raw DataProduct.
+        assert len(artifact["observations"]) == 2
+        # But display spectra may be >2 due to splitting.
+        assert len(artifact["spectra"]) >= 2

--- a/tests/services/test_spectra_merge.py
+++ b/tests/services/test_spectra_merge.py
@@ -519,24 +519,34 @@ class TestEndToEndMerge:
         artifact = generate_spectra_json("nova-e2e", table, s3, "bucket", ctx)
 
         spectra = artifact["spectra"]
-        # Should be 1 merged spectrum, not 3 separate ones.
-        assert len(spectra) == 1
+        # ADR-035: merged 300–2480nm spectrum is split at 1000nm boundary
+        # into optical (300–1000) and nir (1000–2480) fragments.
+        assert len(spectra) == 2
 
-        spec = spectra[0]
-        # Wavelength range spans all 3 arms.
-        assert spec["wavelength_min"] < 310
-        assert spec["wavelength_max"] > 2400
+        # Sort by wavelength_min to get optical first, nir second.
+        spectra.sort(key=lambda s: s["wavelength_min"])
+        optical_spec = spectra[0]
+        nir_spec = spectra[1]
 
-        # Composite ID — not any of the input IDs.
-        assert spec["spectrum_id"] != "dp-uvb"
-        assert spec["spectrum_id"] != "dp-vis"
-        assert spec["spectrum_id"] != "dp-nir"
+        assert optical_spec["regime"] == "optical"
+        assert nir_spec["regime"] == "nir"
 
-        # Point budget respected.
-        assert len(spec["wavelengths"]) <= LTTB_THRESHOLD + 10  # margin for rounding
+        assert optical_spec["wavelength_min"] < 310
+        assert nir_spec["wavelength_max"] > 2400
+
+        # Composite IDs — not any of the input IDs (split adds ::regime suffix).
+        for spec in spectra:
+            assert spec["spectrum_id"] != "dp-uvb"
+            assert spec["spectrum_id"] != "dp-vis"
+            assert spec["spectrum_id"] != "dp-nir"
+
+        # Point budget respected per fragment.
+        for spec in spectra:
+            assert len(spec["wavelengths"]) <= LTTB_THRESHOLD + 10  # margin for rounding
 
         # No NaN or None values in the output arrays.
-        assert all(isinstance(f, float) for f in spec["flux_normalized"])
-        assert all(isinstance(w, float) for w in spec["wavelengths"])
-        assert not any(math.isnan(f) for f in spec["flux_normalized"])
-        assert len(spec["flux_normalized"]) == len(spec["wavelengths"])
+        for spec in spectra:
+            assert all(isinstance(f, float) for f in spec["flux_normalized"])
+            assert all(isinstance(w, float) for w in spec["wavelengths"])
+            assert not any(math.isnan(f) for f in spec["flux_normalized"])
+            assert len(spec["flux_normalized"]) == len(spec["wavelengths"])


### PR DESCRIPTION
## Summary

- Fixed a bug where UV spectra were truncated to a ~2 nm sliver by the global median wavelength display range computation
- Split ADR-034's combined `xuv` regime into separate `xray` (λ_mid < 91 nm, Lyman limit) and `uv` (91 ≤ λ_mid < 320 nm) regimes, bringing the total to five: xray, uv, optical, nir, mir
- Added cross-boundary spectrum splitting for wide-coverage instruments (e.g., X-Shooter 350–2500 nm splits at 1000 nm into optical + NIR fragments) with 15% fractional / 45 nm absolute minor-side thresholds
- Moved regime classification upstream of median trimming in the spectra generator, then restructured trimming to operate independently per regime group
- Bumped `spectra.json` schema from 1.3 to 1.4
- Updated frontend `REGIME_ORDER` and mock fixture data to match new regime IDs
- Added ADR-035 documenting all decisions; added amendment banner to ADR-034

## Why

UV spectra from HST/STIS (~115–310 nm) were being mixed into the same median pool as optical spectra (~300–900 nm). The optical majority dominated the median blue edge (~305 nm), and the trimming algorithm cut UV spectra down to just their red tail (305–310 nm) — rendering them as a few nanometres of noise. The spectra generator's display range computation was designed for a homogeneous optical population and didn't account for bimodal wavelength distributions.

## Testing

- 24 new tests in `test_spectra_regimes.py` covering regime assignment, cross-boundary splitting (X-Shooter split, STIS G430L no-split, boundary point assignment), per-regime trimming (UV not trimmed by optical median, independent medians, intra-regime outliers still trimmed), and end-to-end mixed UV+optical regression scenarios
- Fixed 3 stale `xuv` references in `test_spectra_regime.py`
- Full CI green: mypy strict, ruff, pytest (1514 passed), frontend build

## Notes

- The `::` suffix convention for split spectrum IDs (`dp-123::optical`, `dp-123::nir`) is new — the frontend treats these as opaque string keys so no logic changes were needed there
- The feature marker toggle was already correctly hidden for non-optical regimes (`resolvedRegimeId === 'optical'`), so the xray/uv split required no feature marker code changes
- Backward compatibility: stale artifacts with `xuv` regime IDs will render with a fallback sort order until the next regeneration sweep

## Bugs Fixed

- UV spectra truncated to 305–307 nm when displayed alongside optical spectra

## Next Steps

- Trigger an artifact regeneration sweep to produce 1.4 schema artifacts with correct UV display ranges
- Backfill the 9 DDB items missing `top_level_snr` (pre-existing, unrelated)
- UV spectral feature markers (C IV, Si IV, Mg II, N V) — deferred per ADR-035 §5