### PR TITLE
revert(frontend): remove waterfall gap capping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ tools/novacat-tools/notebooks/novacat.ipynb
 tools/svo-filter-analysis/svo_fps.db-shm
 tools/svo-filter-analysis/svo_fps.db-wal
 tools/svo-filter-analysis/svo_fps.db-wal
+/docs/diagrams

--- a/frontend/src/components/nova/SpectraViewer.tsx
+++ b/frontend/src/components/nova/SpectraViewer.tsx
@@ -382,7 +382,6 @@ function interpolateToGrid(
 
 const PACKING_PADDING = 0.096;
 const PACKING_MIN_GAP = 0.05;
-const PACKING_GAP_CAP_RATIO = 2.5;  // max gap = 2.5× median gap
 const GRID_POINTS = 500;
 
 interface PackingResult {
@@ -454,32 +453,6 @@ function computeWaterfallPacking(
     baselines[i] = baselines[i - 1] + Math.max(rawGap, PACKING_MIN_GAP);
   }
 
-  // ── Gap capping — equitable vertical spacing ────────────────────────
-  // Collision-aware packing can produce extreme gaps when two adjacent
-  // spectra have very different flux profiles.  Cap any gap that exceeds
-  // GAP_CAP_RATIO × median to prevent a few spectra from dominating the
-  // y-range while the rest are compressed into a sliver.
-  if (N >= 3) {
-    const gaps: number[] = [];
-    for (let i = 1; i < N; i++) {
-      gaps.push(baselines[i] - baselines[i - 1]);
-    }
-    const sortedGaps = [...gaps].sort((a, b) => a - b);
-    const medianGap = sortedGaps[Math.floor((sortedGaps.length - 1) / 2)];
-    const maxAllowedGap = PACKING_GAP_CAP_RATIO * medianGap;
-
-    let needsRebuild = false;
-    for (const g of gaps) {
-      if (g > maxAllowedGap) { needsRebuild = true; break; }
-    }
-
-    if (needsRebuild) {
-      for (let i = 1; i < N; i++) {
-        const gap = baselines[i] - baselines[i - 1];
-        baselines[i] = baselines[i - 1] + Math.min(gap, maxAllowedGap);
-      }
-    }
-  }
 
   // Rescale to fill plot: total extent is top baseline + top peak
   const totalExtent = baselines[N - 1] + peakHeights[N - 1];


### PR DESCRIPTION
The gap capping logic (PACKING_GAP_CAP_RATIO = 2.5× median) made the UV waterfall spacing worse in practice — spectra with large emission features overflowed the plot bounds while compressed spectra remained cramped. The underlying issue is normalization being dominated by single-pixel artifacts, not the packing algorithm itself. Removing until the root cause (unified spectral cleaning) is addressed.