### PR TITLE
Epic/30 spectra quality and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ tools/svo-filter-analysis/svo_fps.db-wal
 /tools/catalog-expansion/spectra_tickets/Data
 /tools/catalog-expansion/spectra_tickets
 /tools/catalog-expansion/vizier_data
+/tools/novacat-tools/notebooks/iue_downloads/mastDownload
+/tools/catalog-expansion/v615_vul_valisa
+/tools/catalog-expansion/vizier_nova_spectra

--- a/docs/worklog/bugs_list_4_16_26.md
+++ b/docs/worklog/bugs_list_4_16_26.md
@@ -1,0 +1,8 @@
+
+
+1. An audit (test?) to ensure that all nova pages are loading correctly (i.e., not failing/crashing)
+2. Flag potentially mislabelled data. (e.g., when a nova doesn't have any data points <100 days from discovery and/or has data > 5000 days past outburst or pre-outburst.)
+3. Flag novae without any references
+4. Flag, quarantine, and don't show spectra missing any of the following: source, telescope, instrument.
+5. Flag (and don't show) photometry without a source
+6. Have observation table for photometry.

--- a/docs/worklog/master-tasks.md
+++ b/docs/worklog/master-tasks.md
@@ -1,6 +1,6 @@
 # Nova Cat — Post-MVP Master Task List
 
-_Generated: 2026-04-04 · Updated: 2026-04-09 (v7) · Living document_
+_Generated: 2026-04-04 · Updated: 2026-04-14 (v8) · Living document_
 
 ---
 
@@ -21,25 +21,29 @@ Each task has:
 
 | ID | Task | CC | Dep | Status |
 |----|------|----|-----|--------|
-| B12 | **Sparkline left/right margins misaligned in catalog table.** CSS/table cell alignment issue. | 🟢 | — | ⬜ |
-| BN2 | **Bundle metadata.json count vs README count mismatch.** Audit after BN1 fix — may self-resolve. | 🟡 | — | ⬜ |
-| BN4 | **Empty sources.json spectra array.** Direct consequence of BN1 — audit whether it self-resolved after the BN1 fix. | 🟡 | — | ⬜ |
-| B17 | **Fargate artifact generator logs not sortable.** Log format doesn't include a field that supports proper chronological sorting in CloudWatch. Fix the logger configuration so Fargate operations can be traced sequentially. | 🟡 | — | ⬜ |
+| B17 | **Fargate logger sorting, blank rows, and structured formatting.** Log format doesn't support chronological sorting in CloudWatch. Also ensure Fargate logs are structured correctly so they can be parsed by the reader app and Logs Insights. | 🟡 | — | ⬜ |
 | B18 | **Radio band registry test fixture missing radio entries.** All 17 `test_band_registry_radio.py` tests fail — resolver returns `None` for every lookup. Radio entries were likely dropped from the test fixture during a band registry rebuild. | 🟢 | — | ⬜ |
+| B19 | **Hard floor for spectra y-axis.** When plotting individual spectra, large chunks get cut off — not just the bottom spectrum. Need hard controls on the minimum y-value. Includes log-scale variant. Part of the long-range spectra.py rebuild (R10). | 🟡 | — | ⬜ |
 
 ---
 
-## Spectra
+## Spectra — Display
 
 | ID | Task | CC | Dep | Status |
 |----|------|----|-----|--------|
 | S6 | **Spectra quality audit.** Identify and triage all skipped/edge-trimmed spectra across the catalog. X-Shooter skips already confirmed — investigate remaining instruments. | 🟡 | — | ⬜ |
-| S7 | **Multi-regime spectra display.** Display spectra from instruments covering different wavelength regimes (UV, optical, NIR) on separate panels or with regime indicators. | 🟡 | — | ⬜ |
-| S13 | **Dichroic gap trace splitting.** Frontend: split merged-spectrum Plotly traces at dichroic gap boundaries so Plotly doesn't draw a connecting line across the gap (e.g., UVES blue/red join). | 🟢 | — | ⬜ |
-| S14 | **Use all spectra from a given night via interpolation.** Currently not all spectra from a single night are stitched together. Add interpolation to incorporate all available wavelength regimes from the same observation epoch. | 🟡 | — | ⬜ |
-| S15 | **Change spectral line feature units from Å to nm.** Update the line list and feature marker labels. Also remove the Å symbol from hydrogen feature labels. | 🟢 | — | ✅ |
-| S16 | **STIS adapter for spectra.** Build a validation profile and adapter for HST/STIS spectral data products. | 🟡 | — | ⬜ |
-| S17 | **"Spectral Visits" data column.** Add a column to the catalog table showing the number of unique observation nights with spectra (distinct from total spectrum count). | 🟢 | — | ✅ |
+| S18 | **sqrt(flux) scaling option.** Add a square-root flux scaling toggle when viewing an individual spectrum. | 🟢 | — | ⬜ |
+| S19 | **X-ray x-axis units (keV).** The spectra viewer x-axis needs to support energy (keV) for X-ray data, rather than wavelength (nm). | 🟡 | — | ⬜ |
+| S20 | **Spectral features for X-ray, UV, and NIR.** Extend the spectral feature marker system beyond the current optical-only set (Fe II, He/N, Nebular). | 🟡 | — | ⬜ |
+
+---
+
+## Spectra — Pipeline
+
+| ID | Task | CC | Dep | Status |
+|----|------|----|-----|--------|
+| S21 | **DER_SNR at ingestion time.** Add DER_SNR computation to the ticket validation profile so new ingestions get SNR at write time, rather than relying solely on the artifact generator fallback. | 🟢 | — | ⬜ |
+| S22 | **SNR gate integration tests.** Tests for the display gate (SNR < 5 excluded from waterfall) and compositing relative gate (< 1/3 group median → rejected). | 🟢 | — | ⬜ |
 
 ---
 
@@ -51,14 +55,43 @@ Each task has:
 
 ---
 
+## New Data Regimes
+
+| ID | Task | CC | Dep | Status |
+|----|------|----|-----|--------|
+| DR1 | **Gamma-ray nova detection pipeline.** Add support for detecting gamma-ray novae via Fermi-LAT references. | 🔴 | — | ⬜ |
+| DR2 | **Gamma-ray visualization.** Add support for visualizing gamma-ray detections in the light curve panel. | 🟡 | DR1 | ⬜ |
+
+---
+
+## Frontend
+
+| ID | Task | CC | Dep | Status |
+|----|------|----|-----|--------|
+| F6 | **Splash page = catalog page.** Merge so people access the catalog without navigating away. Show stats on every page. | 🟡 | — | ⬜ |
+| F7 | **Total unique spectral visits in stats display.** | 🟢 | — | ⬜ |
+| F8 | **Stats broken out by spectral regime.** Separate stats per regime (optical, UV, NIR, etc.). | 🟡 | — | ⬜ |
+| F9 | **Sources column for ticket-ingested data should show bibcode.** | 🟢 | — | ⬜ |
+
+---
+
 ## Pipeline & Infrastructure
 
 | ID | Task | CC | Dep | Status |
 |----|------|----|-----|--------|
+| PI1 | **`refresh_references` payload reduction.** Hits the 256 KB SFn payload limit for novae with many references (e.g., IM Nor, recurrent novae). Needs a payload reduction refactor similar to the `discover_spectra_products` fix. | 🟡 | — | ⬜ |
+| PI2 | **CloudWatch log group cleanup formalization.** Cleanup script exists; formalize as recurring task or retention policy. | 🟢 | — | ⬜ |
+| PI3 | **Initial ingestion enrichment.** `initialize_nova` should look up the discovery date, add the nova type(s) (e.g., Symbiotic, Fe II, He/N), and ensure clean display names. Underscore removal is done; discovery date lookup and type assignment are new. | 🟡 | F10 | ⬜ |
 | I2 | **Coordinate dedup ASL wiring.** Wire the coordinate-based dedup logic into the identity resolution step function so near-duplicate novae are caught automatically. | 🟡 | — | ⬜ |
 | R4 | **Smooth pipeline (end-to-end).** Integration and polish pass — the "it all just works" capstone. Depends on most other work being done. | 🔴 | R5, most others | ⬜ |
-| PI1 | **`refresh_references` payload reduction.** Hits the 256 KB SFn payload limit for novae with many references (e.g., IM Nor, recurrent novae). Needs a payload reduction refactor similar to the `discover_spectra_products` fix. | 🟡 | — | ⬜ |
-| PI2 | **CloudWatch log group cleanup.** Stale/unrecognized log groups accumulating. Add cleanup tooling or a retention policy sweep. | 🟢 | — | ⬜ |
+
+---
+
+## Data Model
+
+| ID | Task | CC | Dep | Status |
+|----|------|----|-----|--------|
+| F10 | **Change nova "Type" field to a list.** Currently a string; should support multiple types (e.g., classical + symbiotic). Prerequisite for PI3 automatic type assignment. | 🟡 | — | ⬜ |
 
 ---
 
@@ -66,8 +99,8 @@ Each task has:
 
 | ID | Task | CC | Dep | Status |
 |----|------|----|-----|--------|
-| R5 | **Unified reseed/redeploy/rebuild app (with GUI).** Consolidate the scattered operator scripts (reseed_work_items, set_nova_dates, batch_ingest, propose_filters, etc.) into a single Streamlit or similar app. Replaces R5a–R5d Streamlit console concept. | 🔴 | — | ⬜ |
-| OT8 | **UVES spectra reduction pipeline.** Build our own reduction pipeline for raw UVES data, rather than relying solely on ESO Phase 3 reduced products. | 🔴 | — | ⬜ |
+| R5 | **Unified reseed/redeploy/rebuild app (with GUI).** Consolidate the scattered operator scripts (reseed_work_items, set_nova_dates, batch_ingest, propose_filters, etc.) into a single Streamlit or similar app. | 🔴 | — | ⬜ |
+| OT8 | **UVES spectra reduction pipeline.** Build own reduction pipeline for raw UVES data, rather than relying solely on ESO Phase 3 reduced products. FORS2 via esorex/esoreflex also explored. | 🔴 | — | ⬜ |
 
 ---
 
@@ -85,6 +118,8 @@ Each task has:
 | ID | Task | CC | Dep | Status |
 |----|------|----|-----|--------|
 | L1 | **Enrich structured log context across all handlers.** Ensure `data_product_id`, `bibcode`, `provider`, `instrument` are appended whenever in scope. | 🟡 | — | ⬜ |
+| L5 | **Reduce CloudWatch Logs Insights cost.** Stricter selection criteria for which log groups to query, to reduce data scanned per query. Charged per GB scanned, not just per GB ingested. | 🟢 | — | ⬜ |
+| L6 | **Minimize per-item logging.** Reduce chattiness — e.g., one aggregated log entry for a batch of warnings instead of one entry per warning. Cuts both log volume and Insights scan cost. | 🟡 | — | ⬜ |
 
 ---
 
@@ -93,7 +128,18 @@ Each task has:
 | ID | Task | CC | Dep | Status |
 |----|------|----|-----|--------|
 | D1 | **Update current-architecture.md.** Dated 2026-03-28. Reflects pre-Epic-5 state. | 🟡 | — | ⬜ |
-| D2 | **Recurrent novae design.** Develop a plan/design for how to handle recurrent novae in the catalog — multiple outbursts, cross-outburst identity, epoch disambiguation, UI for multiple light curves per object. | 🔴 | — | ⬜ |
+| D2 | **Recurrent novae design.** Multiple outbursts, cross-outburst identity, epoch disambiguation. Includes redesigning spectra and photometry viewer to accommodate multiple outburst epochs per object. | 🔴 | — | ⬜ |
+| D3 | **Audit .py file documentation.** Ensure docstrings and inline comments across services are accurate and up to date. | 🟡 | — | 🔲 |
+
+---
+
+## Long-Range
+
+| ID | Task | CC | Dep | Status |
+|----|------|----|-----|--------|
+| R10 | **Rebuild spectra.py.** Eliminate redundancies and clean up the artifact generator's spectra pipeline end-to-end. Hard floor fix (B19) is part of this. | 🔴 | — | ⬜ |
+| LR1 | **Data donation page + backend infrastructure.** Allow external contributors to submit observational data to the catalog. | 🔴 | — | ⬜ |
+| LR2 | **Provenance and accreditation system for donated data.** Rules and enforcement for how donated data can be used: creator provisions (co-authorship, acknowledgement, bundle inclusion), downloader obligations (sign terms, notification to donor, README attribution). | 🔴 | LR1 | ⬜ |
 
 ---
 
@@ -101,50 +147,64 @@ Each task has:
 
 | Category | Count |
 |----------|-------|
-| ✅ Done | 77 |
-| ⬜ Remaining (bugs) | 5 |
-| ⬜ Remaining (features/tasks) | 17 |
-| **Total open** | **22** |
+| ✅ Done | 104 |
+| ⬜ Remaining (bugs) | 3 |
+| ⬜ Remaining (features/tasks) | 31 |
+| **Total open** | **34** |
 
 ---
 
 ## Suggested Priority Order
 
-**Quick wins / unblock further ingestion:**
-1. BN2/BN4 — Audit bundle fixes (may already be resolved)
-2. B18 — Radio test fixture rebuild
-3. B17 — Fargate logger sorting + blank rows
+**Quick wins / high impact:**
+1. B18 — Radio test fixture rebuild (10 min, unblocks 17 tests)
+2. S22 — SNR gate integration tests (close out the epic)
+3. F9 — Sources bibcode column (small artifact generator + frontend change)
+4. F7 — Spectral visits in stats display
 
 **Spectra quality & display:**
-4. S13 — Dichroic gap trace splitting
 5. S6 — Spectra quality audit
-6. S14 — Same-night interpolation
-7. S7 — Multi-regime display
+6. B19 — Spectra y-axis hard floor
+7. S18 — sqrt(flux) scaling
+8. S19 — X-ray keV x-axis
+9. S20 — Non-optical spectral features
+
+**Data model & ingestion enrichment:**
+10. F10 — Nova Type as list
+11. PI3 — Initial ingestion enrichment (discovery date, types)
+12. S21 — DER_SNR at ingestion time
 
 **Pipeline robustness:**
-8. PI1 — refresh_references payload reduction
-9. PI2 — CloudWatch log group cleanup
-10. B12 — Sparkline margins
+13. PI1 — refresh_references payload reduction
+14. PI2 — CloudWatch log group cleanup formalization
+15. L5 — Reduce Logs Insights cost
+16. L6 — Minimize per-item logging
+
+**Frontend overhaul:**
+17. F6 — Splash page = catalog page
+18. F8 — Stats by regime
+19. P4 — Photometry color palette
 
 **New capabilities:**
-11. S16 — STIS adapter
-12. P4 — Photometry color palette
-13. I2 — Coordinate dedup ASL wiring
+20. DR1/DR2 — Gamma-ray pipeline + visualization
+21. I2 — Coordinate dedup ASL wiring
 
 **Bigger arcs:**
-14. R5 — Unified operator app
-15. T1, T2 — Test suites
-16. L1 — Log enrichment
-17. D1 — Architecture doc update
-18. D2 — Recurrent novae design
-19. OT8 — UVES reduction pipeline
-20. R4 — Smooth pipeline (capstone)
+22. R5 — Unified operator app
+23. T1, T2 — Test suites
+24. L1 — Log enrichment
+25. D1 — Architecture doc update
+26. D2 — Recurrent novae design
+27. OT8 — UVES reduction pipeline
+28. R10 — spectra.py rebuild
+29. LR1/LR2 — Data donation + provenance
+30. R4 — Smooth pipeline (capstone)
 
 ---
 
 # Completed Tasks
 
-_74 tasks completed across all workstreams._
+_104 tasks completed across all workstreams._
 
 | ID | Task |
 |----|------|
@@ -159,11 +219,25 @@ _74 tasks completed across all workstreams._
 | B9 | Duplicate wavelength hover text |
 | B10 | Truncated MJD values for radio observations |
 | B11 | Month-precision date comparison |
+| B12 | Sparkline left/right margins misaligned |
 | B13 | NaN sentinel in spectra.json |
 | B14 | Zoom state lost on feature/scale toggle |
 | B15 | Hover labels broken while zoomed |
 | B16 | Spectra below x-axis (negative flux packing) |
+| B20 | Red wavelength edge clipping (ADR-035 regime updates) |
+| B21 | Reset axes scaling regression in single-spectrum mode |
+| B22 | Zoom + spectral line toggle state bug |
+| B23 | Radio upper limits silently dropped by artifact generator |
+| B24 | Spectral visits not persisted to DDB (finalizer writeback gap) |
+| B25 | Spectral visits miscounting midnight-spanning runs |
+| B26 | Underscore nova names (pipeline using candidate_name not SIMBAD main_id) |
+| B27 | CDK orphan log groups (AssetHashType.OUTPUT for Docker assets) |
+| B28 | SNR only displaying for ~1 in 5 observations (UVES UV_SOBF vs UV_SFLX) |
+| B29 | Spectral visits regression (pre-feature novae missing DDB field) |
 | BN1 | Bundle generator hardcoded S3 path |
+| BN2 | Bundle metadata.json count vs README count mismatch |
+| BN3 | Empty .bib on partial sweeps (references pre-population) |
+| BN4 | Empty sources.json spectra array |
 | S1 | LTTB downsampling / flat spectra fix |
 | S2 | X-axis truncation |
 | S3 | Flux floor for log scale |
@@ -171,11 +245,21 @@ _74 tasks completed across all workstreams._
 | S4b | NaN sentinel fix for merged spectra |
 | S4c | Merge MJD tolerance widening + overlap rejection |
 | S5 | Spectral feature hover (scatter trace approach) |
+| S7 | Multi-regime spectra display (ADR-034 + frontend regime tabs) |
 | S8 | Wavelength/SNR enrichment pipeline |
 | S9 | ADS collection filter (spurious references fix) |
 | S10 | Same-day spectra deduplication |
 | S11 | Collision-aware waterfall packing |
 | S12 | Dense color palette fix |
+| S13 | Dichroic gap trace splitting |
+| S14 | Same-night interpolation / cross-instrument stitching |
+| S15 | Spectral line feature units Å → nm |
+| S16 | STIS adapter for spectra (MAST HASP discovery + FITS profile) |
+| S17 | Spectral visits catalog column |
+| S23 | ADR-033 spectra compositing pipeline (full implementation) |
+| S24 | DER_SNR fallback + SNR display gate + compositing relative gate |
+| S25 | Equitable vertical spacing (gap capping attempted + reverted; pending R10) |
+| S26 | Long-wavelength spectra regime slicing (ADR-034 framework) |
 | P1 | Radio ingestion diagnosis |
 | P2 | Photometry observation count |
 | P3 | Hover errors on light curve panel |
@@ -187,6 +271,8 @@ _74 tasks completed across all workstreams._
 | F3 | Nova page alias display |
 | F4 | Empty state placeholders |
 | F5 | Observations table (rename + DataProduct fields) |
+| F11 | Discovery date MJD on nova page |
+| F12 | Spectral visits on nova page |
 | I1 | Underscore normalization |
 | R1 | Idempotency override |
 | R2 | DDB check before initialize_nova |
@@ -200,6 +286,7 @@ _74 tasks completed across all workstreams._
 | L4 | Structured error context on failure paths |
 | T3 | Identity resolution edge-case tests |
 | T4 | Spectra merge test suite |
+| T5 | DER_SNR unit tests (24 tests) |
 | OT1 | Reseed work items script |
 | OT2 | CloudWatch log viewer |
 | OT3 | Bundle diagnostic (root-caused BN1–BN4) |
@@ -209,6 +296,13 @@ _74 tasks completed across all workstreams._
 | OT7 | batch_ingest try-parse subcommand |
 | OT8a | propose_filters.py |
 | OT9 | CloudWatch log tracker configurable time/records |
-| S15 | Spectral line feature units Å → nm |
-| S17 | Spectral visits catalog column |
-| BN3 | Empty .bib on partial sweeps (references pre-population) |
+| OT10 | CloudWatch reader app — Fargate + Standard workflow log coverage |
+| OT11 | VOTable → ticket converters (Chomiuk+2021 radio + Strope+2010 V-band) |
+| OT12 | add_radio_freq.py (radio band registry CLI) |
+| OT13 | deploy.sh default changed to NovaCat only |
+| OT14 | Chip-gap zero-run diagnostic script |
+| OT15 | Nova candidate processor notebook |
+| OT16 | ESO instrument reduction feasibility survey (FORS2 + UVES) |
+| DOC1 | ADR-034 spectra wavelength regime model |
+| DOC2 | ADR-035 spectra regime splitting and per-regime display range |
+| DOC3 | ADR-033 amendment — compositing purpose reframing |

--- a/tools/purge_work_items.py
+++ b/tools/purge_work_items.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""purge_work_items.py — Remove WorkItems from the WORKQUEUE partition.
+
+Deletes pending WorkItems so the next sweep no longer picks them up.
+Primary use case: novae that have been hidden (HIDDEN status) but still
+have WorkItems triggering every sweep cycle. The artifact generator
+skips non-ACTIVE novae, so these WorkItems are wasted work that persist
+until their 30-day TTL expires.
+
+Usage (single nova by name):
+    python tools/purge_work_items.py --name "IM Nor" --dry-run
+    python tools/purge_work_items.py --name "IM Nor"
+
+Usage (single nova by ID):
+    python tools/purge_work_items.py --nova-id 64c5c516-... --dry-run
+    python tools/purge_work_items.py --nova-id 64c5c516-...
+
+Usage (all non-ACTIVE novae — the main use case):
+    python tools/purge_work_items.py --all-inactive --dry-run
+    python tools/purge_work_items.py --all-inactive
+
+Usage (specific dirty types only):
+    python tools/purge_work_items.py --name "IM Nor" --dirty spectra
+
+Environment variables:
+    NOVACAT_TABLE_NAME  — DynamoDB table name (default: NovaCat)
+
+Operator tooling — no CI requirements (mypy / ruff not enforced).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import boto3
+from boto3.dynamodb.conditions import Key
+
+_WORKQUEUE_PK = "WORKQUEUE"
+_ALL_DIRTY_TYPES = ["spectra", "photometry", "references"]
+
+_GREEN = "\033[92m"
+_RED = "\033[91m"
+_YELLOW = "\033[93m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+_RESET = "\033[0m"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_name(table, name):
+    """Resolve a nova name to a nova_id via NameMapping."""
+    normalized = name.strip().lower().replace("_", " ")
+    pk = f"NAME#{normalized}"
+    resp = table.query(KeyConditionExpression=Key("PK").eq(pk), Limit=1)
+    items = resp.get("Items", [])
+    return items[0].get("nova_id") if items else None
+
+
+def _get_nova_status(table, nova_id):
+    """Return the status of a Nova item, or None if not found."""
+    resp = table.get_item(
+        Key={"PK": nova_id, "SK": "NOVA"},
+        ProjectionExpression="#s, primary_name",
+        ExpressionAttributeNames={"#s": "status"},
+    )
+    item = resp.get("Item")
+    if not item:
+        return None, None
+    return item.get("status", "unknown"), item.get("primary_name", "unknown")
+
+
+def _query_work_items_for_nova(table, nova_id, dirty_types=None):
+    """Return all WorkItems for a specific nova, optionally filtered by dirty type."""
+    items = []
+    kwargs = {
+        "KeyConditionExpression": Key("PK").eq(_WORKQUEUE_PK)
+        & Key("SK").begins_with(f"{nova_id}#"),
+    }
+    while True:
+        resp = table.query(**kwargs)
+        items.extend(resp.get("Items", []))
+        if resp.get("LastEvaluatedKey") is None:
+            break
+        kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+
+    if dirty_types:
+        items = [i for i in items if i.get("dirty_type") in dirty_types]
+
+    return items
+
+
+def _query_all_work_items(table):
+    """Return all WorkItems from the WORKQUEUE partition."""
+    items = []
+    kwargs = {"KeyConditionExpression": Key("PK").eq(_WORKQUEUE_PK)}
+    while True:
+        resp = table.query(**kwargs)
+        items.extend(resp.get("Items", []))
+        if resp.get("LastEvaluatedKey") is None:
+            break
+        kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+    return items
+
+
+def _batch_delete(table, items, dry_run=False):
+    """Delete a list of WorkItems using BatchWriteItem (25-item chunks)."""
+    if not items:
+        return 0
+
+    deleted = 0
+    # BatchWriteItem accepts max 25 operations per call
+    for i in range(0, len(items), 25):
+        chunk = items[i : i + 25]
+        if dry_run:
+            for item in chunk:
+                print(f"  {_DIM}[DRY RUN] Would delete: SK={item['SK']}{_RESET}")
+            deleted += len(chunk)
+        else:
+            request_items = {
+                table.name: [
+                    {"DeleteRequest": {"Key": {"PK": _WORKQUEUE_PK, "SK": item["SK"]}}}
+                    for item in chunk
+                ]
+            }
+            # Use the underlying client for BatchWriteItem
+            client = table.meta.client
+            resp = client.batch_write_item(RequestItems=request_items)
+            deleted += len(chunk)
+
+            # Handle unprocessed items (retry once)
+            unprocessed = resp.get("UnprocessedItems", {})
+            if unprocessed:
+                print(
+                    f"  {_YELLOW}⚠ Retrying {len(unprocessed.get(table.name, []))} unprocessed items...{_RESET}"
+                )
+                client.batch_write_item(RequestItems=unprocessed)
+
+            for item in chunk:
+                print(f"  {_GREEN}✓{_RESET} Deleted: SK={item['SK']}")
+
+    return deleted
+
+
+# ---------------------------------------------------------------------------
+# Modes
+# ---------------------------------------------------------------------------
+
+
+def _purge_for_nova(table, nova_id, dirty_types, dry_run):
+    """Purge WorkItems for a single nova."""
+    status, name = _get_nova_status(table, nova_id)
+    print(f"Nova:   {name or 'unknown'} ({nova_id})")
+    print(f"Status: {status or 'NOT FOUND'}")
+
+    items = _query_work_items_for_nova(table, nova_id, dirty_types)
+    if not items:
+        print(f"\n{_DIM}No matching WorkItems found — nothing to purge.{_RESET}")
+        return
+
+    print(f"Found:  {len(items)} WorkItem(s)")
+    if dirty_types:
+        print(f"Filter: {', '.join(dirty_types)}")
+    if dry_run:
+        print(f"Mode:   {_YELLOW}DRY RUN{_RESET}")
+    print()
+
+    deleted = _batch_delete(table, items, dry_run=dry_run)
+
+    if dry_run:
+        print(f"\n{_YELLOW}[DRY RUN]{_RESET} Would delete {deleted} WorkItem(s).")
+    else:
+        print(f"\n{_GREEN}Deleted {deleted} WorkItem(s).{_RESET}")
+
+
+def _purge_all_inactive(table, dirty_types, dry_run):
+    """Purge WorkItems for all novae that are not ACTIVE."""
+    print(f"{_BOLD}Scanning WORKQUEUE for all pending WorkItems...{_RESET}")
+    all_items = _query_all_work_items(table)
+
+    if not all_items:
+        print(f"\n{_DIM}Work queue is empty — nothing to purge.{_RESET}")
+        return
+
+    # Extract unique nova_ids from WorkItem SKs
+    nova_ids = set()
+    for item in all_items:
+        # SK format: <nova_id>#<dirty_type>#<created_at>
+        parts = item["SK"].split("#", 1)
+        if parts:
+            nova_ids.add(parts[0])
+
+    print(f"Found {len(all_items)} WorkItem(s) across {len(nova_ids)} nova(e)")
+    print()
+
+    # Check each nova's status
+    inactive_nova_ids = set()
+    for nova_id in sorted(nova_ids):
+        status, name = _get_nova_status(table, nova_id)
+        if status != "ACTIVE":
+            inactive_nova_ids.add(nova_id)
+            print(
+                f"  {_RED}✗{_RESET} {name or 'unknown':20s} ({nova_id[:12]}…) — {status or 'NOT FOUND'}"
+            )
+        else:
+            print(
+                f"  {_GREEN}✓{_RESET} {name or 'unknown':20s} ({nova_id[:12]}…) — ACTIVE (keeping)"
+            )
+
+    if not inactive_nova_ids:
+        print(f"\n{_DIM}All novae with WorkItems are ACTIVE — nothing to purge.{_RESET}")
+        return
+
+    # Filter to only WorkItems belonging to non-ACTIVE novae
+    to_delete = [item for item in all_items if item["SK"].split("#", 1)[0] in inactive_nova_ids]
+
+    if dirty_types:
+        to_delete = [item for item in to_delete if item.get("dirty_type") in dirty_types]
+        print(f"\nDirty type filter: {', '.join(dirty_types)}")
+
+    print(
+        f"\n{_BOLD}Will purge {len(to_delete)} WorkItem(s) for {len(inactive_nova_ids)} inactive nova(e){_RESET}"
+    )
+    if dry_run:
+        print(f"Mode: {_YELLOW}DRY RUN{_RESET}")
+    print()
+
+    deleted = _batch_delete(table, to_delete, dry_run=dry_run)
+
+    if dry_run:
+        print(
+            f"\n{_YELLOW}[DRY RUN]{_RESET} Would delete {deleted} WorkItem(s) for {len(inactive_nova_ids)} inactive nova(e)."
+        )
+    else:
+        print(
+            f"\n{_GREEN}Deleted {deleted} WorkItem(s) for {len(inactive_nova_ids)} inactive nova(e).{_RESET}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Purge WorkItems from the WORKQUEUE partition.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Examples:
+  # Preview what would be purged for all non-ACTIVE novae
+  python tools/purge_work_items.py --all-inactive --dry-run
+
+  # Purge all WorkItems for a hidden nova
+  python tools/purge_work_items.py --name "IM Nor"
+
+  # Purge only spectra WorkItems for a nova
+  python tools/purge_work_items.py --name "IM Nor" --dirty spectra
+""",
+    )
+
+    id_group = parser.add_mutually_exclusive_group(required=True)
+    id_group.add_argument("--nova-id", help="Nova UUID")
+    id_group.add_argument("--name", help="Nova name (resolved via NameMapping)")
+    id_group.add_argument(
+        "--all-inactive",
+        action="store_true",
+        help="Purge WorkItems for ALL non-ACTIVE novae",
+    )
+
+    parser.add_argument(
+        "--dirty",
+        nargs="+",
+        choices=_ALL_DIRTY_TYPES,
+        help="Only purge specific dirty type(s). Default: all types.",
+    )
+    parser.add_argument(
+        "--table",
+        default=os.environ.get("NOVACAT_TABLE_NAME", "NovaCat"),
+        help="DynamoDB table name (default: $NOVACAT_TABLE_NAME or 'NovaCat')",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be deleted")
+
+    args = parser.parse_args()
+
+    dynamodb = boto3.resource("dynamodb")
+    table = dynamodb.Table(args.table)
+
+    print(f"Table: {args.table}")
+    print()
+
+    if args.all_inactive:
+        _purge_all_inactive(table, args.dirty, args.dry_run)
+    else:
+        if args.name:
+            nova_id = _resolve_name(table, args.name)
+            if not nova_id:
+                print(
+                    f"{_RED}ERROR:{_RESET} Could not resolve name '{args.name}' to a nova_id.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            print(f"Resolved '{args.name}' → {nova_id}")
+        else:
+            nova_id = args.nova_id
+
+        _purge_for_nova(table, nova_id, args.dirty, args.dry_run)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- New operator tool `tools/purge_work_items.py` for removing WorkItems from the WORKQUEUE partition
- Supports single-nova (`--name` / `--nova-id`) and bulk (`--all-inactive`) modes, with optional `--dirty` filter
- Updated `master-tasks.md` to track the new tool and related follow-ups

## Why
- Hidden (non-ACTIVE) novae with pending WorkItems were getting picked up on every 6-hour sweep
- The artifact generator skips non-ACTIVE novae, so these items are wasted work that sit in the queue until their 30-day TTL expires
- No existing tool to clean them up — had to wait them out or delete by hand

## Testing
- Ran `--all-inactive --dry-run` against the live table to confirm correct classification of ACTIVE vs. non-ACTIVE novae
- Verified `--name` resolution path via NameMapping
- Confirmed BatchWriteItem chunking handles >25 items

## Notes
- Operator tooling — no mypy strict / ruff CI requirements
- Follow-up idea (not in this PR): make the coordinator self-healing by filtering non-ACTIVE novae at plan-building time and having the Finalizer clean up orphaned WorkItems