### PR TITLE
feat(identity): use SIMBAD canonical name as primary_name, demote ingestion name to alias (B19)

### DIFF
--- a/infra/workflows/initialize_nova.asl.json
+++ b/infra/workflows/initialize_nova.asl.json
@@ -379,7 +379,7 @@
         },
         "UpsertMinimalNovaMetadata": {
             "Type": "Task",
-            "Comment": "Persist minimal nova metadata: nova_id, candidate_name, resolved coordinates, resolver_source, aliases.",
+            "Comment": "Persist minimal nova metadata: nova_id, candidate_name, resolved coordinates, resolver_source, aliases, simbad_main_id.",
             "Resource": "${UpsertMinimalNovaMetadataFunctionArn}",
             "Parameters": {
                 "task_name": "UpsertMinimalNovaMetadata",
@@ -392,6 +392,7 @@
                 "resolved_epoch.$": "$.resolution.resolved_epoch",
                 "resolver_source.$": "$.resolution.resolver_source",
                 "aliases.$": "$.resolution.aliases",
+                "simbad_main_id.$": "$.resolution.simbad_main_id",
                 "correlation_id.$": "$.job_run.correlation_id",
                 "job_run_id.$": "$.job_run.job_run_id"
             },

--- a/services/archive_resolver/handler.py
+++ b/services/archive_resolver/handler.py
@@ -151,6 +151,7 @@ def _resolve_candidate_against_public_archives(
             "is_classical_nova": "false",
             "resolver_source": "NONE",
             "aliases": [],
+            "simbad_main_id": None,
         }
 
     if simbad_result is not None and tns_result is not None:
@@ -163,6 +164,7 @@ def _resolve_candidate_against_public_archives(
         result = cast(dict[str, Any], tns_result)
         result["resolver_source"] = "TNS"
         result.setdefault("aliases", [])
+        result.setdefault("simbad_main_id", None)
 
     logger.info(
         "Archive resolution complete",
@@ -221,6 +223,14 @@ def _query_simbad(candidate_name: str) -> dict[str, Any] | None:
     ra = _raw("ra")
     dec = _raw("dec")
     ids_raw = _raw("ids")
+    main_id_raw = _raw("main_id")
+
+    simbad_main_id: str | None = None
+    if main_id_raw:
+        cleaned = str(main_id_raw).strip()
+        if cleaned.startswith("V* "):
+            cleaned = cleaned[3:].strip()
+        simbad_main_id = cleaned if cleaned else None
 
     is_nova, is_classical_nova = _classify_otypes(all_otypes)
 
@@ -229,6 +239,7 @@ def _query_simbad(candidate_name: str) -> dict[str, Any] | None:
         "is_classical_nova": is_classical_nova,
         "resolved_epoch": "J2000",
         "aliases": _parse_simbad_ids(ids_raw),
+        "simbad_main_id": simbad_main_id,
     }
 
     if is_nova and ra is not None and dec is not None:

--- a/services/nova_resolver/handler.py
+++ b/services/nova_resolver/handler.py
@@ -290,6 +290,23 @@ def _upsert_minimal_nova_metadata(event: dict[str, Any], context: object) -> dic
     resolved_epoch: str = event.get("resolved_epoch") or "J2000"
     resolver_source: str = event.get("resolver_source") or "UNKNOWN"
     aliases: list[str] = event.get("aliases") or []
+    simbad_main_id: str | None = event.get("simbad_main_id")
+
+    # Determine effective primary name: prefer SIMBAD canonical name
+    # over raw ingestion candidate_name.
+    effective_name: str = candidate_name
+    effective_normalized: str = normalized_candidate_name
+    primary_source: str = "INGESTION"
+    demote_candidate: bool = False
+
+    if simbad_main_id:
+        simbad_normalized = re.sub(r"\s+", " ", simbad_main_id.strip().lower())
+        if simbad_normalized != normalized_candidate_name:
+            effective_name = simbad_main_id
+            effective_normalized = simbad_normalized
+            primary_source = "SIMBAD"
+            demote_candidate = True
+
     now = _now()
 
     # Update Nova item with coordinates, ACTIVE status, and aliases list
@@ -298,7 +315,9 @@ def _upsert_minimal_nova_metadata(event: dict[str, Any], context: object) -> dic
         UpdateExpression=(
             "SET ra_deg = :ra, dec_deg = :dec, coord_epoch = :epoch, "
             "coord_frame = :frame, resolver_source = :source, "
-            "#status = :status, aliases = :aliases, updated_at = :now"
+            "#status = :status, aliases = :aliases, "
+            "primary_name = :pname, primary_name_normalized = :pnorm, "
+            "updated_at = :now"
         ),
         ExpressionAttributeNames={"#status": "status"},
         ExpressionAttributeValues={
@@ -309,27 +328,48 @@ def _upsert_minimal_nova_metadata(event: dict[str, Any], context: object) -> dic
             ":source": resolver_source,
             ":status": "ACTIVE",
             ":aliases": aliases,
+            ":pname": effective_name,
+            ":pnorm": effective_normalized,
             ":now": now,
         },
     )
 
     # Write PRIMARY NameMapping
-    _check_name_collision(normalized_candidate_name, nova_id)
+    _check_name_collision(effective_normalized, nova_id)
     _table.put_item(
         Item={
-            "PK": f"NAME#{normalized_candidate_name}",
+            "PK": f"NAME#{effective_normalized}",
             "SK": f"NOVA#{nova_id}",
             "entity_type": "NameMapping",
             "schema_version": _SCHEMA_VERSION,
-            "name_raw": candidate_name,
-            "name_normalized": normalized_candidate_name,
+            "name_raw": effective_name,
+            "name_normalized": effective_normalized,
             "name_kind": "PRIMARY",
             "nova_id": nova_id,
-            "source": "INGESTION",
+            "source": primary_source,
             "created_at": now,
             "updated_at": now,
         }
     )
+
+    # Demote original candidate_name to ALIAS if SIMBAD name took over
+    if demote_candidate:
+        _check_name_collision(normalized_candidate_name, nova_id)
+        _table.put_item(
+            Item={
+                "PK": f"NAME#{normalized_candidate_name}",
+                "SK": f"NOVA#{nova_id}",
+                "entity_type": "NameMapping",
+                "schema_version": _SCHEMA_VERSION,
+                "name_raw": candidate_name,
+                "name_normalized": normalized_candidate_name,
+                "name_kind": "ALIAS",
+                "nova_id": nova_id,
+                "source": "INGESTION",
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
 
     # Write ALIAS NameMapping items for each SIMBAD alias
     alias_count = 0
@@ -337,7 +377,7 @@ def _upsert_minimal_nova_metadata(event: dict[str, Any], context: object) -> dic
         normalized_alias = re.sub(r"\s+", " ", alias_raw.replace("_", " ").strip().lower())
         if not normalized_alias:
             continue
-        if normalized_alias == normalized_candidate_name:
+        if normalized_alias in (normalized_candidate_name, effective_normalized):
             continue
         _check_name_collision(normalized_alias, nova_id)
         _table.put_item(
@@ -359,7 +399,12 @@ def _upsert_minimal_nova_metadata(event: dict[str, Any], context: object) -> dic
 
     logger.info(
         "Minimal nova metadata upserted",
-        extra={"nova_id": nova_id, "alias_count": alias_count},
+        extra={
+            "nova_id": nova_id,
+            "alias_count": alias_count,
+            "primary_name_overridden": demote_candidate,
+            "effective_primary_name": effective_name,
+        },
     )
     return {"nova_id": nova_id}
 

--- a/tests/integration/test_initialize_nova_integration.py
+++ b/tests/integration/test_initialize_nova_integration.py
@@ -277,6 +277,7 @@ class TestCreatedAndLaunched:
                 "resolved_epoch": "J2000",
                 "resolver_source": "SIMBAD",
                 "aliases": ["NOVA Test 2026", "Gaia DR3 1234567890"],
+                "simbad_main_id": "V1324 Sco",
             }
 
             with (
@@ -365,6 +366,7 @@ class TestCreatedAndLaunched:
                         "resolved_epoch": resolution["resolved_epoch"],
                         "resolver_source": resolution["resolver_source"],
                         "aliases": resolution.get("aliases", []),
+                        "simbad_main_id": resolution.get("simbad_main_id"),
                         "correlation_id": state["job_run"]["correlation_id"],
                         "job_run_id": state["job_run"]["job_run_id"],
                     },
@@ -420,6 +422,168 @@ class TestCreatedAndLaunched:
             assert len(alias2) == 1
             assert alias2[0]["name_kind"] == "ALIAS"
             assert alias2[0]["name_raw"] == "Gaia DR3 1234567890"
+
+
+# ---------------------------------------------------------------------------
+# Path 1b: CREATED_AND_LAUNCHED — SIMBAD name override
+# ---------------------------------------------------------------------------
+
+
+class TestSimbadNameOverride:
+    def test_simbad_main_id_overrides_primary_name(self, table: Any) -> None:
+        """When SIMBAD main_id differs from candidate_name, primary_name
+        is overridden and candidate_name becomes an alias."""
+        with mock_aws():
+            h = _load_handlers()
+
+            simbad_result = {
+                "is_nova": True,
+                "is_classical_nova": "true",
+                "resolved_ra": 271.5,
+                "resolved_dec": -31.5,
+                "resolved_epoch": "J2000",
+                "resolver_source": "SIMBAD",
+                "aliases": ["NOVA Sco 2012"],
+                "simbad_main_id": "V1324 Sco",
+            }
+
+            with (
+                patch.object(h["archive_resolver"], "_query_simbad", return_value=simbad_result),
+                patch.object(h["archive_resolver"], "_query_tns", return_value=None),
+                patch.object(h["workflow_launcher"], "_sfn") as mock_sfn,
+            ):
+                mock_sfn.exceptions.ExecutionAlreadyExists = type(
+                    "ExecutionAlreadyExists", (Exception,), {}
+                )
+                mock_sfn.start_execution.return_value = {"executionArn": _FAKE_EXECUTION_ARN}
+
+                state = _run_prefix(h, candidate_name="Nova Sco 2024")
+
+                name_check = h["nova_resolver"].handle(
+                    {
+                        "task_name": "CheckExistingNovaByName",
+                        "workflow_name": "initialize_nova",
+                        "normalized_candidate_name": state["normalization"][
+                            "normalized_candidate_name"
+                        ],
+                        "correlation_id": state["job_run"]["correlation_id"],
+                        "job_run_id": state["job_run"]["job_run_id"],
+                    },
+                    None,
+                )
+                assert name_check["exists"] is False
+
+                resolution = h["archive_resolver"].handle(
+                    {
+                        "task_name": "ResolveCandidateAgainstPublicArchives",
+                        "workflow_name": "initialize_nova",
+                        "candidate_name": state["candidate_name"],
+                        "normalized_candidate_name": state["normalization"][
+                            "normalized_candidate_name"
+                        ],
+                        "correlation_id": state["job_run"]["correlation_id"],
+                        "job_run_id": state["job_run"]["job_run_id"],
+                    },
+                    None,
+                )
+                assert resolution["is_nova"] is True
+
+                coord_check = h["nova_resolver"].handle(
+                    {
+                        "task_name": "CheckExistingNovaByCoordinates",
+                        "workflow_name": "initialize_nova",
+                        "resolved_ra": resolution["resolved_ra"],
+                        "resolved_dec": resolution["resolved_dec"],
+                        "resolved_epoch": resolution["resolved_epoch"],
+                        "correlation_id": state["job_run"]["correlation_id"],
+                        "job_run_id": state["job_run"]["job_run_id"],
+                    },
+                    None,
+                )
+                assert coord_check["match_outcome"] == "NONE"
+
+                nova_creation = h["nova_resolver"].handle(
+                    {
+                        "task_name": "CreateNovaId",
+                        "workflow_name": "initialize_nova",
+                        "candidate_name": state["candidate_name"],
+                        "normalized_candidate_name": state["normalization"][
+                            "normalized_candidate_name"
+                        ],
+                        "correlation_id": state["job_run"]["correlation_id"],
+                        "job_run_id": state["job_run"]["job_run_id"],
+                    },
+                    None,
+                )
+                nova_id = nova_creation["nova_id"]
+
+                h["nova_resolver"].handle(
+                    {
+                        "task_name": "UpsertMinimalNovaMetadata",
+                        "workflow_name": "initialize_nova",
+                        "nova_id": nova_id,
+                        "candidate_name": state["candidate_name"],
+                        "normalized_candidate_name": state["normalization"][
+                            "normalized_candidate_name"
+                        ],
+                        "resolved_ra": resolution["resolved_ra"],
+                        "resolved_dec": resolution["resolved_dec"],
+                        "resolved_epoch": resolution["resolved_epoch"],
+                        "resolver_source": resolution["resolver_source"],
+                        "aliases": resolution.get("aliases", []),
+                        "simbad_main_id": resolution.get("simbad_main_id"),
+                        "correlation_id": state["job_run"]["correlation_id"],
+                        "job_run_id": state["job_run"]["job_run_id"],
+                    },
+                    None,
+                )
+
+                h["workflow_launcher"].handle(
+                    {
+                        "task_name": "PublishIngestNewNova",
+                        "workflow_name": "initialize_nova",
+                        "outcome": "CREATED_AND_LAUNCHED",
+                        "nova_id": nova_id,
+                        "correlation_id": state["job_run"]["correlation_id"],
+                        "job_run_id": state["job_run"]["job_run_id"],
+                    },
+                    None,
+                )
+
+                _finalize_success(h, state, "CREATED_AND_LAUNCHED", nova_id=nova_id)
+
+            # Nova item has SIMBAD name as primary_name
+            nova_item = table.get_item(Key={"PK": nova_id, "SK": "NOVA"}).get("Item")
+            assert nova_item is not None
+            assert nova_item["primary_name"] == "V1324 Sco"
+            assert nova_item["primary_name_normalized"] == "v1324 sco"
+
+            # PRIMARY NameMapping uses SIMBAD name
+            primary = table.get_item(Key={"PK": "NAME#v1324 sco", "SK": f"NOVA#{nova_id}"}).get(
+                "Item"
+            )
+            assert primary is not None
+            assert primary["name_kind"] == "PRIMARY"
+            assert primary["name_raw"] == "V1324 Sco"
+            assert primary["source"] == "SIMBAD"
+
+            # Original candidate_name demoted to ALIAS
+            demoted_items = table.query(KeyConditionExpression=Key("PK").eq("NAME#nova sco 2024"))[
+                "Items"
+            ]
+            assert len(demoted_items) == 1
+            assert demoted_items[0]["name_kind"] == "ALIAS"
+            assert demoted_items[0]["name_raw"] == "Nova Sco 2024"
+            assert demoted_items[0]["source"] == "INGESTION"
+
+            # SIMBAD alias also written
+            alias_items = table.query(KeyConditionExpression=Key("PK").eq("NAME#nova sco 2012"))[
+                "Items"
+            ]
+            assert len(alias_items) == 1
+            assert alias_items[0]["name_kind"] == "ALIAS"
+            assert alias_items[0]["name_raw"] == "NOVA Sco 2012"
+            assert alias_items[0]["source"] == "SIMBAD"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_archive_resolver.py
+++ b/tests/services/test_archive_resolver.py
@@ -84,6 +84,7 @@ class TestSimbadClassification:
         assert result["is_nova"] is True
         assert result["is_classical_nova"] == "true"
         assert result["resolver_source"] == "SIMBAD"
+        assert result["simbad_main_id"] == "V1324 Sco"
 
     def test_recurrent_nova_otype(self) -> None:
         handler = _load_handler()
@@ -93,6 +94,7 @@ class TestSimbadClassification:
             result = handler.handle(_resolve_event(), None)
         assert result["is_nova"] is True
         assert result["is_classical_nova"] == "false"
+        assert result["simbad_main_id"] == "V1324 Sco"
 
     def test_non_nova_otype(self) -> None:
         handler = _load_handler()
@@ -101,6 +103,7 @@ class TestSimbadClassification:
         ):
             result = handler.handle(_resolve_event(), None)
         assert result["is_nova"] is False
+        assert result["simbad_main_id"] == "V1324 Sco"
 
     def test_coordinates_present_for_nova(self) -> None:
         handler = _load_handler()
@@ -109,6 +112,28 @@ class TestSimbadClassification:
         assert "resolved_ra" in result
         assert "resolved_dec" in result
         assert result["resolved_epoch"] == "J2000"
+
+    def test_simbad_main_id_strips_v_star_prefix(self) -> None:
+        """main_id with 'V* ' prefix is stripped to bare name."""
+        handler = _load_handler()
+        rows = []
+        row = MagicMock()
+        row.__getitem__ = lambda self, col: {
+            "otypes.otype_txt": "No*",
+            "ra": 271.08,
+            "dec": -32.46,
+            "main_id": "V* V1324 Sco",
+            "ids": "V* V1324 Sco|Nova Sco 2012",
+        }[col]
+        rows.append(row)
+        tbl = MagicMock()
+        tbl.__len__ = lambda self: len(rows)
+        tbl.__iter__ = lambda self: iter(rows)
+        tbl.__getitem__ = lambda self, idx: rows[idx]
+
+        with patch.object(handler._simbad, "query_object", return_value=tbl):
+            result = handler.handle(_resolve_event(), None)
+        assert result["simbad_main_id"] == "V1324 Sco"
 
     def test_no_coordinates_for_non_nova(self) -> None:
         handler = _load_handler()
@@ -130,6 +155,7 @@ class TestNoResult:
             result = handler.handle(_resolve_event(), None)
         assert result["is_nova"] is False
         assert result["resolver_source"] == "NONE"
+        assert result["simbad_main_id"] is None
 
     def test_simbad_empty_table_treated_as_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("TNS_API_KEY", "")

--- a/tests/services/test_asl_contracts.py
+++ b/tests/services/test_asl_contracts.py
@@ -140,6 +140,7 @@ TASK_RETURN_SHAPES: dict[str, set[str]] = {
         "resolved_ra",
         "resolved_dec",
         "resolved_epoch",
+        "simbad_main_id",
     },
     # -- ticket_parser (services/ticket_parser/handler.py) -------------------
     "ParseTicket": {"ticket_type", "object_name", "ticket"},


### PR DESCRIPTION
## Summary
- `archive_resolver` now extracts `main_id` from SIMBAD query results and returns it as `simbad_main_id` (with `V* ` prefix stripped)
- ASL threads `simbad_main_id` through to `UpsertMinimalNovaMetadata`
- `nova_resolver` overrides `primary_name` with the SIMBAD canonical name when it differs from the raw `candidate_name`; the original ingestion name is demoted to an ALIAS NameMapping
- Updated ASL contract test shapes, archive_resolver unit tests, and initialize_nova integration tests

## Why
- Novae ingested from machine-readable tables carried underscore-laden names (e.g. `V1324_Sco` instead of `V1324 Sco`) because `primary_name` was set from the raw `candidate_name` and never updated after SIMBAD resolution
- SIMBAD's `main_id` is the authoritative canonical identifier — the pipeline already queried it but wasn't using it
- Affects display names across the frontend catalog, artifact metadata, and data bundles

## Testing
- `mypy --strict`, `ruff check`, `ruff format --check` pass on all modified files
- `test_archive_resolver.py`: 17 tests pass (added `simbad_main_id` assertions + V* prefix stripping test)
- `test_asl_contracts.py`: contract validation passes with new `simbad_main_id` field in return shape
- `test_initialize_nova_integration.py`: 9 tests pass (added `TestSimbadNameOverride` class verifying primary_name override and candidate demotion to alias)
- ASL JSON validates cleanly

## Notes
- When `simbad_main_id` matches `candidate_name` (normalized), no override occurs — existing behavior is preserved
- No `primary_name_pinned` escape hatch yet — SIMBAD always wins. Can add later if a community-preferred name ever diverges from SIMBAD

## Next Steps
- B20: Backfill script to re-resolve existing 17 novae against SIMBAD and update `primary_name` + NameMappings
- B21: Additional integration test coverage for edge cases (covered by B20 validation)