### PR TITLE
feat(artifact-generator): wire SNR quality gates into spectra pipeline

### DIFF
--- a/services/artifact_generator/generators/compositing.py
+++ b/services/artifact_generator/generators/compositing.py
@@ -22,6 +22,7 @@ from datetime import UTC, datetime
 from typing import Any, TypedDict
 
 import numpy as np
+from nova_common.spectral import der_snr
 from numpy.typing import NDArray
 
 _logger = logging.getLogger(__name__)
@@ -39,9 +40,45 @@ NIGHT_GAP_THRESHOLD_DAYS: float = 0.5
 #: in a composite.
 MIN_POINTS_FOR_COMPOSITE: int = 2000
 
+#: Relative SNR threshold for compositing group membership.
+#: A spectrum with SNR below this fraction of the group's median
+#: is excluded from the composite but still displayed individually
+#: (if above the absolute display floor in spectra.py).
+_COMPOSITING_SNR_RELATIVE_THRESHOLD: float = 1.0 / 3.0
+
 #: NovaCat UUID v5 namespace for deterministic composite IDs.
 #: Generated once via uuid.uuid4() and frozen here.
 _NOVACAT_UUID_NAMESPACE: uuid.UUID = uuid.UUID("7f1b3c5e-8a2d-4e6f-b9c1-d3e5f7a8b0c2")
+
+
+def _effective_snr_for_product(product: dict[str, Any]) -> float:
+    """Compute effective SNR for a compositing candidate.
+
+    Priority: DDB top-level snr → hints.snr → DER_SNR on raw flux.
+    Requires ``_raw_fluxes`` to be attached to the product dict
+    (set during FITS reading in ``_process_group``).
+    """
+    snr_val = product.get("snr")
+    if snr_val is not None:
+        try:
+            return float(snr_val)
+        except (TypeError, ValueError):
+            pass
+
+    hints = product.get("hints")
+    if isinstance(hints, dict):
+        hints_snr = hints.get("snr")
+        if hints_snr is not None:
+            try:
+                return float(hints_snr)
+            except (TypeError, ValueError):
+                pass
+
+    raw_fluxes = product.get("_raw_fluxes")
+    if raw_fluxes is not None and len(raw_fluxes) > 0:
+        return der_snr(raw_fluxes)
+
+    return 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -1011,6 +1048,32 @@ def _process_compositing_group(
         product["_raw_wavelengths"] = wavelengths
         product["_raw_fluxes"] = fluxes
         constituents.append(product)
+
+    # --- Relative SNR gate (epic/29) ---
+    # Exclude spectra whose SNR is far below the group's median.
+    # These are moved to the rejected list, not silently dropped.
+    if len(constituents) >= 2:
+        snr_values = [_effective_snr_for_product(p) for p in constituents]
+        group_median_snr = float(np.median(snr_values))
+
+        if group_median_snr > 0:
+            snr_floor = group_median_snr * _COMPOSITING_SNR_RELATIVE_THRESHOLD
+            snr_passed: list[dict[str, Any]] = []
+            for p, snr in zip(constituents, snr_values, strict=False):
+                if 0 < snr < snr_floor:
+                    _logger.info(
+                        "Spectrum excluded from composite by relative SNR gate",
+                        extra={
+                            "data_product_id": str(p["data_product_id"]),
+                            "effective_snr": round(snr, 2),
+                            "group_median_snr": round(group_median_snr, 2),
+                            "threshold": round(snr_floor, 2),
+                        },
+                    )
+                    rejected.append(p)
+                else:
+                    snr_passed.append(p)
+            constituents = snr_passed
 
     constituent_ids = sorted(str(p["data_product_id"]) for p in constituents)
     rejected_ids = sorted(str(p["data_product_id"]) for p in rejected)

--- a/services/artifact_generator/generators/spectra.py
+++ b/services/artifact_generator/generators/spectra.py
@@ -33,6 +33,7 @@ from typing import Any
 
 import numpy as np
 from boto3.dynamodb.conditions import Attr, Key
+from nova_common.spectral import der_snr
 
 from generators.compositing import cluster_by_night
 from generators.shared import (
@@ -53,6 +54,12 @@ _TRIM_TOLERANCE = 1.001  # 0.1% beyond median before wavelength trim kicks in
 
 _ARM_MJD_TOLERANCE = 0.333  # days (~8 hr) — grouping tolerance for arms
 _ARM_OVERLAP_MAX_NM = 100.0  # nm — max overlap before we reject a merge
+
+# SNR quality gating (epic/29-spectra-quality-and-docs).
+# Absolute floor: spectra below this are excluded from the waterfall plot
+# but remain in the observation table. Applied after DER_SNR fallback
+# computation so all spectra have an effective SNR value.
+_SNR_DISPLAY_FLOOR = 5.0
 
 # ADR-035 spectra wavelength regime boundaries (nm).
 # Assignment is by wavelength midpoint: (wavelength_min + wavelength_max) / 2.
@@ -99,6 +106,49 @@ _SPECTRA_REGIME_DEFINITIONS: dict[str, dict[str, Any]] = {
         "wavelength_range_nm": [5000, None],
     },
 }
+
+# ---------------------------------------------------------------------------
+# SNR quality gating
+# ---------------------------------------------------------------------------
+
+
+def _compute_effective_snr(rec: dict[str, Any]) -> float:
+    """Compute effective SNR for a parsed spectrum record.
+
+    Priority:
+      1. Top-level ``snr`` on the DDB DataProduct item (from FITS validation).
+      2. ``hints.snr`` (from SSAP discovery metadata).
+      3. DER_SNR computed from the cleaned flux array (Stoehr et al. 2008).
+
+    Returns 0.0 if no SNR can be determined (degenerate spectrum).
+    """
+    product = rec["product"]
+
+    # 1. Top-level SNR from validation
+    snr_val = product.get("snr")
+    if snr_val is not None:
+        try:
+            return float(snr_val)
+        except (TypeError, ValueError):
+            pass
+
+    # 2. Hints SNR from discovery metadata
+    hints = product.get("hints")
+    if isinstance(hints, dict):
+        hints_snr = hints.get("snr")
+        if hints_snr is not None:
+            try:
+                return float(hints_snr)
+            except (TypeError, ValueError):
+                pass
+
+    # 3. DER_SNR fallback from cleaned flux array
+    fluxes = rec.get("fluxes", [])
+    if fluxes:
+        return der_snr(fluxes)
+
+    return 0.0
+
 
 # ADR-035: Cross-boundary spectrum splitting thresholds.
 _SPLIT_FRACTION_THRESHOLD = 0.15  # minor side must be ≥15% of total span
@@ -423,6 +473,40 @@ def generate_spectra_json(
 
     # Step 2a½ — Detect multi-arm groups and merge.
     parsed = _merge_multi_arm_spectra(parsed, nova_id, s3_client, private_bucket)
+
+    # Step 2a¾ — Compute effective SNR and apply absolute display gate.
+    # DER_SNR fallback ensures every spectrum gets an SNR value, even if
+    # the archive/validation pipeline didn't provide one.  Spectra below
+    # the display floor are excluded from the waterfall plot but remain
+    # in the observation table (they are real DataProducts with real metadata).
+    pre_gate_count = len(parsed)
+    gated: list[dict[str, Any]] = []
+    for rec in parsed:
+        eff_snr = _compute_effective_snr(rec)
+        rec["effective_snr"] = eff_snr
+        if 0 < eff_snr < _SNR_DISPLAY_FLOOR:
+            _logger.info(
+                "Spectrum excluded by SNR display gate",
+                extra={
+                    "nova_id": nova_id,
+                    "data_product_id": rec["product"]["data_product_id"],
+                    "effective_snr": round(eff_snr, 2),
+                    "snr_floor": _SNR_DISPLAY_FLOOR,
+                },
+            )
+            continue
+        gated.append(rec)
+    if pre_gate_count != len(gated):
+        _logger.info(
+            "SNR display gate applied",
+            extra={
+                "nova_id": nova_id,
+                "before": pre_gate_count,
+                "after": len(gated),
+                "excluded": pre_gate_count - len(gated),
+            },
+        )
+    parsed = gated
 
     # Step 2b — Regime classification and cross-boundary splitting (ADR-035).
     parsed = _assign_and_split_regimes(parsed)

--- a/tests/services/test_spectral.py
+++ b/tests/services/test_spectral.py
@@ -1,0 +1,242 @@
+"""Unit tests for nova_common.spectral.der_snr.
+
+Covers:
+  - Known Gaussian noise recovery (within tolerance)
+  - Robustness to emission lines (median ignores sharp features)
+  - Constant flux → 0.0 (no noise to measure)
+  - Negative median flux → 0.0
+  - All-zero flux → 0.0
+  - Empty array → 0.0
+  - Too few points (< 5) → 0.0
+  - Exactly 5 points (minimum viable)
+  - NaN/Inf handling (stripped before computation)
+  - List input (not just ndarray)
+  - High SNR recovery
+  - Low SNR recovery
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from nova_common.spectral import der_snr
+
+# ---------------------------------------------------------------------------
+# Known-noise recovery
+# ---------------------------------------------------------------------------
+
+
+class TestGaussianNoiseRecovery:
+    """Verify DER_SNR recovers the known SNR of synthetic Gaussian noise."""
+
+    @pytest.fixture()
+    def rng(self) -> np.random.Generator:
+        return np.random.default_rng(seed=42)
+
+    def test_snr_50_recovery(self, rng: np.random.Generator) -> None:
+        """Flat continuum + Gaussian noise with true SNR ≈ 50."""
+        signal = 100.0
+        noise_sigma = signal / 50.0  # true SNR = 50
+        flux = signal + rng.normal(0, noise_sigma, size=5000)
+
+        estimated = der_snr(flux)
+        assert estimated == pytest.approx(50.0, rel=0.15)
+
+    def test_snr_10_recovery(self, rng: np.random.Generator) -> None:
+        """Low SNR ≈ 10 — noisier but still recoverable."""
+        signal = 100.0
+        noise_sigma = signal / 10.0
+        flux = signal + rng.normal(0, noise_sigma, size=5000)
+
+        estimated = der_snr(flux)
+        assert estimated == pytest.approx(10.0, rel=0.15)
+
+    def test_snr_200_recovery(self, rng: np.random.Generator) -> None:
+        """High SNR ≈ 200 — very clean spectrum."""
+        signal = 1000.0
+        noise_sigma = signal / 200.0
+        flux = signal + rng.normal(0, noise_sigma, size=5000)
+
+        estimated = der_snr(flux)
+        assert estimated == pytest.approx(200.0, rel=0.15)
+
+    def test_different_signal_levels(self, rng: np.random.Generator) -> None:
+        """SNR estimate is independent of the absolute flux level."""
+        for signal in [1e-13, 1.0, 1e6]:
+            noise_sigma = signal / 30.0
+            flux = signal + rng.normal(0, noise_sigma, size=5000)
+            estimated = der_snr(flux)
+            assert estimated == pytest.approx(30.0, rel=0.20), f"Failed at signal={signal:.0e}"
+
+
+# ---------------------------------------------------------------------------
+# Robustness to spectral features
+# ---------------------------------------------------------------------------
+
+
+class TestEmissionLineRobustness:
+    """DER_SNR should be insensitive to sparse sharp features."""
+
+    @pytest.fixture()
+    def rng(self) -> np.random.Generator:
+        return np.random.default_rng(seed=99)
+
+    def test_emission_lines_dont_inflate_snr(self, rng: np.random.Generator) -> None:
+        """A few strong emission lines should not change the SNR estimate."""
+        signal = 100.0
+        noise_sigma = signal / 50.0
+        flux = signal + rng.normal(0, noise_sigma, size=5000)
+
+        # Add 20 strong emission lines (5× continuum)
+        line_positions = rng.choice(5000, size=20, replace=False)
+        flux[line_positions] = signal * 5.0
+
+        estimated = der_snr(flux)
+        # Should still be close to 50, not inflated by lines.
+        assert estimated == pytest.approx(50.0, rel=0.20)
+
+    def test_absorption_lines_dont_deflate_snr(self, rng: np.random.Generator) -> None:
+        """Absorption features should not bias the estimate downward."""
+        signal = 100.0
+        noise_sigma = signal / 50.0
+        flux = signal + rng.normal(0, noise_sigma, size=5000)
+
+        # Add 20 absorption lines (drop to 20% of continuum)
+        line_positions = rng.choice(5000, size=20, replace=False)
+        flux[line_positions] = signal * 0.2
+
+        estimated = der_snr(flux)
+        assert estimated == pytest.approx(50.0, rel=0.20)
+
+
+# ---------------------------------------------------------------------------
+# Sloped continuum
+# ---------------------------------------------------------------------------
+
+
+class TestSlopedContinuum:
+    """DER_SNR should handle spectra with a sloped continuum."""
+
+    def test_linear_slope(self) -> None:
+        """Linear continuum slope is cancelled by the second difference."""
+        rng = np.random.default_rng(seed=77)
+        n = 5000
+        wavelength = np.linspace(300, 900, n)
+        # Continuum rises from 50 to 150 across the spectrum.
+        continuum = 50 + 100 * (wavelength - 300) / 600
+        noise_sigma = np.median(continuum) / 40.0  # true SNR ≈ 40
+        flux = continuum + rng.normal(0, noise_sigma, size=n)
+
+        estimated = der_snr(flux)
+        assert estimated == pytest.approx(40.0, rel=0.20)
+
+
+# ---------------------------------------------------------------------------
+# Degenerate inputs
+# ---------------------------------------------------------------------------
+
+
+class TestDegenerateInputs:
+    """Edge cases that should return 0.0 without raising."""
+
+    def test_constant_flux(self) -> None:
+        """Constant flux → noise = 0 → returns 0.0."""
+        flux = np.full(1000, 42.0)
+        assert der_snr(flux) == 0.0
+
+    def test_all_zeros(self) -> None:
+        """All-zero flux → 0.0."""
+        assert der_snr(np.zeros(1000)) == 0.0
+
+    def test_empty_array(self) -> None:
+        """Empty array → 0.0."""
+        assert der_snr(np.array([])) == 0.0
+
+    def test_single_value(self) -> None:
+        """Single element → 0.0 (fewer than 5 points)."""
+        assert der_snr(np.array([100.0])) == 0.0
+
+    def test_four_points(self) -> None:
+        """Exactly 4 points → 0.0 (minimum is 5)."""
+        assert der_snr(np.array([1.0, 2.0, 3.0, 4.0])) == 0.0
+
+    def test_five_points_works(self) -> None:
+        """Exactly 5 points is the minimum viable input."""
+        rng = np.random.default_rng(seed=11)
+        flux = 100.0 + rng.normal(0, 5, size=5)
+        result = der_snr(flux)
+        # Not testing accuracy with 5 points — just that it runs.
+        assert result >= 0.0
+
+    def test_negative_median_flux(self) -> None:
+        """Negative median → 0.0 (no meaningful signal)."""
+        flux = np.full(1000, -50.0) + np.random.default_rng(0).normal(0, 1, 1000)
+        assert der_snr(flux) == 0.0
+
+    def test_all_nan(self) -> None:
+        """All NaN → 0.0 (nothing finite to work with)."""
+        assert der_snr(np.full(100, np.nan)) == 0.0
+
+    def test_all_inf(self) -> None:
+        """All Inf → 0.0."""
+        assert der_snr(np.full(100, np.inf)) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# NaN / Inf handling
+# ---------------------------------------------------------------------------
+
+
+class TestNonFiniteHandling:
+    """Non-finite values are stripped; computation proceeds on the rest."""
+
+    def test_scattered_nans_stripped(self) -> None:
+        """A few NaNs mixed in don't break the estimate."""
+        rng = np.random.default_rng(seed=55)
+        flux = 100.0 + rng.normal(0, 2.0, size=5000)
+        # Sprinkle 50 NaNs.
+        nan_idx = rng.choice(5000, size=50, replace=False)
+        flux[nan_idx] = np.nan
+
+        estimated = der_snr(flux)
+        assert estimated == pytest.approx(50.0, rel=0.15)
+
+    def test_infs_stripped(self) -> None:
+        """Inf values are removed, estimate uses remaining data."""
+        rng = np.random.default_rng(seed=66)
+        flux = 100.0 + rng.normal(0, 2.0, size=5000)
+        flux[0] = np.inf
+        flux[1] = -np.inf
+
+        estimated = der_snr(flux)
+        assert estimated == pytest.approx(50.0, rel=0.15)
+
+
+# ---------------------------------------------------------------------------
+# Input type flexibility
+# ---------------------------------------------------------------------------
+
+
+class TestInputTypes:
+    """der_snr accepts array-like inputs, not just ndarray."""
+
+    def test_list_input(self) -> None:
+        """Plain Python list is accepted."""
+        rng = np.random.default_rng(seed=88)
+        flux = (100.0 + rng.normal(0, 2.0, size=1000)).tolist()
+        estimated = der_snr(flux)
+        assert estimated > 0
+
+    def test_integer_array(self) -> None:
+        """Integer flux values are promoted to float64."""
+        rng = np.random.default_rng(seed=44)
+        flux = (1000 + rng.normal(0, 20, size=1000)).astype(np.int32)
+        estimated = der_snr(flux)
+        assert estimated == pytest.approx(50.0, rel=0.20)
+
+    def test_float32_array(self) -> None:
+        """float32 input is handled correctly."""
+        rng = np.random.default_rng(seed=33)
+        flux = (100.0 + rng.normal(0, 2.0, size=1000)).astype(np.float32)
+        estimated = der_snr(flux)
+        assert estimated == pytest.approx(50.0, rel=0.15)


### PR DESCRIPTION
## Summary
- Wired DER_SNR fallback into the spectra artifact generator — every
  spectrum now has an effective SNR value, even ticket-ingested data
  with no archive-provided SNR
- Added absolute display gate: spectra with SNR < 5 excluded from the
  waterfall plot (observation table unaffected)
- Added relative compositing gate: spectra with SNR < 1/3 of their
  group's median excluded from composites, moved to
  rejected_data_product_ids
- 24 unit tests for der_snr itself

## Why
- Low-SNR spectra (noise-dominated, SNR ~3–7) were being displayed
  alongside high-quality spectra and included in composites, degrading
  both visual quality and composite SNR
- Many spectra (especially ticket-ingested data) had no SNR value at
  all, making any threshold-based gating ineffective without a fallback
  estimator
- DER_SNR (Stoehr et al. 2008) fills that gap using only the flux
  array — no error arrays, no continuum fitting, no wavelength
  calibration needed

## Testing
- 24 new der_snr unit tests: Gaussian noise recovery at SNR 10/50/200,
  emission/absorption line robustness, sloped continua, all degenerate
  inputs (constant flux, zeros, empty, < 5 points, negative median,
  NaN, Inf), input type flexibility (list, int32, float32)
- All existing tests pass (1549 + 24 = 1573 total)
- mypy strict, ruff clean, frontend build clean

## Notes
- SNR of 0.0 (DER_SNR returns this for constant flux, degenerate
  inputs) is treated as pass-through — "I can't compute an SNR" is
  not the same as "the SNR is bad"
- The display gate runs after multi-arm merge so merged spectra get
  DER_SNR computed on their combined flux, not inherited from one arm
- The compositing gate only fires when group_median_snr > 0 — if
  nobody in the group has SNR, no rejections occur

## Out of Scope
- Tests for the display gate and compositing gate integration (next
  commit)
- DER_SNR computation at validation/ingestion time (future — tracked
  as worklog item #38)
- ADR-033 amendment for compositing purpose reframing (separate commit,
  already written)

## Next Steps
- Integration tests for display gate and compositing gate
- Run full artifact sweep to see gating in action across the catalog
- Add DER_SNR to ticket validation profile for new ingestions