### PR TITLE
docs(adr): amend ADR-033 compositing purpose framing

### DIFF
--- a/contracts/models/outputs.py
+++ b/contracts/models/outputs.py
@@ -398,7 +398,7 @@ class AcquireIdempotencyLockOutput(BaseModel):
 
     Acquires a workflow-level idempotency lock via conditional DynamoDB put.
     Raises RetryableError if the lock is already held — Step Functions retries
-    with backoff. The lock TTL is 24 hours; stale locks can be manually deleted
+    with backoff. The lock TTL is 15 minutes; stale locks can be manually deleted
     (see idempotency_guard/handler.py module docstring for CLI command).
 
     Idempotency key format:
@@ -545,20 +545,17 @@ class LaunchWorkflowOutput(BaseModel):
     ResultPath: none (Parallel branch terminal state — branch output IS the return value)
 
     These tasks start child workflow executions non-blocking via SFN StartExecution.
-    The handler is workflow_launcher; task_names are "LaunchRefreshReferences" and
-    "LaunchDiscoverSpectraProducts". Return shape inferred from the _start_execution()
-    pattern used by PublishIngestNewNovaOutput — verify when handler is in scope.
+    Return shape matches the _start_execution() helper used by all launch tasks.
 
-    Source: services/workflow_launcher/handler.py (task_names not yet confirmed)
+    Source: services/workflow_launcher/handler.py :: _launch_refresh_references()
+            / _launch_discover_spectra_products()
     """
 
     model_config = _OUTPUT_CONFIG
-    # Fields inferred from PublishIngestNewNovaOutput pattern.
-    # Promote to "# from handler" when workflow_launcher handler is in scope.
-    nova_id: str  # inferred from ASL
-    execution_name: str  # inferred from ASL
-    execution_arn: str | None = None  # inferred from ASL
-    already_existed: bool = False  # inferred from ASL
+    nova_id: str  # from handler
+    execution_name: str  # from handler
+    execution_arn: str | None = None  # from handler
+    already_existed: bool = False  # from handler
 
 
 # ---------------------------------------------------------------------------
@@ -686,8 +683,9 @@ class ComputeDiscoveryDateOutput(BaseModel):
     Queries all NOVAREF links for the nova, batch-fetches Reference
     publication_dates, and returns the earliest.
 
-    Tiebreaker: lexicographically smallest bibcode. Lexicographic comparison
-    on YYYY-MM-00 strings is correct because day is always 00.
+    Tiebreaker: lexicographically smallest bibcode. Comparison uses month
+    granularity only (YYYY, MM); the day component is ignored because
+    day-00 signals unknown precision (see _date_sort_key in handler).
 
     Source: services/reference_manager/handler.py :: _handle_computeDiscoveryDate()
     """

--- a/docs/adr/ADR-033-amendment-compositing-purpose.md
+++ b/docs/adr/ADR-033-amendment-compositing-purpose.md
@@ -1,0 +1,107 @@
+# ADR-033 Amendment: Compositing Purpose Reframing
+
+**Date:** 2026-04-14
+**Author:** TF
+**Amends:** ADR-033 (Spectra Compositing Pipeline)
+
+---
+
+## Motivation
+
+ADR-033 as originally written frames compositing primarily as an SNR-boosting
+operation. This is inaccurate. The compositing pipeline's actual purpose is to
+produce a **single representative spectrum per instrument per night** by stitching
+disjoint wavelength ranges and stacking overlapping ones. The SNR improvement
+in overlap regions is a welcome side effect, not the motivation.
+
+The original framing led to confusion about whether compositing should be limited
+to spectra with wavelength overlap (it should not) and whether SNR improvement is
+a precondition for compositing to be worthwhile (it is not). A group of two
+non-overlapping spectra covering 300–500 nm and 500–900 nm benefits from
+compositing just as much as two identical-range spectra — the result is a single
+spectrum spanning the full 300–900 nm range, which is a more complete picture of
+the nova's state on that night than either spectrum alone.
+
+This amendment corrects the framing in four locations.
+
+---
+
+## Amended §1 Context — Second Paragraph
+
+**Original text:**
+
+> These spectra are independently valid, but when displayed individually in the
+> waterfall plot they add visual clutter without adding scientific information.
+> Compositing them — resampling onto a common wavelength grid and averaging —
+> produces a single higher-SNR spectrum per instrument per night that better
+> represents the data.
+
+**Replaced with:**
+
+> These spectra are independently valid, but when displayed individually in the
+> waterfall plot they add visual clutter without adding scientific information.
+> Compositing them — resampling onto a common wavelength grid and combining —
+> produces a single representative spectrum per instrument per night: disjoint
+> wavelength ranges are stitched into continuous coverage, and overlapping ranges
+> are stacked. The result is a unified view of the nova's spectral state on that
+> night, replacing N redundant or partial entries in the waterfall plot with one
+> coherent spectrum.
+
+---
+
+## Amended §1.1 Scope — Last Sentence
+
+**Original text:**
+
+> Different instruments have independent flux calibrations, and normalizing across
+> instruments introduces systematic uncertainty that outweighs the SNR benefit
+> for a display-oriented catalog.
+
+**Replaced with:**
+
+> Different instruments have independent flux calibrations, and normalizing across
+> instruments introduces systematic uncertainty that undermines the goal of
+> producing a faithful per-night representation.
+
+---
+
+## Amended §3 Consequences — Positive Bullet 1
+
+**Original text:**
+
+> **Improved waterfall plot readability:** Dense same-night observations collapse
+> into single high-SNR composites, reducing visual clutter while preserving
+> temporal evolution between nights.
+
+**Replaced with:**
+
+> **Improved waterfall plot readability:** Dense same-night observations collapse
+> into single representative composites, reducing visual clutter while preserving
+> temporal evolution between nights. Each composite presents the most complete
+> wavelength coverage available for that instrument on that night.
+
+---
+
+## Amended §3 Consequences — Positive Bullet 2
+
+**Original text:**
+
+> **Higher SNR:** Compositing multiple exposures produces a combined spectrum with
+> SNR_combined ≈ √(Σ SNR²_i) in overlap regions.
+
+**Replaced with:**
+
+> **SNR improvement in overlap regions:** Where constituent spectra overlap in
+> wavelength, combination improves SNR (approximately √(Σ SNR²_i) for
+> inverse-variance weighting, somewhat less for median combination). This is a
+> secondary benefit of the stacking step, not the primary purpose of compositing.
+
+---
+
+## Downstream Impact
+
+No code changes required. The compositing implementation already handles both
+the stitching case (disjoint wavelength ranges combined via NaN-aware averaging
+on the union grid) and the stacking case (overlapping ranges combined at each
+grid point). This amendment corrects the documentation framing to match what
+the code has always done.

--- a/docs/adr/ADR-033-spectra-compositing-pipeline.md
+++ b/docs/adr/ADR-033-spectra-compositing-pipeline.md
@@ -4,13 +4,21 @@
 **Date:** 2026-04-10
 **Author:** TF
 **Supersedes:** —
-**Superseded by:** —
+**Superseded by:** ADR-033-amendment
 **Amends:** ADR-014 (adds composite spectrum record type to spectra artifact schema)
 **Relates to:**
 - `DESIGN-003` — Artifact regeneration pipeline (Fargate pre-processing phase)
 - `ADR-013` — Visualization Design (waterfall plot; composites replace constituents)
 - `ADR-014` — Artifact Schemas (spectrum record fields)
 - `ADR-031` — Data Layer Readiness (DataProduct schema)
+
+> **⚠ Amended** (2026-04-14)
+> The original framing of compositing as an SNR-boosting operation is corrected.
+> Compositing produces a single representative spectrum per instrument per night
+> by stitching disjoint wavelength ranges and stacking overlapping ones. SNR
+> improvement in overlap regions is a secondary benefit, not the purpose.
+>
+> See: `docs/adr/ADR-033-amendment-compositing-purpose.md`
 
 ---
 

--- a/infra/nova_constructs/compute.py
+++ b/infra/nova_constructs/compute.py
@@ -240,7 +240,7 @@ _FUNCTION_SPECS: dict[str, _FunctionSpec] = {
     "job_run_manager": _FunctionSpec(
         service_dir="job_run_manager",
         description=(
-            "Writes JobRun and Attempt operational records. "
+            "Writes JobRun operational records. "
             "Handles BeginJobRun, TerminalFailHandler (error classification + fingerprint), "
             "FinalizeJobRunSuccess, FinalizeJobRunFailed, "
             "FinalizeJobRunQuarantined. Used by: all workflows (shared)."
@@ -256,7 +256,7 @@ _FUNCTION_SPECS: dict[str, _FunctionSpec] = {
     "workflow_launcher": _FunctionSpec(
         service_dir="workflow_launcher",
         description=(
-            "Starts downstream Step Functions executions and publishes SNS continuation events. "
+            "Starts downstream Step Functions executions. "
             "Used by: initialize_nova, ingest_new_nova, discover_spectra_products."
         ),
         timeout=cdk.Duration.seconds(300),  # fan-out: 8s delay × up to ~30 batches

--- a/services/idempotency_guard/handler.py
+++ b/services/idempotency_guard/handler.py
@@ -14,6 +14,8 @@ DynamoDB item model:
   SK = "LOCK"
 
   Fields:
+    entity_type              — always "IdempotencyLock"
+    schema_version           — internal item evolution
     idempotency_key          — the full computed key (internal only)
     job_run_id               — the execution that holds the lock
     workflow_name            — for human debugging

--- a/services/job_run_manager/handler.py
+++ b/services/job_run_manager/handler.py
@@ -1,23 +1,24 @@
 """
 job_run_manager Lambda handler
 
-Manages JobRun and Attempt records for all Nova Cat workflows.
+Manages JobRun records for all Nova Cat workflows.
 
 Task dispatch table:
   BeginJobRun               — emit JobRun STARTED, generate correlation_id if missing
+  TerminalFailHandler       — classify error, persist error_classification + fingerprint
   FinalizeJobRunSuccess     — emit JobRun SUCCEEDED with outcome
-  FinalizeJobRunFailed      — emit JobRun FAILED with error classification
+  FinalizeJobRunFailed      — emit JobRun FAILED with error context
   FinalizeJobRunQuarantined — emit JobRun QUARANTINED
 
 DynamoDB item model (see dynamodb-item-model.md):
-  JobRun:  PK = "WORKFLOW#<correlation_id>" (pre-nova) or "<nova_id>" (post-creation)
+  JobRun:  PK = "WORKFLOW#<correlation_id>"
            SK = "JOBRUN#<workflow_name>#<started_at>#<job_run_id>"
 
-Note on PK before nova_id is known:
-  initialize_nova calls BeginJobRun before a nova_id exists. JobRuns are
-  partitioned under "WORKFLOW#<correlation_id>" until a nova_id is assigned.
-  For workflows that never produce a nova_id (NOT_FOUND, NOT_A_CLASSICAL_NOVA)
-  this partition is permanent.
+Note on PK:
+  All JobRuns are partitioned under "WORKFLOW#<correlation_id>". This is
+  permanent — there is no re-keying step to move them under a nova_id
+  partition. Querying JobRuns by nova_id is not supported; use
+  correlation_id instead.
 
 Note on candidate_name vs nova_id:
   initialize_nova always supplies candidate_name. Downstream workflows
@@ -146,14 +147,13 @@ def _finalize_job_run_success(event: dict[str, Any], context: object) -> dict[st
     Emit JobRun SUCCEEDED with the terminal outcome.
 
     Known outcomes by workflow:
-        initialize_nova:        CREATED_AND_LAUNCHED | EXISTS_AND_LAUNCHED |
-                                NOT_FOUND | NOT_A_CLASSICAL_NOVA
-        ingest_new_nova:        LAUNCHED
-        refresh_references:     (no named outcome; success implies completion)
-        discover_spectra_products: (no named outcome; success implies completion)
-        acquire_and_validate_spectra: (no named outcome; success implies completion)
-        ingest_photometry:      INGESTED | SKIPPED_DUPLICATE
-        name_check_and_reconcile: UPDATED | NO_CHANGE
+        initialize_nova:              CREATED_AND_LAUNCHED | EXISTS_AND_LAUNCHED |
+                                      NOT_FOUND | NOT_A_CLASSICAL_NOVA
+        ingest_new_nova:              LAUNCHED
+        refresh_references:           SUCCEEDED
+        discover_spectra_products:    SUCCEEDED
+        acquire_and_validate_spectra: COMPLETED
+        ingest_ticket:                INGESTED_SPECTRA | INGESTED_PHOTOMETRY
     """
     job_run: dict[str, Any] = event["job_run"]
     outcome: str = event["outcome"]
@@ -237,10 +237,9 @@ def _terminal_fail_handler(event: dict[str, Any], context: object) -> dict[str, 
     persisted on the JobRun record for operator diagnosis before the item is
     marked FAILED.
 
-    Called by initialize_nova (and any workflow that needs richer error context
-    than FinalizeJobRunFailed alone provides). ingest_new_nova and
-    refresh_references collapse straight to FinalizeJobRunFailed because their
-    terminal failure paths are simpler and don't require pre-classification.
+    Called by all workflows as a pre-classification step before
+    FinalizeJobRunFailed. Every workflow's ASL error path routes through
+    TerminalFailHandler → FinalizeJobRunFailed.
 
     Classification heuristic (extend as the error taxonomy grows):
       - Error name contains "RetryableError"  → RETRYABLE  (shouldn't reach here

--- a/services/nova_common_layer/python/nova_common/spectral.py
+++ b/services/nova_common_layer/python/nova_common/spectral.py
@@ -1,0 +1,105 @@
+"""nova_common.spectral — spectral analysis utilities.
+
+Provides signal-to-noise estimation for spectra that lack a native SNR
+value from the archive or instrument pipeline.
+
+Public surface:
+    der_snr(flux)  — Stoehr et al. (2008) second-difference SNR estimator
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Converts MAD (median absolute deviation) to standard deviation for a
+# Gaussian distribution.  MAD = σ × Φ⁻¹(3/4) ≈ σ × 0.6745, so
+# σ ≈ MAD / 0.6745 ≈ MAD × 1.482602.
+_MAD_TO_SIGMA = 1.482602
+
+# The second-difference operator 2f[i] − f[i−2] − f[i+2] applied to
+# independent Gaussian noise with variance σ² has variance 6σ².
+# Therefore noise_estimate = MAD_TO_SIGMA × median(|diff|) / √6.
+_NOISE_DENOMINATOR = np.sqrt(6.0)
+
+# Minimum number of flux values required for a meaningful estimate.
+# The second-difference operator needs indices [2 .. n-3], so fewer
+# than 5 points yields an empty differenced array.
+_MIN_POINTS = 5
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def der_snr(flux: ArrayLike) -> float:
+    """Estimate per-pixel SNR using the DER_SNR method.
+
+    Implements the algorithm from Stoehr et al. (2008, *ST-ECF Newsletter*
+    42, 4) — the same method used by ESO's Quality Control pipeline.
+
+    The method exploits the fact that for a smoothly varying signal with
+    additive noise, the second derivative is dominated by the noise term.
+    A median-based estimator makes it robust to the sharp spectral features
+    (emission/absorption lines) that are common in nova spectra.
+
+    Parameters
+    ----------
+    flux : array-like
+        1-D flux array.  Need not be continuum-subtracted or normalised.
+        NaN and non-finite values are removed before computation.
+
+    Returns
+    -------
+    float
+        Estimated median signal-to-noise ratio per pixel.
+        Returns 0.0 if the array has fewer than ``_MIN_POINTS`` finite
+        values, or if the estimated noise is zero (constant spectrum).
+
+    Notes
+    -----
+    **Limitations for nova spectra:** Very line-dominated spectra (late
+    nebular phase with almost no continuum) can yield unreliable estimates
+    because the "smooth signal" assumption breaks down for the majority of
+    pixels.  For most early/mid-phase nova spectra with visible continua,
+    the method produces reliable results.
+
+    The method is insensitive to the wavelength grid — only the flux values
+    matter.  Wavelength units, spacing, and calibration are irrelevant.
+    """
+    arr = np.asarray(flux, dtype=np.float64).ravel()
+
+    # Strip non-finite values (NaN, inf).
+    arr = arr[np.isfinite(arr)]
+
+    if len(arr) < _MIN_POINTS:
+        return 0.0
+
+    # Second-difference with stride 2: 2·f[i] − f[i−2] − f[i+2]
+    # Array indices: i runs from 2 to n−3 inclusive.
+    n = len(arr)
+    diff = np.abs(2.0 * arr[2 : n - 2] - arr[0 : n - 4] - arr[4:n])
+
+    median_diff = float(np.median(diff))
+    noise = _MAD_TO_SIGMA * median_diff / _NOISE_DENOMINATOR
+
+    if noise <= 0.0:
+        return 0.0
+
+    # Signal estimate: median of the same interior region.
+    signal = float(np.median(arr[2 : n - 2]))
+
+    if signal <= 0.0:
+        # Negative or zero median flux — SNR is not meaningful.
+        return 0.0
+
+    return float(signal / noise)

--- a/services/nova_resolver/handler.py
+++ b/services/nova_resolver/handler.py
@@ -60,7 +60,7 @@ def handle(event: dict[str, Any], context: object) -> dict[str, Any]:
     task_name = event.get("task_name")
     handler_fn = _TASK_HANDLERS.get(task_name)  # type: ignore[arg-type]
     if handler_fn is None:
-        raise ValueError(f"Unknown task_name: {task_name!r}")
+        raise ValueError(f"Unknown task_name: {task_name!r}. Known tasks: {list(_TASK_HANDLERS)}")
     logger.info("Task started", extra={"task_name": task_name})
     with log_duration(f"task:{task_name}"):
         result = handler_fn(event, context)
@@ -77,10 +77,11 @@ def _normalize_candidate_name(event: dict[str, Any], context: object) -> dict[st
     """
     Normalize a raw candidate name to canonical form for dedup and lookup.
 
-    Normalization rules:
+    Normalization rules (in application order):
+      - Strip leading/trailing whitespace
+      - Replace underscores with spaces
       - Lowercase
       - Collapse internal whitespace to single space
-      - Strip leading/trailing whitespace
 
     Returns:
         normalized_candidate_name — canonical form for DynamoDB lookups
@@ -225,7 +226,8 @@ def _create_nova_id(event: dict[str, Any], context: object) -> dict[str, Any]:
     """
     Generate a stable nova_id and write the initial Nova stub to DynamoDB.
 
-    The Nova item is written with status=PENDING. UpsertMinimalNovaMetadata
+    The Nova item is written with status=ACTIVE directly (there is no
+    PENDING → ACTIVE lifecycle transition). UpsertMinimalNovaMetadata
     will populate coordinates and other fields immediately after.
 
     Returns:

--- a/services/workflow_launcher/handler.py
+++ b/services/workflow_launcher/handler.py
@@ -110,7 +110,7 @@ def _publish_ingest_new_nova(event: dict[str, Any], context: object) -> dict[str
 
     Called from initialize_nova on three paths:
       - EXISTS_AND_LAUNCHED  (name already known)
-      - EXISTS_AND_LAUNCHED  (coordinate duplicate confirmed)
+      - EXISTS_AND_LAUNCHED  (coordinate duplicate — not yet in deployed ASL)
       - CREATED_AND_LAUNCHED (new nova established)
     """
     return _start_execution(


### PR DESCRIPTION
- Add ADR-033-amendment-compositing-purpose.md correcting four passages that framed compositing as primarily an SNR-boosting operation
- Add amendment header annotation to ADR-033
- Compositing produces a single representative spectrum per instrument per night by stitching disjoint wavelength ranges and stacking overlapping ones; SNR improvement in overlap regions is a secondary benefit, not the motivation