### PR TITLE
docs(services): fix documentation inconsistencies in markdown docs and contracts

### DIFF
--- a/docs/architecture/current-architecture.md
+++ b/docs/architecture/current-architecture.md
@@ -81,7 +81,11 @@ Name-based resolution occurs only in `initialize_nova`.
 Mechanism:
 - `NAME#<normalized_name>` global partition
 - Maps alias → `nova_id`
-- Deterministic normalization applied
+- Deterministic normalization applied:
+  1. Strip leading/trailing whitespace
+  2. Replace underscores with spaces
+  3. Lowercase
+  4. Collapse internal whitespace to single space
 
 Duplicate detection via coordinate thresholds:
 
@@ -124,7 +128,7 @@ specification.
 | `ingest_new_nova` | Standard | Orchestrates downstream launches (`refresh_references`, `discover_spectra_products`) for a newly resolved nova. |
 | `refresh_references` | Standard | Fetches ADS references for a nova, upserts Reference and NovaReference items, computes `discovery_date`. |
 | `discover_spectra_products` | Standard | Queries provider archives, assigns `data_product_id` values, persists product stubs, fans out `acquire_and_validate_spectra`. |
-| `acquire_and_validate_spectra` | Standard | Downloads spectra bytes, validates FITS against instrument profiles, persists normalized products to S3 + DDB. |
+| `acquire_and_validate_spectra` | Express | Downloads spectra bytes, validates FITS against instrument profiles, persists normalized products to S3 + DDB. |
 | `ingest_ticket` | Standard | Ingests hand-curated photometry or spectra tickets. Resolves nova identity, then branches by ticket type. |
 
 All Standard Workflows follow a consistent execution pattern: `BeginJobRun` →
@@ -346,6 +350,8 @@ Item types:
   during `initialize_nova` quarantine before a `nova_id` exists)
 - `WORKQUEUE` — WorkItem records for the regeneration pipeline (§4)
 - `REGEN_PLAN` — RegenBatchPlan records for sweep coordination (§4)
+- `IDEMPOTENCY#<idempotency_key>` — workflow-level idempotency locks
+  (15-minute TTL, DynamoDB TTL auto-cleanup; see `idempotency_guard` handler)
 
 ## 6.2 Dedicated Photometry Table (NovaCatPhotometry)
 

--- a/docs/storage/dynamodb-item-model.md
+++ b/docs/storage/dynamodb-item-model.md
@@ -137,7 +137,7 @@ Used for:
 
 ```json
 {
-  "PK": "NAME#nova sco 2012 #2",
+  "PK": "NAME#v1324 sco",
   "SK": "NOVA#4e9b0e88-5d2b-4d1a-9a1a-4a4f6f0cb9b1",
   "entity_type": "NameMapping",
   "schema_version": "1",
@@ -956,7 +956,7 @@ condition_expression=attribute_not_exists(PK).
 #### Example:
 ```json
 {
-  "PK": "4e9b0e88-5d2b-4d1a-9a1a-4a4f6f0cb9b1",
+  "PK": "WORKFLOW#a1b2c3d4-9e8f-7a6b-5c4d-3e2f1a0b9c8d",
   "SK": "JOBRUN#acquire_and_validate_spectra#2026-02-23T18:10:00Z#5a4fce02-3b02-4b5c-8d06-541d9f2d4f60",
   "entity_type": "JobRun",
   "schema_version": "1",

--- a/docs/workflows/initialize-nova.md
+++ b/docs/workflows/initialize-nova.md
@@ -59,14 +59,14 @@ Other workflows may be triggered directly when `nova_id` already exists.
    - No  -> continue
 8. **ResolveCandidateAgainstPublicArchives** (Task)
 
-9. **CheckExistingNovaByCoordinates** (Task)
+9. **CheckExistingNovaByCoordinates** (Task) *(handler implemented; not yet in deployed ASL)*
    - Inputs: resolved coordinates (RA/Dec + epoch if available)
    - Behavior:
      - Retrieve existing nova coordinates from persistent store
      - Compute angular separation to each candidate
      - Determine minimum separation
 
-10. **CoordinateMatchClassification?** (Choice)
+10. **CoordinateMatchClassification?** (Choice) *(not yet in deployed ASL)*
    - Separation < 2"  -> **UpsertAliasForExistingNova** -> **PublishIngestNewNova**
      -> **FinalizeJobRunSuccess** (outcome = `EXISTS_AND_LAUNCHED`)
    - Separation 2"–10" -> **QuarantineHandler** -> **FinalizeJobRunQuarantined**

--- a/docs/workflows/refresh-references.md
+++ b/docs/workflows/refresh-references.md
@@ -177,13 +177,15 @@ notification delivery fails.
 
 ## Idempotency Guarantees & Invariants
 
-- Workflow idempotency key (time-bucketed): `RefreshReferences:{nova_id}:{schema_version}:{time_bucket}`
+- Workflow idempotency key (time-bucketed): `refresh_references:{nova_id}:{schema_version}:{time_bucket}`
 - Reference upsert dedupe key: `ReferenceUpsert:ADS:{bibcode}:{schema_version}`
 - Relationship dedupe key: `NovaReferenceLink:{nova_id}:{bibcode}`
 - DiscoveryDate dedupe key: `DiscoveryDate:{nova_id}:{earliest_bibcode}:{rule_version}`
 - Invariant: `discovery_date` update is monotonically earlier (unless explicitly
   configured otherwise). `discovery_date` is stored as `YYYY-MM-DD` string; day `00`
-  signals month-only precision. Lexicographic comparison is correct for this format.
+  signals month-only precision. Comparison uses month granularity only `(YYYY, MM)`;
+  the day component is ignored because `00` means unknown precision. A day-00 date
+  and a day-precise date in the same month are treated as equal (no overwrite).
 - Invariant: `idempotency_key` is internal-only (not in event schemas).
 
 ---


### PR DESCRIPTION
## Summary
- Fixed 11 documentation inconsistencies across 4 markdown files and 1 contract model file
- Batch 2: `dynamodb-item-model.md`, `current-architecture.md`, `initialize-nova.md`, `refresh-references.md`
- Batch 3: `contracts/models/outputs.py`
- All fixes are documentation-only — zero runtime behavior changes

## Why
- Companion to the handler docstring fixes that landed in the previous PR
- Together they close 23 of 27 findings from the 5-handler documentation audit
- Highlights: NameMapping example PK didn't match its own `name_normalized` field (F5), JobRun example used a bare nova_id PK that the code never produces (F15), the authoritative architecture doc listed `acquire_and_validate_spectra` as Standard when it's Express (F19rev), and the contracts claimed a 24-hour idempotency lock TTL when the code sets 15 minutes (F17)

## Testing
- Both patch scripts include precondition checks (abort if anchor text not found) and post-condition checks (verify expected text present/absent)
- Both applied cleanly on first run with all post-conditions passing

## Out of Scope
- Schema version harmonization ("1" vs "1.0.0" → canonical "1.0") — runtime impact, needs backfill plan
- Remaining ~12 handlers not yet audited (round 2 planned)

## Next Steps
- Round 2 of the documentation audit targeting the spectra pipeline, ticket pipeline, and artifact pipeline handlers
- Add schema_version harmonization to the master task list