### PR TITLE
fix(artifact-gen): fix upper limit handling, spectral visits, and nova page enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ tools/svo-filter-analysis/svo_fps.db-wal
 /tools/filter_band_reg/parse_radio_table/data
 /tools/filter_band_reg/parse_radio_table
 /tools/filter_band_reg/parse_strope_table/data
+/tools/filter_band_reg/spectra_tickets

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/components/nova/ObjectSummary.tsx
+++ b/frontend/src/components/nova/ObjectSummary.tsx
@@ -133,6 +133,11 @@ export default function ObjectSummary({ nova, bundleHref }: ObjectSummaryProps) 
         <MetaRow label="Discovery">
           <span className="text-[var(--color-text-primary)]">
             {formatDiscoveryDate(nova.discovery_date)}
+            {nova.discovery_date_mjd != null && (
+              <span className="text-[var(--color-text-tertiary)]">
+                {' '}(MJD {nova.discovery_date_mjd.toFixed(1)})
+              </span>
+            )}
           </span>
         </MetaRow>
 
@@ -153,6 +158,14 @@ export default function ObjectSummary({ nova, bundleHref }: ObjectSummaryProps) 
         <MetaRow label="Spectra">
           <span className="font-mono tabular-nums text-[var(--color-text-primary)]">
             {nova.spectra_count}
+          </span>
+        </MetaRow>
+
+        <MetaRow label="Spectral visits">
+          <span className="font-mono tabular-nums text-[var(--color-text-primary)]">
+            {nova.spectral_visits > 0
+              ? `${nova.spectral_visits} night${nova.spectral_visits !== 1 ? 's' : ''}`
+              : '—'}
           </span>
         </MetaRow>
 

--- a/frontend/src/types/nova.ts
+++ b/frontend/src/types/nova.ts
@@ -24,9 +24,13 @@ export interface NovaMetadata {
    * Examples: "1901-02-22", "1901-02-00", "1901-00-00"
    */
   discovery_date: string;
+  /** Discovery date as MJD; null when discovery_date is absent. */
+  discovery_date_mjd: number | null;
   nova_type: string;
   spectra_count: number;
   photometry_count: number;
+  /** Count of distinct observing nights with spectra. */
+  spectral_visits: number;
 }
 
 // ── References artifact (references.json) ─────────────────────────────────────

--- a/services/artifact_finalizer/handler.py
+++ b/services/artifact_finalizer/handler.py
@@ -287,7 +287,7 @@ def _write_observation_counts(
     """Write observation counts to the Nova DDB item (§4.5, §11.10).
 
     Fields written: ``spectra_count``, ``photometry_count``,
-    ``references_count``, ``has_sparkline``.
+    ``references_count``, ``has_sparkline``, ``spectral_visits``.
     """
     _table.update_item(
         Key={"PK": nova_id, "SK": "NOVA"},
@@ -295,13 +295,15 @@ def _write_observation_counts(
             "SET spectra_count = :sc, "
             "photometry_count = :pc, "
             "references_count = :rc, "
-            "has_sparkline = :hs"
+            "has_sparkline = :hs, "
+            "spectral_visits = :sv"
         ),
         ExpressionAttributeValues={
             ":sc": result.get("spectra_count", 0),
             ":pc": result.get("photometry_count", 0),
             ":rc": result.get("references_count", 0),
             ":hs": result.get("has_sparkline", False),
+            ":sv": result.get("spectral_visits", 0),
         },
     )
 

--- a/services/artifact_generator/generators/nova.py
+++ b/services/artifact_generator/generators/nova.py
@@ -23,7 +23,7 @@ import logging
 from decimal import Decimal
 from typing import Any
 
-from generators.shared import format_coordinates, generated_at_timestamp
+from generators.shared import discovery_date_to_mjd, format_coordinates, generated_at_timestamp
 
 _logger = logging.getLogger("artifact_generator")
 
@@ -74,9 +74,17 @@ def generate_nova_json(
     # Nova type (§5.3) — null until post-MVP enrichment.
     nova_type: str | None = nova_item.get("nova_type")
 
+    # Discovery date as MJD (null when discovery_date is absent).
+    discovery_date_mjd: float | None = None
+    if discovery_date is not None:
+        discovery_date_mjd = round(discovery_date_to_mjd(discovery_date), 1)
+
     # Observation counts from upstream generators (§5.4).
     spectra_count: int = nova_context.get("spectra_count", 0)
     photometry_count: int = nova_context.get("photometry_count", 0)
+
+    # Spectral visits (distinct observing nights with spectra).
+    spectral_visits: int = nova_context.get("spectral_visits", 0)
 
     return {
         "schema_version": _SCHEMA_VERSION,
@@ -88,8 +96,10 @@ def generate_nova_json(
         "dec": dec_str,
         "discovery_date": discovery_date,
         "nova_type": nova_type,
+        "discovery_date_mjd": discovery_date_mjd,
         "spectra_count": spectra_count,
         "photometry_count": photometry_count,
+        "spectral_visits": spectral_visits,
     }
 
 

--- a/services/artifact_generator/generators/photometry.py
+++ b/services/artifact_generator/generators/photometry.py
@@ -361,7 +361,7 @@ def _classify_rows(
 
 def _has_measurement(item: dict[str, Any]) -> bool:
     """Return True if the item has at least one non-null measurement field."""
-    for field in ("magnitude", "flux_density", "count_rate", "photon_flux"):
+    for field in ("magnitude", "flux_density", "count_rate", "photon_flux", "limiting_value"):
         val = item.get(field)
         if val is not None:
             return True
@@ -845,6 +845,21 @@ def _build_observation_record(
     elif regime == "radio":
         flux = _to_float_or_none(row.get("flux_density"))
         flux_err = _to_float_or_none(row.get("flux_density_err"))
+
+    # Upper-limit fallback: populate the regime's primary field from
+    # limiting_value when the normal source field is NULL (non-optical
+    # upper limits store the value only in limiting_value).
+    if row.get("is_upper_limit", False):
+        lv = _to_float_or_none(row.get("limiting_value"))
+        if lv is not None:
+            if regime == "optical" and mag is None:
+                mag = lv
+            elif regime == "radio" and flux is None:
+                flux = lv
+            elif regime == "xray" and count is None:
+                count = lv
+            elif regime == "gamma" and photon is None:
+                photon = lv
 
     # Provider fallback chain (§8.9): orig_catalog → bibcode → "unknown".
     provider = row.get("orig_catalog") or row.get("bibcode") or "unknown"

--- a/services/artifact_generator/generators/shared.py
+++ b/services/artifact_generator/generators/shared.py
@@ -109,6 +109,16 @@ def resolve_outburst_mjd(
     return None, False
 
 
+def discovery_date_to_mjd(discovery_date: str) -> float:
+    """Convert a ``YYYY-MM-DD`` discovery date string to MJD.
+
+    Handles the ``00`` convention for imprecise dates (same as
+    ``resolve_outburst_mjd``): day ``00`` → 1st, month+day ``00-00``
+    → January 1st.
+    """
+    return _outburst_from_discovery_date(discovery_date)
+
+
 def _outburst_from_discovery_date(discovery_date: str) -> float:
     """Parse a ``YYYY-MM-DD`` discovery date to MJD.
 

--- a/services/artifact_generator/generators/spectra.py
+++ b/services/artifact_generator/generators/spectra.py
@@ -34,6 +34,7 @@ from typing import Any
 import numpy as np
 from boto3.dynamodb.conditions import Attr, Key
 
+from generators.compositing import cluster_by_night
 from generators.shared import (
     generated_at_timestamp,
     reject_chip_gap_artifacts,
@@ -485,14 +486,16 @@ def generate_spectra_json(
     # Step 5 — Update context.
     nova_context["spectra_count"] = len(individual_products)
 
-    # Group by integer MJD (floor) to count distinct nights.
-    distinct_nights = len(
-        {
-            int(float(p["observation_date_mjd"]))
-            for p in individual_products
-            if p.get("observation_date_mjd") is not None
-        }
-    )
+    # Count distinct observing nights using gap-based clustering
+    # (same algorithm as the compositing pipeline — ADR-033 Decision 2).
+    products_with_mjd = [
+        p for p in individual_products if p.get("observation_date_mjd") is not None
+    ]
+    if products_with_mjd:
+        night_groups = cluster_by_night(products_with_mjd)
+        distinct_nights = len(night_groups)
+    else:
+        distinct_nights = 0
     nova_context["spectral_visits"] = distinct_nights
 
     _logger.info(

--- a/services/artifact_generator/main.py
+++ b/services/artifact_generator/main.py
@@ -707,8 +707,6 @@ def main() -> None:
             )
 
     # Step 8 — Write results back to the plan.
-    # TODO: Add spectral_visits to Finalize Lambda writeback
-    # (services/artifact_finalizer/handler.py — _write_observation_counts)
     _write_results_to_plan(plan, nova_results)
 
     _logger.info(

--- a/tests/services/artifact_generator/test_generators_spectra.py
+++ b/tests/services/artifact_generator/test_generators_spectra.py
@@ -904,13 +904,13 @@ class TestSpectralVisits:
             yield tbl
 
     def test_three_nights_from_six_spectra(self, ddb_table: Any) -> None:
-        """6 spectra across 3 distinct integer-MJD nights → spectral_visits = 3."""
+        """6 spectra across 3 distinct nights (gap-based clustering) → spectral_visits = 3."""
         _seed_spectra_product(ddb_table, _SV_NOVA_ID, "p1", observation_date_mjd=Decimal("59234.1"))
-        _seed_spectra_product(ddb_table, _SV_NOVA_ID, "p2", observation_date_mjd=Decimal("59234.8"))
-        _seed_spectra_product(ddb_table, _SV_NOVA_ID, "p3", observation_date_mjd=Decimal("59235.3"))
-        _seed_spectra_product(ddb_table, _SV_NOVA_ID, "p4", observation_date_mjd=Decimal("59235.9"))
-        _seed_spectra_product(ddb_table, _SV_NOVA_ID, "p5", observation_date_mjd=Decimal("59240.2"))
-        _seed_spectra_product(ddb_table, _SV_NOVA_ID, "p6", observation_date_mjd=Decimal("59240.7"))
+        _seed_spectra_product(ddb_table, _SV_NOVA_ID, "p2", observation_date_mjd=Decimal("59234.4"))
+        _seed_spectra_product(ddb_table, _SV_NOVA_ID, "p3", observation_date_mjd=Decimal("59235.1"))
+        _seed_spectra_product(ddb_table, _SV_NOVA_ID, "p4", observation_date_mjd=Decimal("59235.4"))
+        _seed_spectra_product(ddb_table, _SV_NOVA_ID, "p5", observation_date_mjd=Decimal("59240.1"))
+        _seed_spectra_product(ddb_table, _SV_NOVA_ID, "p6", observation_date_mjd=Decimal("59240.4"))
 
         ctx = _make_sv_context()
         generate_spectra_json(_SV_NOVA_ID, ddb_table, _stub_s3(), "test-bucket", ctx)
@@ -919,14 +919,31 @@ class TestSpectralVisits:
         assert ctx["spectral_visits"] == 3
 
     def test_same_night_counts_as_one(self, ddb_table: Any) -> None:
-        """2 spectra on the same night (MJD 59234.1 and 59234.8) → spectral_visits = 1."""
+        """2 spectra on the same night (gap < 0.5d) → spectral_visits = 1."""
         _seed_spectra_product(ddb_table, _SV_NOVA_ID, "p1", observation_date_mjd=Decimal("59234.1"))
-        _seed_spectra_product(ddb_table, _SV_NOVA_ID, "p2", observation_date_mjd=Decimal("59234.8"))
+        _seed_spectra_product(ddb_table, _SV_NOVA_ID, "p2", observation_date_mjd=Decimal("59234.4"))
 
         ctx = _make_sv_context()
         generate_spectra_json(_SV_NOVA_ID, ddb_table, _stub_s3(), "test-bucket", ctx)
 
         assert ctx["spectra_count"] == 2
+        assert ctx["spectral_visits"] == 1
+
+    def test_midnight_spanning_run_counts_as_one_night(self, ddb_table: Any) -> None:
+        """Two spectra straddling midnight (gap < 0.5d) count as one night."""
+        _seed_spectra_product(
+            ddb_table, _SV_NOVA_ID, "p1", observation_date_mjd=Decimal("59234.95")
+        )
+        _seed_spectra_product(
+            ddb_table, _SV_NOVA_ID, "p2", observation_date_mjd=Decimal("59235.05")
+        )
+
+        ctx = _make_sv_context()
+        generate_spectra_json(_SV_NOVA_ID, ddb_table, _stub_s3(), "test-bucket", ctx)
+
+        assert ctx["spectra_count"] == 2
+        # MJD 59234.95 and 59235.05 have different integer floors (59234 vs 59235)
+        # but gap = 0.1 < 0.5 threshold, so they are one observing night.
         assert ctx["spectral_visits"] == 1
 
     def test_zero_spectra(self, ddb_table: Any) -> None:

--- a/tests/services/test_artifact_finalizer.py
+++ b/tests/services/test_artifact_finalizer.py
@@ -204,6 +204,7 @@ def _success_result(
     photometry_count: int = 12,
     references_count: int = 3,
     has_sparkline: bool = True,
+    spectral_visits: int = 0,
 ) -> dict[str, Any]:
     return {
         "nova_id": nova_id,
@@ -213,6 +214,7 @@ def _success_result(
         "photometry_count": photometry_count,
         "references_count": references_count,
         "has_sparkline": has_sparkline,
+        "spectral_visits": spectral_visits,
     }
 
 
@@ -293,6 +295,7 @@ class TestFinalizeAllSucceed:
                         photometry_count=42,
                         references_count=3,
                         has_sparkline=True,
+                        spectral_visits=4,
                     )
                 ],
                 workitem_sks=[],
@@ -303,6 +306,7 @@ class TestFinalizeAllSucceed:
         assert nova["photometry_count"] == 42
         assert nova["references_count"] == 3
         assert nova["has_sparkline"] is True
+        assert nova["spectral_visits"] == 4
 
     def test_sets_plan_status_completed(self, table: Any) -> None:
         with mock_aws():

--- a/tests/services/test_generators_nova.py
+++ b/tests/services/test_generators_nova.py
@@ -37,6 +37,7 @@ import re
 from decimal import Decimal
 from typing import Any
 
+import pytest
 from generators.nova import generate_nova_json
 
 # ---------------------------------------------------------------------------
@@ -77,6 +78,7 @@ def _make_context(
     *,
     spectra_count: int = 24,
     photometry_count: int = 1840,
+    spectral_visits: int = 3,
 ) -> dict[str, Any]:
     return {
         "nova_item": nova,
@@ -84,6 +86,7 @@ def _make_context(
         "outburst_mjd_is_estimated": False,
         "spectra_count": spectra_count,
         "photometry_count": photometry_count,
+        "spectral_visits": spectral_visits,
     }
 
 
@@ -126,6 +129,31 @@ class TestCoordinateFormatting:
 # ---------------------------------------------------------------------------
 # Discovery date
 # ---------------------------------------------------------------------------
+
+
+class TestDiscoveryDateMjd:
+    def test_precise_date_converted_to_mjd(self) -> None:
+        ctx = _make_context(_nova_item(discovery_date="2021-06-12"))
+        artifact = generate_nova_json(_NOVA_ID, ctx)
+        # 2021-06-12 = MJD 59377.0
+        assert artifact["discovery_date_mjd"] == pytest.approx(59377.0, abs=0.5)
+
+    def test_imprecise_month_defaults_day_to_first(self) -> None:
+        ctx = _make_context(_nova_item(discovery_date="2021-06-00"))
+        artifact = generate_nova_json(_NOVA_ID, ctx)
+        # 2021-06-01 = MJD 59366.0
+        assert artifact["discovery_date_mjd"] == pytest.approx(59366.0, abs=0.5)
+
+    def test_imprecise_year_defaults_to_jan_first(self) -> None:
+        ctx = _make_context(_nova_item(discovery_date="2021-00-00"))
+        artifact = generate_nova_json(_NOVA_ID, ctx)
+        # 2021-01-01 = MJD 59215.0
+        assert artifact["discovery_date_mjd"] == pytest.approx(59215.0, abs=0.5)
+
+    def test_null_when_no_discovery_date(self) -> None:
+        ctx = _make_context(_nova_item(discovery_date=None))
+        artifact = generate_nova_json(_NOVA_ID, ctx)
+        assert artifact["discovery_date_mjd"] is None
 
 
 class TestDiscoveryDate:
@@ -184,6 +212,16 @@ class TestObservationCounts:
         artifact = generate_nova_json(_NOVA_ID, ctx)
         assert artifact["spectra_count"] == 0
         assert artifact["photometry_count"] == 0
+
+    def test_spectral_visits_from_context(self) -> None:
+        ctx = _make_context(_nova_item(), spectral_visits=5)
+        artifact = generate_nova_json(_NOVA_ID, ctx)
+        assert artifact["spectral_visits"] == 5
+
+    def test_missing_spectral_visits_defaults_to_zero(self) -> None:
+        ctx = {"nova_item": _nova_item()}
+        artifact = generate_nova_json(_NOVA_ID, ctx)
+        assert artifact["spectral_visits"] == 0
 
 
 # ---------------------------------------------------------------------------
@@ -246,8 +284,10 @@ class TestSchema:
             "ra",
             "dec",
             "discovery_date",
+            "discovery_date_mjd",
             "nova_type",
             "spectra_count",
             "photometry_count",
+            "spectral_visits",
         }
         assert set(artifact.keys()) == expected

--- a/tests/services/test_generators_photometry.py
+++ b/tests/services/test_generators_photometry.py
@@ -152,6 +152,7 @@ def _seed_phot_row(
     flux_density: float | None = None,
     flux_density_err: float | None = None,
     is_upper_limit: bool = False,
+    limiting_value: float | None = None,
     telescope: str | None = "CTIO 1.3m",
     instrument: str | None = "ANDICAM",
     observer: str | None = None,
@@ -188,6 +189,8 @@ def _seed_phot_row(
         item["bibcode"] = bibcode
     if band_name is not None:
         item["band_name"] = band_name
+    if limiting_value is not None:
+        item["limiting_value"] = Decimal(str(limiting_value))
     table.put_item(Item=item)
 
 
@@ -596,6 +599,86 @@ class TestValueRouting:
         )
         obs = artifact["observations"][0]
         assert obs["photon_flux"] == pytest.approx(1.2e-7)
+
+
+# ---------------------------------------------------------------------------
+# Radio upper limit routing
+# ---------------------------------------------------------------------------
+
+
+class TestRadioUpperLimitRouting:
+    """Radio upper limits (flux_density=None, limiting_value=<val>) must survive
+    classification and appear in the output with flux_density populated."""
+
+    def test_radio_upper_limit_included_in_output(self, phot_table: Any, main_table: Any) -> None:
+        """A radio upper limit with only limiting_value set must appear in output."""
+        _seed_phot_row(
+            phot_table,
+            _NOVA_ID,
+            "rul1",
+            regime="radio",
+            band_id="Radio_34.8_GHz",
+            magnitude=None,
+            mag_err=None,
+            flux_density=None,
+            flux_density_err=None,
+            is_upper_limit=True,
+            limiting_value=0.13,
+        )
+        ctx = _base_context()
+        artifact = generate_photometry_json(_NOVA_ID, phot_table, main_table, _REGISTRY, ctx)
+        assert len(artifact["observations"]) == 1
+        obs = artifact["observations"][0]
+        assert obs["is_upper_limit"] is True
+        assert obs["flux_density"] == pytest.approx(0.13)
+        assert obs["regime"] == "radio"
+        assert obs["magnitude"] is None
+        assert obs["count_rate"] is None
+        assert obs["photon_flux"] is None
+
+    def test_optical_upper_limit_with_only_limiting_value(
+        self, phot_table: Any, main_table: Any
+    ) -> None:
+        """An optical upper limit with magnitude=None, limiting_value set."""
+        _seed_phot_row(
+            phot_table,
+            _NOVA_ID,
+            "oul1",
+            regime="optical",
+            band_id="Generic_V",
+            magnitude=None,
+            mag_err=None,
+            is_upper_limit=True,
+            limiting_value=18.5,
+        )
+        ctx = _base_context()
+        artifact = generate_photometry_json(_NOVA_ID, phot_table, main_table, _REGISTRY, ctx)
+        assert len(artifact["observations"]) == 1
+        obs = artifact["observations"][0]
+        assert obs["is_upper_limit"] is True
+        assert obs["magnitude"] == pytest.approx(18.5)
+        assert obs["flux_density"] is None
+
+    def test_radio_detection_unchanged(self, phot_table: Any, main_table: Any) -> None:
+        """A normal radio detection (flux_density set, no limiting_value) is unaffected."""
+        _seed_phot_row(
+            phot_table,
+            _NOVA_ID,
+            "rd1",
+            regime="radio",
+            band_id="Radio_34.8_GHz",
+            magnitude=None,
+            mag_err=None,
+            flux_density=0.5,
+            flux_density_err=0.05,
+            is_upper_limit=False,
+        )
+        ctx = _base_context()
+        artifact = generate_photometry_json(_NOVA_ID, phot_table, main_table, _REGISTRY, ctx)
+        assert len(artifact["observations"]) == 1
+        obs = artifact["observations"][0]
+        assert obs["is_upper_limit"] is False
+        assert obs["flux_density"] == pytest.approx(0.5)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/fix_underscore_names.py
+++ b/tools/fix_underscore_names.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Replace underscores with spaces in Nova primary_name fields.
+
+Scans all ACTIVE Nova items, finds any with underscores in primary_name,
+and updates the display name. Does NOT touch primary_name_normalized or
+NameMappings (those already have spaces).
+
+Dry-run by default. Pass --execute to apply.
+
+Usage:
+    python tools/fix_underscore_names.py
+    python tools/fix_underscore_names.py --execute
+
+Operator tooling — not subject to CI, mypy strict, or ruff.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import UTC, datetime
+
+import boto3
+
+TABLE_NAME = "NovaCat"
+REGION = "us-east-1"
+
+GREEN = "\033[92m"
+RED = "\033[91m"
+YELLOW = "\033[93m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+RESET = "\033[0m"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Fix underscores in Nova primary_name.")
+    parser.add_argument("--execute", action="store_true", help="Apply changes.")
+    parser.add_argument("--region", default=REGION)
+    args = parser.parse_args()
+
+    dry_run = not args.execute
+    table = boto3.resource("dynamodb", region_name=args.region).Table(TABLE_NAME)
+
+    # Scan all Nova items
+    items = []
+    kwargs = {
+        "FilterExpression": "entity_type = :et AND SK = :sk",
+        "ExpressionAttributeValues": {":et": "Nova", ":sk": "NOVA"},
+        "ProjectionExpression": "PK, primary_name, nova_id",
+    }
+    while True:
+        resp = table.scan(**kwargs)
+        items.extend(resp.get("Items", []))
+        if resp.get("LastEvaluatedKey") is None:
+            break
+        kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+
+    items.sort(key=lambda x: x.get("primary_name", ""))
+
+    if dry_run:
+        print(f"\n  {YELLOW}DRY RUN — pass --execute to apply.{RESET}\n")
+
+    needs_fix = [i for i in items if "_" in i.get("primary_name", "")]
+    no_fix = [i for i in items if "_" not in i.get("primary_name", "")]
+
+    print(f"  Total novae: {len(items)}")
+    print(f"  Need fixing: {len(needs_fix)}")
+    print(f"  Already OK:  {len(no_fix)}\n")
+
+    if not needs_fix:
+        print(f"  {GREEN}Nothing to fix.{RESET}\n")
+        return
+
+    now = datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+    fixed = 0
+
+    for item in needs_fix:
+        old_name = item["primary_name"]
+        new_name = old_name.replace("_", " ")
+        nova_id = item["nova_id"]
+
+        print(f"  {old_name:25s} → {new_name}", end="")
+
+        if dry_run:
+            print(f"  {DIM}(dry run){RESET}")
+        else:
+            table.update_item(
+                Key={"PK": nova_id, "SK": "NOVA"},
+                UpdateExpression="SET primary_name = :pn, updated_at = :now",
+                ExpressionAttributeValues={":pn": new_name, ":now": now},
+            )
+            print(f"  {GREEN}✓{RESET}")
+            fixed += 1
+
+    print(f"\n  {BOLD}{'Would fix' if dry_run else 'Fixed'}: {len(needs_fix)} novae{RESET}")
+    if dry_run:
+        print(f"  {YELLOW}Run with --execute to apply.{RESET}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/investigate_upper_limits.py
+++ b/tools/investigate_upper_limits.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""
+Investigate missing upper limits for a nova.
+
+Compares DynamoDB photometry rows (source of truth) against the published
+photometry.json artifact in S3 to identify where upper limits are being
+lost in the pipeline.
+
+Usage:
+    python investigate_upper_limits.py --nova "V5588 Sgr"
+    python investigate_upper_limits.py --nova-id b8009ab4-9f35-486d-a071-ea4fc9490a85
+    python investigate_upper_limits.py --nova "V5588 Sgr" --bucket my-bucket
+
+Operator tooling — not subject to CI, mypy strict, or ruff.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from decimal import Decimal
+
+import boto3
+from boto3.dynamodb.conditions import Key
+
+# ── Config ──────────────────────────────────────────────────────────────────
+MAIN_TABLE = "NovaCat"
+PHOT_TABLE = "NovaCatPhotometry"
+REGION = "us-east-1"
+
+GREEN = "\033[92m"
+RED = "\033[91m"
+YELLOW = "\033[93m"
+CYAN = "\033[96m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+RESET = "\033[0m"
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _dec(v):
+    """Convert Decimal to float for display."""
+    if isinstance(v, Decimal):
+        return float(v)
+    return v
+
+
+def _section(title: str) -> None:
+    print(f"\n{BOLD}{'─' * 60}{RESET}")
+    print(f"{BOLD}  {title}{RESET}")
+    print(f"{BOLD}{'─' * 60}{RESET}")
+
+
+def _ok(msg: str) -> None:
+    print(f"  {GREEN}✓{RESET} {msg}")
+
+
+def _warn(msg: str) -> None:
+    print(f"  {YELLOW}⚠{RESET} {msg}")
+
+
+def _fail(msg: str) -> None:
+    print(f"  {RED}✗{RESET} {msg}")
+
+
+def _info(msg: str) -> None:
+    print(f"  {CYAN}ℹ{RESET} {msg}")
+
+
+# ── Name resolution ────────────────────────────────────────────────────────
+
+
+def resolve_nova_id(main_table, name: str) -> str | None:
+    normalized = re.sub(r"\s+", " ", name.strip().lower())
+    resp = main_table.query(
+        KeyConditionExpression=Key("PK").eq(f"NAME#{normalized}"),
+        Limit=1,
+    )
+    items = resp.get("Items", [])
+    if not items:
+        return None
+    return items[0].get("nova_id")
+
+
+def get_nova_item(main_table, nova_id: str) -> dict | None:
+    resp = main_table.get_item(Key={"PK": nova_id, "SK": "NOVA"})
+    return resp.get("Item")
+
+
+# ── DynamoDB photometry query ──────────────────────────────────────────────
+
+
+def query_all_phot_rows(phot_table, nova_id: str) -> list[dict]:
+    """Paginated query for all PHOT# rows."""
+    rows = []
+    kwargs = dict(
+        KeyConditionExpression=Key("PK").eq(nova_id) & Key("SK").begins_with("PHOT#"),
+    )
+    while True:
+        resp = phot_table.query(**kwargs)
+        rows.extend(resp.get("Items", []))
+        last = resp.get("LastEvaluatedKey")
+        if not last:
+            break
+        kwargs["ExclusiveStartKey"] = last
+    return rows
+
+
+# ── S3 artifact query ──────────────────────────────────────────────────────
+
+
+def get_current_release(s3, bucket: str) -> str | None:
+    try:
+        resp = s3.get_object(Bucket=bucket, Key="current.json")
+        pointer = json.loads(resp["Body"].read().decode("utf-8"))
+        return pointer.get("release_id")
+    except Exception as exc:
+        print(f"  Could not read current.json: {exc}")
+        return None
+
+
+def get_photometry_json(s3, bucket: str, release_id: str, nova_id: str) -> dict | None:
+    key = f"releases/{release_id}/nova/{nova_id}/photometry.json"
+    try:
+        resp = s3.get_object(Bucket=bucket, Key=key)
+        return json.loads(resp["Body"].read().decode("utf-8"))
+    except s3.exceptions.NoSuchKey:
+        return None
+    except Exception as exc:
+        print(f"  Error reading photometry.json: {exc}")
+        return None
+
+
+def list_nova_artifacts(s3, bucket: str, release_id: str, nova_id: str) -> list[str]:
+    prefix = f"releases/{release_id}/nova/{nova_id}/"
+    try:
+        resp = s3.list_objects_v2(Bucket=bucket, Prefix=prefix)
+        return [obj["Key"].split("/")[-1] for obj in resp.get("Contents", [])]
+    except Exception:
+        return []
+
+
+# ── Analysis ───────────────────────────────────────────────────────────────
+
+
+def analyze_ddb_rows(rows: list[dict]) -> None:
+    _section("DynamoDB Photometry Rows")
+
+    if not rows:
+        _fail("No photometry rows found in DynamoDB.")
+        return
+
+    _ok(f"Total rows: {len(rows)}")
+
+    # Split by upper limit
+    detections = [r for r in rows if not r.get("is_upper_limit", False)]
+    upper_limits = [r for r in rows if r.get("is_upper_limit", False)]
+
+    _info(f"Detections: {len(detections)}")
+    _info(f"Upper limits: {len(upper_limits)}")
+
+    if not upper_limits:
+        _warn("No upper limits in DynamoDB — nothing to investigate downstream.")
+        return
+
+    # Check upper limit data quality
+    _section("Upper Limit Data Quality (DynamoDB)")
+
+    ul_with_limiting = [r for r in upper_limits if r.get("limiting_value") is not None]
+    ul_without_limiting = [r for r in upper_limits if r.get("limiting_value") is None]
+    ul_with_flux = [r for r in upper_limits if r.get("flux_density") is not None]
+
+    _info(f"Upper limits with limiting_value: {len(ul_with_limiting)}")
+    if ul_without_limiting:
+        _fail(f"Upper limits MISSING limiting_value: {len(ul_without_limiting)}")
+        for r in ul_without_limiting[:5]:
+            print(
+                f"    MJD={_dec(r.get('time_mjd'))}, band={r.get('band_id')}, "
+                f"flux_density={_dec(r.get('flux_density'))}"
+            )
+    else:
+        _ok("All upper limits have limiting_value populated.")
+
+    if ul_with_flux:
+        _warn(
+            f"Upper limits with non-null flux_density: {len(ul_with_flux)} "
+            "(expected None for radio ULs)"
+        )
+    else:
+        _ok("All upper limits have flux_density=None (correct for radio).")
+
+    # Band breakdown
+    _section("Band Breakdown (DynamoDB)")
+
+    band_counts: Counter = Counter()
+    band_ul_counts: Counter = Counter()
+    for r in rows:
+        band = r.get("band_id", "?")
+        band_counts[band] += 1
+        if r.get("is_upper_limit", False):
+            band_ul_counts[band] += 1
+
+    print(f"  {'Band':<25s} {'Total':>6s} {'ULs':>6s}")
+    print(f"  {'─' * 40}")
+    for band in sorted(band_counts.keys()):
+        total = band_counts[band]
+        uls = band_ul_counts.get(band, 0)
+        marker = f" {YELLOW}← has ULs{RESET}" if uls > 0 else ""
+        print(f"  {band:<25s} {total:>6d} {uls:>6d}{marker}")
+
+    # Regime breakdown
+    regimes = Counter(r.get("regime", "?") for r in rows)
+    _info(f"Regimes: {dict(regimes)}")
+
+
+def analyze_artifact(artifact: dict, ddb_upper_limits: list[dict]) -> None:
+    _section("Published Artifact (photometry.json)")
+
+    observations = artifact.get("observations", [])
+    _info(f"Total observations in artifact: {len(observations)}")
+
+    art_detections = [o for o in observations if not o.get("is_upper_limit", False)]
+    art_uls = [o for o in observations if o.get("is_upper_limit", False)]
+
+    _info(f"Detections in artifact: {len(art_detections)}")
+    _info(f"Upper limits in artifact: {len(art_uls)}")
+
+    if not art_uls and ddb_upper_limits:
+        _fail(f"ZERO upper limits in artifact but {len(ddb_upper_limits)} in DynamoDB!")
+    elif len(art_uls) < len(ddb_upper_limits):
+        _warn(
+            f"Fewer upper limits in artifact ({len(art_uls)}) than DynamoDB "
+            f"({len(ddb_upper_limits)}) — some may have been suppressed or lost."
+        )
+    elif art_uls:
+        _ok(f"Upper limits present in artifact: {len(art_uls)}")
+
+    # Check UL values in artifact
+    if art_uls:
+        _section("Upper Limit Values in Artifact")
+
+        # uls_with_value = [o for o in art_uls
+        #                   if o.get("limiting_value") is not None
+        #                   or o.get("flux_density") is not None
+        #                   or o.get("magnitude") is not None]
+        uls_empty = [
+            o
+            for o in art_uls
+            if o.get("limiting_value") is None
+            and o.get("flux_density") is None
+            and o.get("magnitude") is None
+        ]
+
+        if uls_empty:
+            _fail(
+                f"Upper limits with NO value (no limiting_value, flux_density, "
+                f"or magnitude): {len(uls_empty)}"
+            )
+            for o in uls_empty[:5]:
+                print(f"    MJD={o.get('time_mjd')}, band={o.get('band')}")
+        else:
+            _ok("All artifact upper limits have at least one value field.")
+
+        for o in art_uls[:5]:
+            print(
+                f"    MJD={o.get('time_mjd')}, band={o.get('band')}, "
+                f"lim={o.get('limiting_value')}, "
+                f"flux={o.get('flux_density')}, "
+                f"mag={o.get('magnitude')}"
+            )
+
+    # Band breakdown in artifact
+    _section("Band Breakdown (Artifact)")
+
+    art_band_counts: Counter = Counter()
+    art_band_ul_counts: Counter = Counter()
+    for o in observations:
+        band = o.get("band", "?")
+        art_band_counts[band] += 1
+        if o.get("is_upper_limit", False):
+            art_band_ul_counts[band] += 1
+
+    print(f"  {'Band':<25s} {'Total':>6s} {'ULs':>6s}")
+    print(f"  {'─' * 40}")
+    for band in sorted(art_band_counts.keys()):
+        total = art_band_counts[band]
+        uls = art_band_ul_counts.get(band, 0)
+        marker = f" {YELLOW}← has ULs{RESET}" if uls > 0 else ""
+        print(f"  {band:<25s} {total:>6d} {uls:>6d}{marker}")
+
+
+def compare_ddb_to_artifact(ddb_rows: list[dict], artifact: dict) -> None:
+    _section("DynamoDB ↔ Artifact Comparison")
+
+    observations = artifact.get("observations", [])
+
+    _info(f"DynamoDB rows: {len(ddb_rows)}")
+    _info(f"Artifact observations: {len(observations)}")
+
+    if len(observations) < len(ddb_rows):
+        diff = len(ddb_rows) - len(observations)
+        _warn(
+            f"Artifact has {diff} fewer observations than DynamoDB. "
+            f"Possible causes: subsampling, suppression, or stale artifact."
+        )
+    elif len(observations) == len(ddb_rows):
+        _ok("Row counts match.")
+    else:
+        _warn(
+            f"Artifact has MORE observations ({len(observations)}) than "
+            f"DynamoDB ({len(ddb_rows)}) — unexpected."
+        )
+
+    # Compare upper limit counts by band
+    ddb_ul_by_band: Counter = Counter()
+    for r in ddb_rows:
+        if r.get("is_upper_limit"):
+            ddb_ul_by_band[r.get("band_id", "?")] += 1
+
+    art_ul_by_band: Counter = Counter()
+    for o in observations:
+        if o.get("is_upper_limit"):
+            art_ul_by_band[o.get("band", "?")] += 1
+
+    all_bands = sorted(set(ddb_ul_by_band.keys()) | set(art_ul_by_band.keys()))
+    if all_bands:
+        print(f"\n  {'Band':<25s} {'DDB ULs':>8s} {'Art ULs':>8s} {'Status':>10s}")
+        print(f"  {'─' * 55}")
+        for band in all_bands:
+            ddb_n = ddb_ul_by_band.get(band, 0)
+            # The artifact uses display labels, DDB uses band_id — try both
+            art_n = art_ul_by_band.get(band, 0)
+            if art_n == 0:
+                # Try matching by display name pattern (e.g., "34.8 GHz" vs "Radio_34.8_GHz")
+                for art_band, count in art_ul_by_band.items():
+                    if art_band in band or band in art_band:
+                        art_n = count
+                        break
+            status = f"{GREEN}OK{RESET}" if ddb_n == art_n else f"{RED}MISMATCH{RESET}"
+            print(f"  {band:<25s} {ddb_n:>8d} {art_n:>8d} {status:>10s}")
+
+
+# ── Main ───────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Investigate missing upper limits for a nova.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--nova", help="Nova name (e.g., 'V5588 Sgr')")
+    group.add_argument("--nova-id", help="Nova UUID directly")
+    parser.add_argument(
+        "--bucket",
+        default=None,
+        help="Public site S3 bucket (default: NOVACAT_PUBLIC_SITE_BUCKET env var)",
+    )
+    parser.add_argument("--region", default=REGION)
+    parser.add_argument(
+        "--skip-s3", action="store_true", help="Skip S3 artifact checks (DynamoDB only)"
+    )
+    args = parser.parse_args()
+
+    import os
+
+    bucket = args.bucket or os.environ.get("NOVACAT_PUBLIC_SITE_BUCKET")
+
+    dynamodb = boto3.resource("dynamodb", region_name=args.region)
+    main_table = dynamodb.Table(MAIN_TABLE)
+    phot_table = dynamodb.Table(PHOT_TABLE)
+
+    # ── Resolve nova ──────────────────────────────────────────────────
+    _section("Nova Resolution")
+
+    if args.nova:
+        nova_id = resolve_nova_id(main_table, args.nova)
+        if not nova_id:
+            _fail(f"Could not resolve name: {args.nova!r}")
+            sys.exit(1)
+        _ok(f"Name: {args.nova} → nova_id: {nova_id}")
+    else:
+        nova_id = args.nova_id
+        _info(f"Using nova_id directly: {nova_id}")
+
+    nova_item = get_nova_item(main_table, nova_id)
+    if nova_item:
+        _ok(f"primary_name: {nova_item.get('primary_name')}")
+        _info(f"status: {nova_item.get('status')}")
+        _info(
+            f"spectra_count: {nova_item.get('spectra_count', '?')}, "
+            f"photometry_count: {nova_item.get('photometry_count', '?')}"
+        )
+    else:
+        _warn("Nova item not found in main table.")
+
+    # ── Query DynamoDB ────────────────────────────────────────────────
+    ddb_rows = query_all_phot_rows(phot_table, nova_id)
+    ddb_upper_limits = [r for r in ddb_rows if r.get("is_upper_limit", False)]
+
+    analyze_ddb_rows(ddb_rows)
+
+    if args.skip_s3:
+        _info("\nSkipping S3 checks (--skip-s3).")
+        return
+
+    # ── Check S3 artifact ─────────────────────────────────────────────
+    if not bucket:
+        _warn("\nNo S3 bucket configured. Set NOVACAT_PUBLIC_SITE_BUCKET or pass --bucket.")
+        _warn("Skipping artifact comparison.")
+        return
+
+    s3 = boto3.client("s3", region_name=args.region)
+
+    _section("S3 Release Info")
+
+    release_id = get_current_release(s3, bucket)
+    if not release_id:
+        _fail("Could not determine current release.")
+        return
+    _ok(f"Current release: {release_id}")
+
+    artifacts = list_nova_artifacts(s3, bucket, release_id, nova_id)
+    if artifacts:
+        _ok(f"Artifacts for this nova: {', '.join(sorted(artifacts))}")
+    else:
+        _fail(f"No artifacts found for nova {nova_id} in release {release_id}.")
+        _info("This nova may not have been included in the last artifact generation sweep.")
+        return
+
+    if "photometry.json" not in artifacts:
+        _fail("photometry.json is MISSING from the release.")
+        _info("Artifacts present: " + ", ".join(sorted(artifacts)))
+        _info("The artifact generator may have skipped photometry for this nova.")
+        return
+
+    # ── Load and analyze artifact ─────────────────────────────────────
+    artifact = get_photometry_json(s3, bucket, release_id, nova_id)
+    if artifact is None:
+        _fail("Could not load photometry.json.")
+        return
+
+    analyze_artifact(artifact, ddb_upper_limits)
+    compare_ddb_to_artifact(ddb_rows, artifact)
+
+    # ── Summary ───────────────────────────────────────────────────────
+    _section("Summary")
+
+    art_obs = artifact.get("observations", [])
+    art_uls = [o for o in art_obs if o.get("is_upper_limit")]
+
+    if len(ddb_upper_limits) > 0 and len(art_uls) == 0:
+        _fail(
+            "DIAGNOSIS: Upper limits exist in DynamoDB but are completely absent "
+            "from the published artifact. The artifact generator is either not "
+            "reading them or dropping them during generation."
+        )
+    elif len(ddb_upper_limits) > len(art_uls):
+        _warn(
+            "DIAGNOSIS: Some upper limits are missing from the artifact. "
+            "Possible subsampling, suppression, or stale artifact."
+        )
+    elif len(ddb_upper_limits) == 0:
+        _warn(
+            "DIAGNOSIS: No upper limits in DynamoDB — nothing to publish. "
+            "Check whether ingestion dropped the rows (band resolution failure?)."
+        )
+    else:
+        _ok("Upper limits appear consistent between DynamoDB and the artifact.")
+
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Non-optical upper limits (radio, future x-ray/gamma) no longer silently dropped from photometry.json — `_has_measurement()` now checks `limiting_value`, and `_build_observation_record()` falls back to `limiting_value` for the regime's primary field when `is_upper_limit=True`
- `spectral_visits` computation switched from naive integer-MJD floor to gap-based night clustering (`cluster_by_night()` from the compositing pipeline, 12-hour threshold) — correctly handles midnight-spanning observing runs
- `spectral_visits` now persisted to the Nova DDB item via `_write_observation_counts()` in the finalizer — previously only existed in-memory during sweeps, so unswepped novae showed 0
- `nova.json` now emits `discovery_date_mjd` (discovery date as MJD, rounded to 1 dp) and `spectral_visits`
- Nova detail page shows MJD parenthetical next to discovery date and a "Spectral visits" metadata row

## Why
- V5588 Sgr had 2 radio upper limits in DynamoDB that were missing from photometry.json (271 obs vs 273 DDB rows) — the artifact generator's measurement gate didn't recognize `limiting_value` as a valid measurement. Affects every non-optical upper limit in the catalog
- Spectral visits disappeared from the website after any partial regeneration sweep because the value was never written back to DDB — the TODO flagging this was already in `main.py`
- The integer-MJD night counting was splitting midnight-spanning runs into two nights — a common scenario for professional observing campaigns
- Discovery date MJD and spectral visits on the nova page were requested as quick wins to enrich the detail view

## Testing
- `TestRadioUpperLimitRouting`: 3 new tests covering radio UL, optical UL with only `limiting_value`, and regression guard for normal detections
- `TestSpectralVisits`: updated seed MJDs for gap-based clustering, added `test_midnight_spanning_run_counts_as_one_night` proving the midnight fix
- `test_writes_observation_counts_to_nova_item`: extended with `spectral_visits` assertion
- `TestDiscoveryDateMjd`: 4 new tests (precise date, imprecise month, imprecise year, null)
- 2 new spectral visits tests in `TestObservationCounts`
- All mypy --strict, ruff, and `cd frontend && npx next build` pass

## Bugs Fixed
- Non-optical upper limits silently dropped by artifact generator (`_has_measurement` + `_build_observation_record`)
- `spectral_visits` not persisted to DDB (finalizer writeback gap)
- `spectral_visits` miscounting midnight-spanning runs as two nights

## Out of Scope
- Backfill of existing DDB items missing radio upper limits at 5.9/6.75 GHz (requires redeploy + re-ingest of V5588 Sgr ticket)
- Existing optical upper limit test data seeds `magnitude=<value>` with `is_upper_limit=True`, which doesn't match what the ticket ingestor actually produces — tests still pass but exercise a legacy pattern

## Next Steps
- Deploy and re-ingest V5588 Sgr to recover the 5 rows that failed band resolution on the original run (registry already updated)
- Run full artifact regeneration sweep to repopulate `spectral_visits` on all Nova DDB items and recover radio upper limits in photometry.json
- Verify the Visits column is back on the website after sweep