### PR TITLE
fix(spectra): tighten wavelength trim tolerance and cap waterfall gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check for backend changes
         id: changes
         run: |
-          if git diff --name-only HEAD~1 HEAD | grep -qvE '^frontend/'; then
+          if git diff --name-only HEAD~1 HEAD | grep -qvE '^(frontend/|docs/)|\.md$'; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"

--- a/docs/worklog/bugs_list_4_12_26.md
+++ b/docs/worklog/bugs_list_4_12_26.md
@@ -1,0 +1,6 @@
+
+1. After recent updates (ADR-035), the clipping of red wavelegnth edges that are far past the median appears to be failing.
+2. We need to ensure that there is at least somewhat equitable distribution of vertical spacing for all spectra. I have a situation in the UV where two spectra two early spectra take up ~85% of the entire y-stretch of the figure, and the last three spectra get ~15%. You can see essentially nothing on the top three spectra.
+3. From the 4-11 worklog, item # 4: When I click on individual spectra and switch to log scaling, I've seen several instances where the minimum y-values get cut off. Again, another issue with the floor.
+4. There should be an option for sqrt(flux) scaling when you've selected an individual spectra.
+5. I just want to make sure that my memory is correct here: when you select individual spectra you're being shown a high(er) resolution spectra, as compared to the waterfall, right?

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,8 @@
         "plotly.js": "^3.4.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
-        "react-plotly.js": "^2.6.0"
+        "react-plotly.js": "^2.6.0",
+        "vitest": "^4.1.4"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -323,6 +324,422 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1023,7 +1440,6 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -1432,11 +1848,342 @@
       "integrity": "sha512-Mdk+vUACbQvjd0m/1JJjOOafmkp/EpmHjISsopEz5Av44CBq7rPC05HHNbYGKVyNUF2zmEoBS/TT0pd0SPFFyw==",
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -1835,11 +2582,26 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/geojson": {
@@ -1892,7 +2654,7 @@
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2497,6 +3259,112 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abs-svg-path": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
@@ -2772,6 +3640,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -3034,6 +3911,15 @@
         "element-size": "^1.1.1"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3196,7 +4082,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/core-util-is": {
@@ -3826,6 +4711,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3936,6 +4827,47 @@
         "es5-ext": "^0.10.46",
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/escalade": {
@@ -4429,6 +5361,15 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4455,6 +5396,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/ext": {
@@ -4676,6 +5626,20 @@
       "dependencies": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -5939,7 +6903,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -6096,7 +7060,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -6410,7 +7374,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -6995,6 +7958,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7138,6 +8111,12 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
     "node_modules/pbf": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
@@ -7269,7 +8248,6 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
       "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7665,6 +8643,50 @@
       "integrity": "sha512-DA8+YS+sMIVpbsuKgy+Z67L9Lxb1p05mNxRpDPNksPDEFir4vmBlUtuN9jkTGn9YMMdlBuK7XQgFiz6ws+yhSg==",
       "license": "MIT"
     },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -8013,6 +9035,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "license": "ISC"
+    },
     "node_modules/signum": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
@@ -8053,6 +9081,12 @@
         "node": "*"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "license": "MIT"
+    },
     "node_modules/static-eval": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.1.tgz",
@@ -8061,6 +9095,12 @@
       "dependencies": {
         "escodegen": "^2.1.0"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -8412,17 +9452,31 @@
         "xtend": "~4.0.1"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "license": "MIT"
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
     },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -8439,7 +9493,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -8457,7 +9510,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8471,6 +9523,15 @@
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
       "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
       "license": "ISC"
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/to-float32": {
       "version": "1.1.0",
@@ -8733,7 +9794,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unquote": {
@@ -8829,6 +9890,210 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/vt-pbf": {
       "version": "3.1.3",
@@ -8959,6 +10224,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "plotly.js": "^3.4.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "react-plotly.js": "^2.6.0"
+    "react-plotly.js": "^2.6.0",
+    "vitest": "^4.1.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/frontend/src/components/nova/SpectraViewer.tsx
+++ b/frontend/src/components/nova/SpectraViewer.tsx
@@ -784,10 +784,16 @@ export default function SpectraViewer({ data, onRetry }: SpectraViewerProps) {
   const [userXRange, setUserXRange] = useState<[number, number] | null>(null);
   const [userYRange, setUserYRange] = useState<[number, number] | null>(null);
 
+  // Revision counter — incremented on every explicit range reset.
+  // Fed into layout.uirevision so Plotly drops cached zoom/pan state
+  // and re-applies our computed default ranges from scratch.
+  const [plotRevision, setPlotRevision] = useState(0);
+
   const handleRelayout = useCallback((update: Record<string, unknown>) => {
     if ('xaxis.autorange' in update || 'yaxis.autorange' in update) {
       setUserXRange(null);
       setUserYRange(null);
+      setPlotRevision(r => r + 1);
       return;
     }
     const x0 = update['xaxis.range[0]'] as number | undefined;
@@ -819,6 +825,7 @@ export default function SpectraViewer({ data, onRetry }: SpectraViewerProps) {
     setSelectedSpectrumId(null);
     setUserXRange(null);
     setUserYRange(null);
+    setPlotRevision(r => r + 1);
     if (regimeId !== 'optical') {
       setActiveFeatureGroups(new Set());
     }
@@ -848,7 +855,14 @@ export default function SpectraViewer({ data, onRetry }: SpectraViewerProps) {
     return <ErrorState onRetry={onRetry} />;
   }
 
-  const { traces, layout, config, preparedSpectra } = plotData;
+  const { traces, layout: plotLayout, config, preparedSpectra } = plotData;
+
+  // Plotly caches zoom/pan state internally and may restore stale ranges
+  // after React re-renders (e.g., toggling feature markers after a reset,
+  // or clicking 'reset axes' in single-spectrum mode).  Setting uirevision
+  // to a counter that increments on every explicit reset forces Plotly to
+  // drop its cached UI state and re-apply our layout ranges.
+  const layout = { ...plotLayout, uirevision: plotRevision };
 
   return (
     <div className="rounded-md border border-[var(--color-border-subtle)] overflow-hidden bg-[var(--color-surface-primary)]">
@@ -876,7 +890,7 @@ export default function SpectraViewer({ data, onRetry }: SpectraViewerProps) {
           <ToggleGroup<EpochFormat>
             ariaLabel="Epoch label format"
             value={epochFormat}
-            onChange={(v) => { setEpochFormat(v); setUserXRange(null); setUserYRange(null); }}
+            onChange={(v) => { setEpochFormat(v); setUserXRange(null); setUserYRange(null); setPlotRevision(r => r + 1); }}
             options={[
               {
                 value: 'dpo', label: 'DPO',
@@ -951,7 +965,7 @@ export default function SpectraViewer({ data, onRetry }: SpectraViewerProps) {
       <LegendStrip
         spectra={preparedSpectra}
         selectedId={selectedSpectrumId}
-        onSelect={(id) => { setSelectedSpectrumId(id); setUserXRange(null); setUserYRange(null); }}
+        onSelect={(id) => { setSelectedSpectrumId(id); setUserXRange(null); setUserYRange(null); setPlotRevision(r => r + 1); }}
       />
     </div>
   );
@@ -1077,6 +1091,7 @@ function buildPlotData(
       xaxis: {
         title: { text: 'Wavelength (nm)', font: { size: 12, color: 'var(--color-text-secondary)', family: 'DM Sans, sans-serif' } },
         range: userXRange ?? defaultXRange,
+        autorange: !userXRange,
         gridcolor: 'var(--color-border-subtle)',
         zerolinecolor: 'var(--color-border-subtle)',
         tickfont: { size: 10, color: 'var(--color-text-tertiary)', family: 'DM Mono, monospace' },
@@ -1089,6 +1104,7 @@ function buildPlotData(
         zerolinecolor: 'var(--color-border-subtle)',
         tickfont: { size: 10, color: 'var(--color-text-tertiary)', family: 'DM Mono, monospace' },
         range: userYRange ?? defaultYRange,
+        autorange: !userYRange,
       },
       annotations: allAnnotations,
       shapes,
@@ -1102,7 +1118,11 @@ function buildPlotData(
     const config = {
       displayModeBar: 'hover' as const,
       responsive: true,
-      modeBarButtonsToRemove: ['select2d', 'lasso2d', 'autoScale2d', 'toImage'] as const,
+      // Use autoScale2d (live autorange) instead of resetScale2d (cached
+      // _initialRange) — Plotly's _initialRange can retain stale waterfall
+      // y-ranges after transitioning to single-spectrum mode, causing the
+      // "Reset axes" button to shrink the spectrum to ~10% of the y-axis.
+      modeBarButtonsToRemove: ['select2d', 'lasso2d', 'resetScale2d', 'toImage'] as const,
       displaylogo: false,
     };
 

--- a/frontend/src/components/nova/SpectraViewer.tsx
+++ b/frontend/src/components/nova/SpectraViewer.tsx
@@ -382,6 +382,7 @@ function interpolateToGrid(
 
 const PACKING_PADDING = 0.096;
 const PACKING_MIN_GAP = 0.05;
+const PACKING_GAP_CAP_RATIO = 2.5;  // max gap = 2.5× median gap
 const GRID_POINTS = 500;
 
 interface PackingResult {
@@ -451,6 +452,33 @@ function computeWaterfallPacking(
     if (maxSep === -Infinity) maxSep = 0;
     const rawGap = maxSep + padding;
     baselines[i] = baselines[i - 1] + Math.max(rawGap, PACKING_MIN_GAP);
+  }
+
+  // ── Gap capping — equitable vertical spacing ────────────────────────
+  // Collision-aware packing can produce extreme gaps when two adjacent
+  // spectra have very different flux profiles.  Cap any gap that exceeds
+  // GAP_CAP_RATIO × median to prevent a few spectra from dominating the
+  // y-range while the rest are compressed into a sliver.
+  if (N >= 3) {
+    const gaps: number[] = [];
+    for (let i = 1; i < N; i++) {
+      gaps.push(baselines[i] - baselines[i - 1]);
+    }
+    const sortedGaps = [...gaps].sort((a, b) => a - b);
+    const medianGap = sortedGaps[Math.floor((sortedGaps.length - 1) / 2)];
+    const maxAllowedGap = PACKING_GAP_CAP_RATIO * medianGap;
+
+    let needsRebuild = false;
+    for (const g of gaps) {
+      if (g > maxAllowedGap) { needsRebuild = true; break; }
+    }
+
+    if (needsRebuild) {
+      for (let i = 1; i < N; i++) {
+        const gap = baselines[i] - baselines[i - 1];
+        baselines[i] = baselines[i - 1] + Math.min(gap, maxAllowedGap);
+      }
+    }
   }
 
   // Rescale to fill plot: total extent is top baseline + top peak

--- a/services/artifact_generator/generators/bundle.py
+++ b/services/artifact_generator/generators/bundle.py
@@ -103,6 +103,10 @@ def generate_bundle_zip(
                         extra={
                             "nova_id": nova_id,
                             "data_product_id": dp_id,
+                            "instrument": dp.get("instrument", "unknown"),
+                            "telescope": dp.get("telescope", "unknown"),
+                            "provider": dp.get("provider", "unknown"),
+                            "observation_date_mjd": str(dp.get("observation_date_mjd", "")),
                         },
                     )
                     spectra_skipped += 1
@@ -117,6 +121,8 @@ def generate_bundle_zip(
                         extra={
                             "nova_id": nova_id,
                             "data_product_id": dp_id,
+                            "instrument": dp.get("instrument", "unknown"),
+                            "provider": dp.get("provider", "unknown"),
                             "fits_bucket": fits_bucket,
                             "fits_key": fits_key,
                             "error": str(exc),

--- a/services/artifact_generator/generators/compositing.py
+++ b/services/artifact_generator/generators/compositing.py
@@ -968,7 +968,13 @@ def _process_compositing_group(
         if not raw_key:
             _logger.warning(
                 "No raw_s3_key on DataProduct, skipping for compositing",
-                extra={"data_product_id": dp_id},
+                extra={
+                    "nova_id": nova_id,
+                    "data_product_id": dp_id,
+                    "instrument": product.get("instrument", "unknown"),
+                    "telescope": product.get("telescope", "unknown"),
+                    "provider": product.get("provider", "unknown"),
+                },
             )
             rejected.append(product)
             continue
@@ -978,7 +984,12 @@ def _process_compositing_group(
         if fits_result is None:
             _logger.warning(
                 "Could not read FITS for compositing",
-                extra={"data_product_id": dp_id},
+                extra={
+                    "nova_id": nova_id,
+                    "data_product_id": dp_id,
+                    "instrument": product.get("instrument", "unknown"),
+                    "provider": product.get("provider", "unknown"),
+                },
             )
             rejected.append(product)
             continue

--- a/services/artifact_generator/generators/spectra.py
+++ b/services/artifact_generator/generators/spectra.py
@@ -48,7 +48,7 @@ _SCHEMA_VERSION = "1.4"  # ADR-035: xray/uv split, per-regime trimming
 _WAVELENGTH_UNIT = "nm"
 
 _FLUX_FLOOR = 1e-4  # minimum normalized flux; prevents log(0) in frontend
-_TRIM_TOLERANCE = 1.1  # 10% beyond median before wavelength trim kicks in
+_TRIM_TOLERANCE = 1.001  # 0.1% beyond median before wavelength trim kicks in
 
 _ARM_MJD_TOLERANCE = 0.333  # days (~8 hr) — grouping tolerance for arms
 _ARM_OVERLAP_MAX_NM = 100.0  # nm — max overlap before we reject a merge

--- a/services/artifact_generator/generators/spectra.py
+++ b/services/artifact_generator/generators/spectra.py
@@ -621,6 +621,8 @@ def _process_spectrum_stage1(
             extra={
                 "nova_id": nova_id,
                 "data_product_id": data_product_id,
+                "instrument": product.get("instrument", "unknown"),
+                "provider": product.get("provider", "unknown"),
                 "s3_key": s3_key,
                 "error": str(exc),
             },
@@ -633,7 +635,12 @@ def _process_spectrum_stage1(
     if not wavelengths:
         _logger.warning(
             "Empty web-ready CSV — skipping spectrum",
-            extra={"nova_id": nova_id, "data_product_id": data_product_id},
+            extra={
+                "nova_id": nova_id,
+                "data_product_id": data_product_id,
+                "instrument": product.get("instrument", "unknown"),
+                "provider": product.get("provider", "unknown"),
+            },
         )
         return None
 
@@ -643,7 +650,12 @@ def _process_spectrum_stage1(
     if not wavelengths:
         _logger.warning(
             "All-zero spectrum after edge trimming — skipping",
-            extra={"nova_id": nova_id, "data_product_id": data_product_id},
+            extra={
+                "nova_id": nova_id,
+                "data_product_id": data_product_id,
+                "instrument": product.get("instrument", "unknown"),
+                "provider": product.get("provider", "unknown"),
+            },
         )
         return None
 
@@ -656,7 +668,12 @@ def _process_spectrum_stage1(
     if not wavelengths:
         _logger.warning(
             "Empty spectrum after chip gap rejection — skipping",
-            extra={"nova_id": nova_id, "data_product_id": data_product_id},
+            extra={
+                "nova_id": nova_id,
+                "data_product_id": data_product_id,
+                "instrument": product.get("instrument", "unknown"),
+                "provider": product.get("provider", "unknown"),
+            },
         )
         return None
 
@@ -760,7 +777,12 @@ def _process_spectrum_stage2(
     if normalization_scale is None:
         _logger.warning(
             "Zero peak flux — skipping spectrum",
-            extra={"nova_id": nova_id, "data_product_id": data_product_id},
+            extra={
+                "nova_id": nova_id,
+                "data_product_id": data_product_id,
+                "instrument": product.get("instrument", "unknown"),
+                "provider": product.get("provider", "unknown"),
+            },
         )
         return None
 

--- a/tests/services/artifact_generator/test_generators_spectra.py
+++ b/tests/services/artifact_generator/test_generators_spectra.py
@@ -275,17 +275,17 @@ class TestWavelengthRangeTrim:
     def test_no_trimming_when_similar_ranges(self) -> None:
         """All spectra with similar ranges are left untouched."""
         recs = [
-            _make_stage1_rec(400, 900, dp_id="dp-a"),
-            _make_stage1_rec(400, 920, dp_id="dp-b"),
-            _make_stage1_rec(400, 910, dp_id="dp-c"),
+            _make_stage1_rec(400, 910.0, dp_id="dp-a"),
+            _make_stage1_rec(400, 910.2, dp_id="dp-b"),
+            _make_stage1_rec(400, 910.5, dp_id="dp-c"),
         ]
 
         wl_maxes = [r["wavelengths"][-1] for r in recs]
-        display_max = statistics.median(wl_maxes)  # 910
+        display_max = statistics.median(wl_maxes)  # 910.2
 
         for rec in recs:
             original_wl = list(rec["wavelengths"])
-            # None exceed 910 * 1.1 = 1001
+            # None exceed 910.2 * 1.001 ≈ 911.1
             if rec["wavelengths"][-1] > display_max * _TRIM_TOLERANCE:
                 _trim_wavelength_range(rec, display_max)
             assert rec["wavelengths"] == original_wl
@@ -329,17 +329,17 @@ class TestWavelengthRangeTrim:
     def test_blue_no_trimming_when_similar_ranges(self) -> None:
         """All spectra with similar blue starts are left untouched."""
         recs = [
-            _make_stage1_rec(390, 900, dp_id="dp-a"),
-            _make_stage1_rec(400, 900, dp_id="dp-b"),
-            _make_stage1_rec(410, 900, dp_id="dp-c"),
+            _make_stage1_rec(399.8, 900, dp_id="dp-a"),
+            _make_stage1_rec(400.0, 900, dp_id="dp-b"),
+            _make_stage1_rec(400.2, 900, dp_id="dp-c"),
         ]
 
         wl_mins = [r["wavelengths"][0] for r in recs]
-        display_min = statistics.median(wl_mins)  # 400
+        display_min = statistics.median(wl_mins)  # 400.0
 
         for rec in recs:
             original_wl = list(rec["wavelengths"])
-            # None below 400 / 1.1 ≈ 363.6
+            # None below 400.0 / 1.001 ≈ 399.6
             if rec["wavelengths"][0] < display_min / _TRIM_TOLERANCE:
                 _trim_wavelength_range_min(rec, display_min)
             assert rec["wavelengths"] == original_wl

--- a/tools/diagnose_chip_gap_zeros.py
+++ b/tools/diagnose_chip_gap_zeros.py
@@ -1,0 +1,567 @@
+#!/usr/bin/env python3
+"""Diagnose chip-gap zero-runs in V906 Car UVES spectra.
+
+Pulls web-ready CSVs (what the artifact generator sees) and optionally
+the raw FITS files (full resolution) for all V906 Car UVES spectra.
+For each spectrum:
+
+  1. Identifies all runs of zero or near-zero flux
+  2. Reports run length, wavelength position, and local spacing
+  3. Generates per-spectrum plots with zero-runs highlighted
+
+Operator tooling — no CI requirements.
+
+Usage:
+    # Basic — pull web-ready CSVs and analyze
+    python diagnose_chip_gap_zeros.py
+
+    # Also pull raw FITS for full-resolution comparison
+    python diagnose_chip_gap_zeros.py --fits
+
+    # Limit to N spectra (useful for quick check)
+    python diagnose_chip_gap_zeros.py --limit 3
+
+    # Custom output directory
+    python diagnose_chip_gap_zeros.py --outdir /tmp/chipgap
+
+Environment variables:
+    NOVACAT_TABLE_NAME     — DynamoDB table (default: reads from env)
+    NOVACAT_PRIVATE_BUCKET — S3 bucket (default: reads from env)
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import os
+import sys
+from pathlib import Path
+
+import boto3
+import matplotlib.pyplot as plt
+import numpy as np
+from boto3.dynamodb.conditions import Key
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+NOVA_NAME = "V906 Car"
+# Relative threshold: fraction of peak flux below which a value is "near-zero"
+# (matches RELATIVE_ZERO_FRACTION in shared.py)
+RELATIVE_ZERO_FRACTION = 1e-6
+
+
+# ---------------------------------------------------------------------------
+# DynamoDB helpers
+# ---------------------------------------------------------------------------
+
+
+def resolve_nova_id(table, name: str) -> str | None:
+    """Resolve a nova name to nova_id via NameMapping."""
+    normalized = name.strip().lower().replace("_", " ")
+    pk = f"NAME#{normalized}"
+    resp = table.query(KeyConditionExpression=Key("PK").eq(pk), Limit=1)
+    items = resp.get("Items", [])
+    return items[0]["nova_id"] if items else None
+
+
+def query_uves_spectra(table, nova_id: str) -> list[dict]:
+    """Query all VALID UVES DataProduct items for a nova."""
+    items: list[dict] = []
+    kwargs = {
+        "KeyConditionExpression": (
+            Key("PK").eq(nova_id) & Key("SK").begins_with("DATAPRODUCT#SPECTRA#")
+        ),
+    }
+    while True:
+        resp = table.query(**kwargs)
+        for item in resp.get("Items", []):
+            if item.get("instrument") == "UVES" and item.get("validation_status") == "VALID":
+                items.append(item)
+        last_key = resp.get("LastEvaluatedKey")
+        if last_key is None:
+            break
+        kwargs["ExclusiveStartKey"] = last_key
+    return items
+
+
+# ---------------------------------------------------------------------------
+# S3 helpers
+# ---------------------------------------------------------------------------
+
+
+def download_web_ready_csv(s3, bucket: str, nova_id: str, dp_id: str) -> str | None:
+    """Download a web-ready CSV from S3, return contents or None."""
+    key = f"derived/spectra/{nova_id}/{dp_id}/web_ready.csv"
+    try:
+        resp = s3.get_object(Bucket=bucket, Key=key)
+        return resp["Body"].read().decode("utf-8")
+    except Exception as e:
+        print(f"  [WARN] Could not download {key}: {e}")
+        return None
+
+
+def download_raw_fits(s3, bucket: str, raw_s3_key: str) -> bytes | None:
+    """Download a raw FITS file from S3, return bytes or None."""
+    try:
+        resp = s3.get_object(Bucket=bucket, Key=raw_s3_key)
+        return resp["Body"].read()
+    except Exception as e:
+        print(f"  [WARN] Could not download FITS {raw_s3_key}: {e}")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# CSV parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_web_ready_csv(body: str) -> tuple[np.ndarray, np.ndarray]:
+    """Parse a web-ready CSV into wavelength and flux arrays."""
+    reader = csv.reader(io.StringIO(body))
+    header = next(reader, None)
+    if not header:
+        return np.array([]), np.array([])
+
+    wl_list: list[float] = []
+    fx_list: list[float] = []
+    for row in reader:
+        if len(row) < 2:
+            continue
+        try:
+            wl_list.append(float(row[0]))
+            fx_list.append(float(row[1]))
+        except ValueError:
+            continue
+    return np.array(wl_list), np.array(fx_list)
+
+
+# ---------------------------------------------------------------------------
+# FITS extraction (optional, for full-resolution comparison)
+# ---------------------------------------------------------------------------
+
+
+def extract_fits_spectrum(fits_bytes: bytes) -> tuple[np.ndarray, np.ndarray] | None:
+    """Extract wavelength/flux from a FITS file. Returns None on failure."""
+    try:
+        from astropy.io import fits
+
+        with fits.open(io.BytesIO(fits_bytes), memmap=False) as hdul:
+            primary = hdul[0]
+
+            # Try primary image HDU with WCS
+            if primary.data is not None and primary.data.ndim >= 1:
+                flux = np.asarray(primary.data, dtype=np.float64).flatten()
+                crval1 = float(primary.header.get("CRVAL1", 0.0))
+                cdelt1 = float(primary.header.get("CDELT1", 1.0))
+                crpix1 = float(primary.header.get("CRPIX1", 1.0))
+                n_pix = len(flux)
+                wavelength = crval1 + cdelt1 * (np.arange(n_pix) - (crpix1 - 1.0))
+                # Convert Angstrom to nm if needed
+                if crval1 > 1000:  # likely Angstrom
+                    wavelength = wavelength / 10.0
+                return wavelength, flux
+
+            # Try binary table
+            if len(hdul) > 1 and hasattr(hdul[1], "columns"):
+                tbl = hdul[1].data
+                col_names = [c.upper() for c in hdul[1].columns.names]
+                wave_col = flux_col = None
+                for cand in ("WAVE", "WAVELENGTH", "LAMBDA", "WAVE_AIR"):
+                    if cand in col_names:
+                        wave_col = hdul[1].columns.names[col_names.index(cand)]
+                        break
+                for cand in ("FLUX", "FLUX_REDUCED", "FLUX_OPT"):
+                    if cand in col_names:
+                        flux_col = hdul[1].columns.names[col_names.index(cand)]
+                        break
+                if wave_col and flux_col:
+                    wl = np.asarray(tbl[wave_col], dtype=np.float64).flatten()
+                    fx = np.asarray(tbl[flux_col], dtype=np.float64).flatten()
+                    # Convert Angstrom to nm if needed
+                    unit = hdul[1].header.get("TUNIT1", "") or primary.header.get("CUNIT1", "")
+                    if "ang" in unit.lower() or (len(wl) > 0 and wl[0] > 1000):
+                        wl = wl / 10.0
+                    return wl, fx
+
+        return None
+    except Exception as e:
+        print(f"  [WARN] FITS extraction failed: {e}")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Zero-run analysis
+# ---------------------------------------------------------------------------
+
+
+def find_zero_runs(
+    wavelengths: np.ndarray,
+    fluxes: np.ndarray,
+) -> list[dict]:
+    """Find all runs of zero/near-zero flux in the spectrum.
+
+    Returns a list of dicts, each describing one run:
+      - start_idx, end_idx: indices (inclusive start, exclusive end)
+      - length: number of points in the run
+      - wl_start, wl_end: wavelength range of the run
+      - wl_center: center wavelength
+      - is_edge: whether the run touches the array boundary
+      - local_spacing: median wavelength step in the run's neighborhood
+      - spacing_is_regular: whether the run's spacing matches the local median
+      - max_flux_in_run: the largest |flux| value in the run
+    """
+    n = len(fluxes)
+    if n == 0:
+        return []
+
+    peak = np.max(np.abs(fluxes))
+    if peak == 0.0:
+        return [{"note": "ALL_ZERO", "length": n}]
+
+    threshold = peak * RELATIVE_ZERO_FRACTION
+
+    # Also check for exact zeros separately
+    is_dead = np.abs(fluxes) < threshold
+    is_exact_zero = fluxes == 0.0
+
+    runs: list[dict] = []
+
+    # Find contiguous runs of dead pixels
+    in_run = False
+    run_start = 0
+    for i in range(n):
+        if is_dead[i] or is_exact_zero[i]:
+            if not in_run:
+                run_start = i
+                in_run = True
+        else:
+            if in_run:
+                _append_run(runs, wavelengths, fluxes, run_start, i, n, is_exact_zero)
+                in_run = False
+    if in_run:
+        _append_run(runs, wavelengths, fluxes, run_start, n, n, is_exact_zero)
+
+    return runs
+
+
+def _append_run(
+    runs: list[dict],
+    wavelengths: np.ndarray,
+    fluxes: np.ndarray,
+    start: int,
+    end: int,
+    n: int,
+    is_exact_zero: np.ndarray,
+) -> None:
+    """Append a run descriptor to the runs list."""
+    length = end - start
+    is_edge = start == 0 or end == n
+
+    # Local spacing: look at 20 points around the run
+    ctx_start = max(0, start - 10)
+    ctx_end = min(n, end + 10)
+    if ctx_end - ctx_start > 1:
+        local_steps = np.diff(wavelengths[ctx_start:ctx_end])
+        local_median_step = float(np.median(local_steps))
+    else:
+        local_median_step = float("nan")
+
+    # Spacing within the run itself
+    if length > 1:
+        run_steps = np.diff(wavelengths[start:end])
+        run_median_step = float(np.median(run_steps))
+        # "Regular" if within 50% of local median
+        spacing_is_regular = (
+            abs(run_median_step - local_median_step) / max(local_median_step, 1e-12) < 0.5
+        )
+    else:
+        run_median_step = float("nan")
+        # For single-point runs, check gap to neighbors
+        if start > 0 and end < n:
+            gap_left = wavelengths[start] - wavelengths[start - 1]
+            gap_right = wavelengths[end] - wavelengths[end - 1] if end < n else float("inf")
+            spacing_is_regular = (
+                abs(gap_left - local_median_step) / max(local_median_step, 1e-12) < 0.5
+                and abs(gap_right - local_median_step) / max(local_median_step, 1e-12) < 0.5
+            )
+        else:
+            spacing_is_regular = True  # edge — can't tell
+
+    exact_zero_count = int(np.sum(is_exact_zero[start:end]))
+
+    runs.append(
+        {
+            "start_idx": start,
+            "end_idx": end,
+            "length": length,
+            "wl_start": float(wavelengths[start]),
+            "wl_end": float(wavelengths[end - 1]),
+            "wl_center": float(np.mean(wavelengths[start:end])),
+            "is_edge": is_edge,
+            "local_median_step_nm": round(local_median_step, 6),
+            "run_median_step_nm": round(run_median_step, 6) if length > 1 else None,
+            "spacing_is_regular": spacing_is_regular,
+            "max_flux_in_run": float(np.max(np.abs(fluxes[start:end]))),
+            "exact_zero_count": exact_zero_count,
+            "all_exact_zeros": exact_zero_count == length,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Plotting
+# ---------------------------------------------------------------------------
+
+
+def plot_spectrum_with_zeros(
+    wavelengths: np.ndarray,
+    fluxes: np.ndarray,
+    runs: list[dict],
+    dp_id: str,
+    label: str,
+    outdir: Path,
+) -> None:
+    """Plot a spectrum with zero-runs highlighted in red."""
+    fig, axes = plt.subplots(2, 1, figsize=(16, 10), gridspec_kw={"height_ratios": [3, 1]})
+
+    # Top: full spectrum
+    ax_full = axes[0]
+    ax_full.plot(wavelengths, fluxes, linewidth=0.5, color="steelblue", alpha=0.8)
+    for run in runs:
+        if "start_idx" not in run:
+            continue
+        s, e = run["start_idx"], run["end_idx"]
+        ax_full.axvspan(
+            wavelengths[s],
+            wavelengths[min(e, len(wavelengths) - 1)],
+            color="red",
+            alpha=0.3,
+            label=f"zero run (n={run['length']})" if s == runs[0].get("start_idx") else None,
+        )
+    ax_full.set_xlabel("Wavelength (nm)")
+    ax_full.set_ylabel("Flux")
+    ax_full.set_title(f"{label}\n{dp_id[:13]}  —  {len(runs)} zero-run(s) found")
+    ax_full.legend(loc="upper right", fontsize=8)
+
+    # Bottom: zoom into chip-gap region (~520–620 nm for UVES red arm)
+    ax_zoom = axes[1]
+    # Find runs near the chip gap (roughly 520-620 nm)
+    interior_runs = [r for r in runs if "start_idx" in r and not r["is_edge"]]
+    if interior_runs:
+        # Zoom around the first interior run
+        center = interior_runs[0]["wl_center"]
+        zoom_half = 15.0  # ±15 nm
+        mask = (wavelengths >= center - zoom_half) & (wavelengths <= center + zoom_half)
+        if np.any(mask):
+            ax_zoom.plot(
+                wavelengths[mask],
+                fluxes[mask],
+                linewidth=1.0,
+                color="steelblue",
+                marker=".",
+                markersize=3,
+            )
+            for run in interior_runs:
+                s, e = run["start_idx"], run["end_idx"]
+                wl_s = wavelengths[s]
+                wl_e = wavelengths[min(e, len(wavelengths) - 1)]
+                if wl_e >= center - zoom_half and wl_s <= center + zoom_half:
+                    ax_zoom.axvspan(wl_s, wl_e, color="red", alpha=0.3)
+            ax_zoom.set_xlabel("Wavelength (nm)")
+            ax_zoom.set_ylabel("Flux")
+            ax_zoom.set_title(
+                f"Zoom: {center - zoom_half:.1f}–{center + zoom_half:.1f} nm (around first interior zero-run)"
+            )
+        else:
+            ax_zoom.text(
+                0.5, 0.5, "No data in chip-gap zoom range", transform=ax_zoom.transAxes, ha="center"
+            )
+    else:
+        ax_zoom.text(
+            0.5, 0.5, "No interior zero-runs found", transform=ax_zoom.transAxes, ha="center"
+        )
+
+    plt.tight_layout()
+    safe_id = dp_id[:13].replace("-", "")
+    plt.savefig(outdir / f"chipgap_{safe_id}_{label.lower().replace(' ', '_')}.png", dpi=150)
+    plt.close()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Diagnose chip-gap zeros in V906 Car UVES spectra")
+    parser.add_argument(
+        "--fits", action="store_true", help="Also download raw FITS for full-res comparison"
+    )
+    parser.add_argument("--limit", type=int, default=0, help="Limit to N spectra (0 = all)")
+    parser.add_argument(
+        "--outdir", type=str, default="chipgap_diag", help="Output directory for plots"
+    )
+    args = parser.parse_args()
+
+    table_name = os.environ.get("NOVACAT_TABLE_NAME")
+    bucket_name = os.environ.get("NOVACAT_PRIVATE_BUCKET")
+    if not table_name or not bucket_name:
+        print("ERROR: Set NOVACAT_TABLE_NAME and NOVACAT_PRIVATE_BUCKET env vars.")
+        print("       (These are set automatically after running deploy.sh)")
+        sys.exit(1)
+
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    ddb = boto3.resource("dynamodb")
+    table = ddb.Table(table_name)
+    s3 = boto3.client("s3")
+
+    # Resolve nova
+    nova_id = resolve_nova_id(table, NOVA_NAME)
+    if not nova_id:
+        print(f"ERROR: Could not resolve '{NOVA_NAME}' to a nova_id.")
+        sys.exit(1)
+    print(f"Nova: {NOVA_NAME}  →  {nova_id}")
+
+    # Query UVES spectra
+    products = query_uves_spectra(table, nova_id)
+    print(f"Found {len(products)} VALID UVES spectra")
+
+    if args.limit > 0:
+        products = products[: args.limit]
+        print(f"  (limited to {args.limit})")
+
+    # Summary accumulators
+    all_summaries: list[dict] = []
+
+    for i, product in enumerate(products):
+        dp_id = product["data_product_id"]
+        obs_mjd = product.get("observation_date_mjd", "?")
+        print(f"\n{'=' * 70}")
+        print(f"[{i + 1}/{len(products)}] {dp_id[:13]}...  MJD={obs_mjd}")
+        print(f"{'=' * 70}")
+
+        # --- Web-ready CSV analysis ---
+        csv_body = download_web_ready_csv(s3, bucket_name, nova_id, dp_id)
+        if csv_body:
+            wl_csv, fx_csv = parse_web_ready_csv(csv_body)
+            print(f"  Web-ready CSV: {len(wl_csv)} points")
+            print(f"    Flux range: [{fx_csv.min():.6e}, {fx_csv.max():.6e}]")
+            print(f"    Exact zeros: {np.sum(fx_csv == 0.0)}")
+
+            if len(wl_csv) > 1:
+                steps = np.diff(wl_csv)
+                print(
+                    f"    WL step: median={np.median(steps):.4f} nm, "
+                    f"min={steps.min():.4f} nm, max={steps.max():.4f} nm"
+                )
+
+            runs_csv = find_zero_runs(wl_csv, fx_csv)
+            interior_runs = [r for r in runs_csv if "start_idx" in r and not r["is_edge"]]
+            edge_runs = [r for r in runs_csv if "start_idx" in r and r["is_edge"]]
+
+            print(
+                f"    Zero-runs: {len(runs_csv)} total, "
+                f"{len(interior_runs)} interior, {len(edge_runs)} edge"
+            )
+
+            for j, run in enumerate(interior_runs):
+                print(f"    INTERIOR RUN {j + 1}:")
+                print(
+                    f"      Position: {run['wl_start']:.2f}–{run['wl_end']:.2f} nm "
+                    f"(center: {run['wl_center']:.2f} nm)"
+                )
+                print(f"      Length: {run['length']} points")
+                print(
+                    f"      All exact zeros: {run['all_exact_zeros']} "
+                    f"({run['exact_zero_count']}/{run['length']} exact)"
+                )
+                print(
+                    f"      Spacing regular: {run['spacing_is_regular']} "
+                    f"(local median step: {run['local_median_step_nm']:.4f} nm"
+                    + (
+                        f", run step: {run['run_median_step_nm']:.4f} nm"
+                        if run["run_median_step_nm"]
+                        else ""
+                    )
+                    + ")"
+                )
+                print(f"      Max |flux| in run: {run['max_flux_in_run']:.6e}")
+
+            plot_spectrum_with_zeros(wl_csv, fx_csv, runs_csv, dp_id, "web_ready", outdir)
+
+            all_summaries.append(
+                {
+                    "dp_id": dp_id[:13],
+                    "mjd": str(obs_mjd),
+                    "csv_points": len(wl_csv),
+                    "exact_zeros": int(np.sum(fx_csv == 0.0)),
+                    "interior_runs": len(interior_runs),
+                    "interior_run_lengths": [r["length"] for r in interior_runs],
+                    "interior_run_centers_nm": [round(r["wl_center"], 1) for r in interior_runs],
+                    "interior_spacing_regular": [r["spacing_is_regular"] for r in interior_runs],
+                }
+            )
+        else:
+            print("  [SKIP] No web-ready CSV")
+            continue
+
+        # --- Optional: raw FITS analysis ---
+        if args.fits:
+            raw_key = product.get("raw_s3_key")
+            if raw_key:
+                fits_bytes = download_raw_fits(s3, bucket_name, raw_key)
+                if fits_bytes:
+                    result = extract_fits_spectrum(fits_bytes)
+                    if result:
+                        wl_fits, fx_fits = result
+                        print(f"  Raw FITS: {len(wl_fits)} points")
+                        print(f"    Flux range: [{fx_fits.min():.6e}, {fx_fits.max():.6e}]")
+                        print(f"    Exact zeros: {np.sum(fx_fits == 0.0)}")
+
+                        runs_fits = find_zero_runs(wl_fits, fx_fits)
+                        interior_fits = [
+                            r for r in runs_fits if "start_idx" in r and not r["is_edge"]
+                        ]
+                        print(
+                            f"    Zero-runs: {len(runs_fits)} total, {len(interior_fits)} interior"
+                        )
+
+                        for j, run in enumerate(interior_fits):
+                            print(
+                                f"    FITS INTERIOR RUN {j + 1}: "
+                                f"{run['wl_start']:.2f}–{run['wl_end']:.2f} nm, "
+                                f"len={run['length']}, "
+                                f"regular_spacing={run['spacing_is_regular']}, "
+                                f"all_exact_zeros={run['all_exact_zeros']}"
+                            )
+
+                        plot_spectrum_with_zeros(
+                            wl_fits, fx_fits, runs_fits, dp_id, "raw_fits", outdir
+                        )
+
+    # --- Summary table ---
+    print(f"\n{'=' * 70}")
+    print("SUMMARY")
+    print(f"{'=' * 70}")
+    print(
+        f"{'dp_id':>15s} {'MJD':>12s} {'pts':>6s} {'zeros':>6s} {'int_runs':>9s} {'run_lens':>20s} {'centers_nm':>30s} {'regular?':>20s}"
+    )
+    print("-" * 120)
+    for s in all_summaries:
+        print(
+            f"{s['dp_id']:>15s} {s['mjd']:>12s} {s['csv_points']:>6d} {s['exact_zeros']:>6d} "
+            f"{s['interior_runs']:>9d} {str(s['interior_run_lengths']):>20s} "
+            f"{str(s['interior_run_centers_nm']):>30s} {str(s['interior_spacing_regular']):>20s}"
+        )
+
+    print(f"\nPlots saved to: {outdir.resolve()}")
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/reseed_work_items.py
+++ b/tools/reseed_work_items.py
@@ -7,28 +7,28 @@ their artifacts.
 
 Usage:
     # Reseed spectra WorkItem for V906 Car (by nova_id)
-    python reseed_work_items.py --nova-id 64c5c516-... --dirty spectra
+    python tools/reseed_work_items.py --nova-id 64c5c516-... --dirty spectra
 
     # Reseed both spectra and photometry
-    python reseed_work_items.py --nova-id 64c5c516-... --dirty spectra photometry
+    python tools/reseed_work_items.py --nova-id 64c5c516-... --dirty spectra photometry
 
     # Reseed all dirty types for a single nova
-    python reseed_work_items.py --nova-id 64c5c516-... --dirty all
+    python tools/reseed_work_items.py --nova-id 64c5c516-... --dirty all
 
     # Resolve by name instead of nova_id
-    python reseed_work_items.py --name "V906 Car" --dirty spectra
+    python tools/reseed_work_items.py --name "V906 Car" --dirty spectra
 
     # Reseed ALL ACTIVE novae with all dirty types (full catalog rebuild)
-    python reseed_work_items.py --all --dirty all
+    python tools/reseed_work_items.py --all --dirty all
 
     # Reseed ALL ACTIVE novae for spectra only
-    python reseed_work_items.py --all --dirty spectra
+    python tools/reseed_work_items.py --all --dirty spectra
 
     # Dry run — show what would be written
-    python reseed_work_items.py --all --dirty all --dry-run
+    python tools/reseed_work_items.py --all --dirty all --dry-run
 
     # Use a specific table (default: reads NOVACAT_TABLE_NAME from env)
-    python reseed_work_items.py --nova-id abc123 --dirty spectra --table NovaCat
+    python tools/reseed_work_items.py --nova-id abc123 --dirty spectra --table NovaCat
 
 Operator tooling — no CI requirements.
 """


### PR DESCRIPTION
## Summary
- Fix "reset axes" in single-spectrum mode restoring stale waterfall
  y-range (swap resetScale2d → autoScale2d in single-spectrum modebar)
- Fix feature-toggle zoom leak (uirevision counter drops Plotly's
  cached zoom state on explicit resets)
- Tighten _TRIM_TOLERANCE from 1.1 to 1.001 for more aggressive
  wavelength outlier clipping
- Cap extreme waterfall gaps at 2.5× median for equitable vertical
  spacing across spectra
- Skip backend CI on docs-only changes

## Why
- Spectra viewer had multiple Plotly state management bugs making
  zoom/reset unreliable in single-spectrum mode
- UV spectra with varying flux profiles were producing waterfall plots
  where 2 of 5 spectra consumed ~85% of the y-range
- Red wavelength edges far past the median were not being clipped after
  ADR-035 changes due to the lenient 10% tolerance

## Testing
- Manual: select spectrum → zoom → reset axes → spectrum fills full
  y-axis (not ~10%)
- Manual: zoom → toggle features → untoggle → reset → retoggle → no
  stale zoom restoration
- Manual: UV waterfall with varying flux profiles shows equitable
  vertical distribution (pending real data verification)
- pytest: updated wavelength trim tests pass with tighter tolerance
- Frontend build: clean, no type errors

## Notes
- PACKING_GAP_CAP_RATIO (2.5) is tunable — may need adjustment after
  eyeballing real UV data on the deployed site
- The autoScale2d swap only affects single-spectrum mode; waterfall
  modebar is unchanged

## Out of Scope
- Floor/clipping fixes (Bug 3) — deferred to next pass
- sqrt(flux) scaling in single-spectrum mode (feature request)