### PR TITLE
feat(catalog): Sources column, SNR gate tests, and bug tracking updates

### DIFF
--- a/docs/worklog/bugs_list_4_16_26.md
+++ b/docs/worklog/bugs_list_4_16_26.md
@@ -6,3 +6,6 @@
 4. Flag, quarantine, and don't show spectra missing any of the following: source, telescope, instrument.
 5. Flag (and don't show) photometry without a source
 6. Have observation table for photometry.
+7. When you're on the third page of the catalog, click on a nova, and then hit back, it takes you to the first page.
+8. Issue with zoom in when toggling spectral features now affecting waterfall plot
+9. Pull Gaia and 2MASS info/data

--- a/frontend/src/components/catalog/CatalogTable.tsx
+++ b/frontend/src/components/catalog/CatalogTable.tsx
@@ -43,7 +43,7 @@ import {
   ChevronRight,
   Search,
 } from 'lucide-react';
-import type { NovaSummary } from '@/types/catalog';
+import type { NovaSummary, SourceEntry } from '@/types/catalog';
 import { getArtifactUrl } from '@/lib/dataClient';
 
 // ── Constants ──────────────────────────────────────────────────────────────
@@ -323,6 +323,32 @@ export function CatalogTable({
             {getValue<number>()}
           </span>
         ),
+      },
+
+      // ── Sources (§F9) ─────────────────────────────────────────────────
+      // Data provenance: archive providers and/or bibcodes from ticket ingestion.
+      {
+        id: 'sources',
+        header: 'Sources',
+        enableSorting: false,
+        cell: ({ row }) => {
+          const sources: SourceEntry[] = row.original.sources ?? [];
+          if (sources.length === 0) {
+            return (
+              <span className="text-[var(--color-text-disabled)]">—</span>
+            );
+          }
+          const labels = sources.map((s) =>
+            s.type === 'archive' ? s.provider : s.bibcode,
+          );
+          return (
+            <div className="flex flex-col text-sm text-[var(--color-text-primary)] leading-snug">
+              {labels.map((label) => (
+                <span key={label}>{label}</span>
+              ))}
+            </div>
+          );
+        },
       },
 
       // ── Light curve sparkline ────────────────────────────────────────

--- a/frontend/src/types/catalog.ts
+++ b/frontend/src/types/catalog.ts
@@ -1,7 +1,7 @@
 /**
  * Types for the catalog.json static artifact.
  *
- * Schema version: 1.1 (ADR-014, DESIGN-003 §11.9)
+ * Schema version: 1.2 (ADR-014, DESIGN-003 §11.9, §F9)
  * These types mirror the artifact schema exactly. Field renames are breaking
  * changes — any update here must be coordinated with the backend generation
  * pipeline.
@@ -12,6 +12,21 @@
  *     month and day are "00" when only year precision is available.
  *     Null when no dated references exist for the nova.
  */
+
+/** Archive-provider source (e.g. ESO, AAVSO). */
+export interface ArchiveSource {
+  type: 'archive';
+  provider: string;
+}
+
+/** Bibcode-backed source from ticket ingestion. */
+export interface BibcodeSource {
+  type: 'bibcode';
+  bibcode: string;
+}
+
+/** Discriminated union for data provenance entries. */
+export type SourceEntry = ArchiveSource | BibcodeSource;
 
 /** One entry in the `novae` array of catalog.json. */
 export interface NovaSummary {
@@ -63,6 +78,15 @@ export interface NovaSummary {
    * The light curve column is post-MVP; this flag is reserved for when it lands.
    */
   has_sparkline: boolean;
+
+  /**
+   * Data provenance entries. Each entry is either an archive provider
+   * (e.g. "ESO") or a bibcode from ticket-ingested data.
+   * Empty array when no validated spectra exist for this nova.
+   *
+   * Schema v1.2 (§F9).
+   */
+  sources: SourceEntry[];
 }
 
 /** Aggregate statistics block for the homepage stats bar. */

--- a/services/artifact_generator/generators/catalog.py
+++ b/services/artifact_generator/generators/catalog.py
@@ -25,6 +25,7 @@ Schema amendments (§11.9):
 from __future__ import annotations
 
 import logging
+from collections import defaultdict
 from decimal import Decimal
 from typing import Any
 
@@ -35,7 +36,9 @@ from generators.shared import format_coordinates, generated_at_timestamp
 
 _logger = logging.getLogger("artifact_generator")
 
-_SCHEMA_VERSION = "1.1"
+_SCHEMA_VERSION = "1.2"
+
+_TICKET_PROVIDER = "ticket_ingestion"
 
 
 # ---------------------------------------------------------------------------
@@ -70,8 +73,11 @@ def generate_catalog_json(
     # Step 2 — Scan all ACTIVE Nova items from DDB.
     active_novae = _scan_active_novae(table)
 
+    # Step 2b — Scan DataProducts to build per-nova source lists.
+    sources_by_nova = _scan_data_product_sources(table)
+
     # Step 3 — Merge: DDB as base, in-memory as overlay (§11.3).
-    records = _merge_records(active_novae, sweep_overlay)
+    records = _merge_records(active_novae, sweep_overlay, sources_by_nova)
 
     # Step 4 — Sort: spectra_count desc, primary_name asc (§11.6).
     records.sort(key=lambda r: (-r["spectra_count"], r["primary_name"]))
@@ -174,6 +180,73 @@ def _scan_active_novae(table: Any) -> list[dict[str, Any]]:
 
 
 # ---------------------------------------------------------------------------
+# DataProduct source extraction
+# ---------------------------------------------------------------------------
+
+
+def _scan_data_product_sources(
+    table: Any,
+) -> dict[str, list[dict[str, str]]]:
+    """Scan all VALID SPECTRA DataProducts and extract per-nova source lists.
+
+    Returns a dict keyed by nova_id → sorted, deduplicated list of source
+    entry dicts (``{"type": "archive", "provider": "..."}`` or
+    ``{"type": "bibcode", "bibcode": "..."}``).
+
+    Ticket-ingested DataProducts are identified by ``provider ==
+    "ticket_ingestion"``; their bibcode is extracted from the
+    ``locator_identity`` field (format ``ticket_ingestion:<bibcode>:<file>``).
+    """
+    # Collect unique (type, value) tuples per nova.
+    raw: dict[str, set[tuple[str, str]]] = defaultdict(set)
+
+    scan_kwargs: dict[str, Any] = {
+        "FilterExpression": (
+            Attr("SK").begins_with("PRODUCT#SPECTRA#") & Attr("validation_status").eq("VALID")
+        ),
+        "ProjectionExpression": "PK, provider, locator_identity",
+    }
+
+    while True:
+        response: dict[str, Any] = table.scan(**scan_kwargs)
+        for item in response.get("Items", []):
+            nova_id = item.get("PK", "")
+            provider = item.get("provider", "")
+            locator = item.get("locator_identity", "")
+
+            if provider == _TICKET_PROVIDER:
+                # Format: "ticket_ingestion:<bibcode>:<filename>"
+                # Silently skip if the locator is missing or malformed.
+                if locator.startswith("ticket_ingestion:"):
+                    parts = locator.split(":", 2)
+                    if len(parts) >= 2 and parts[1]:
+                        raw[nova_id].add(("bibcode", parts[1]))
+            elif provider:
+                raw[nova_id].add(("archive", provider))
+
+        if response.get("LastEvaluatedKey") is None:
+            break
+        scan_kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
+
+    # Convert to sorted list of dicts for deterministic output.
+    result: dict[str, list[dict[str, str]]] = {}
+    for nova_id, entries in raw.items():
+        sources: list[dict[str, str]] = []
+        for kind, value in sorted(entries):
+            if kind == "archive":
+                sources.append({"type": "archive", "provider": value})
+            else:
+                sources.append({"type": "bibcode", "bibcode": value})
+        result[nova_id] = sources
+
+    _logger.info(
+        "DataProduct source scan complete",
+        extra={"novae_with_sources": len(result), "phase": "catalog_sources"},
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
 # Record assembly (§11.3)
 # ---------------------------------------------------------------------------
 
@@ -181,6 +254,7 @@ def _scan_active_novae(table: Any) -> list[dict[str, Any]]:
 def _merge_records(
     active_novae: list[dict[str, Any]],
     sweep_overlay: dict[str, _SweepCounts],
+    sources_by_nova: dict[str, list[dict[str, str]]] | None = None,
 ) -> list[dict[str, Any]]:
     """Merge DDB items with in-memory sweep results.
 
@@ -229,6 +303,9 @@ def _merge_records(
             float(_to_decimal(dec_deg)),
         )
 
+        # Source entries for this nova (§F9).
+        sources = (sources_by_nova or {}).get(nova_id, [])
+
         # Output mapping (§11.5).
         records.append(
             {
@@ -243,6 +320,7 @@ def _merge_records(
                 "references_count": references_count,
                 "has_sparkline": has_sparkline,
                 "spectral_visits": spectral_visits,
+                "sources": sources,
             }
         )
 

--- a/tests/integration/test_snr_gates.py
+++ b/tests/integration/test_snr_gates.py
@@ -1,0 +1,481 @@
+"""Integration tests for spectra SNR quality gates.
+
+Covers two gates introduced in epic/29-spectra-quality-and-docs:
+
+1. **Display gate** (``spectra.py:487``, constant ``_SNR_DISPLAY_FLOOR = 5.0``):
+   Individual spectra with ``0 < effective_snr < 5.0`` are excluded from the
+   waterfall plot output.  SNR exactly equal to 5.0 is *included* (strict
+   less-than comparison).
+
+2. **Composite relative gate** (``compositing.py:1055–1076``,
+   constant ``_COMPOSITING_SNR_RELATIVE_THRESHOLD = 1/3``):
+   Within a compositing group of ≥ 2 members, spectra with
+   ``0 < snr < (group_median_snr × 1/3)`` are excluded from the composite
+   but may still appear individually if they pass the display gate.
+
+Gate implementations:
+  - Display gate:    ``services/artifact_generator/generators/spectra.py`` line 487
+  - Composite gate:  ``services/artifact_generator/generators/compositing.py`` line 1055
+  - SNR estimator:   ``services/nova_common_layer/python/nova_common/spectral.py`` (``der_snr``)
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+from unittest.mock import patch
+
+import boto3
+import numpy as np
+from moto import mock_aws
+from nova_common.spectral import der_snr
+from numpy.typing import NDArray
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_TABLE_NAME = "NovaCat-SNRGate-Test"
+_BUCKET = "nova-cat-snr-gate-test"
+_REGION = "us-east-1"
+_NOVA_ID = "snrgate-0000-0000-0000-000000000001"
+
+
+# ---------------------------------------------------------------------------
+# Synthetic flux helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_high_snr_fluxes(n: int = 2000, seed: int = 42) -> list[float]:
+    """Return a flux array whose DER_SNR estimate is well above 5.
+
+    Constant signal = 1000 with low Gaussian noise (σ = 10) → SNR ≈ 100.
+    """
+    rng = np.random.default_rng(seed)
+    result: list[float] = (1000.0 + rng.normal(0, 10, n)).tolist()
+    return result
+
+
+def _make_low_snr_fluxes(n: int = 2000, seed: int = 99) -> list[float]:
+    """Return a flux array whose DER_SNR estimate is well below 5.
+
+    Signal = 10 with high Gaussian noise (σ = 50) → SNR ≈ 0.2.
+    """
+    rng = np.random.default_rng(seed)
+    fluxes = 10.0 + rng.normal(0, 50, n)
+    # Ensure all values are positive so DER_SNR doesn't bail on negative median.
+    result: list[float] = np.abs(fluxes).tolist()
+    return result
+
+
+def _make_csv(fluxes: list[float], wl_start: float = 400.0, wl_end: float = 700.0) -> str:
+    """Build a ``wavelength_nm,flux`` CSV body from a flux array."""
+    wavelengths = np.linspace(wl_start, wl_end, len(fluxes))
+    lines = ["wavelength_nm,flux"]
+    for w, f in zip(wavelengths, fluxes, strict=True):
+        lines.append(f"{w:.6f},{f:.6f}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# DynamoDB helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_table(dynamodb: Any) -> Any:
+    """Create a minimal NovaCat table in moto."""
+    return dynamodb.create_table(
+        TableName=_TABLE_NAME,
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+
+
+def _seed_spectra_product(
+    table: Any,
+    data_product_id: str,
+    *,
+    snr: float | None = None,
+    hints_snr: float | None = None,
+    observation_date_mjd: float = 56083.0,
+    instrument: str = "Goodman",
+    provider: str = "TestProvider",
+) -> None:
+    """Seed a VALID spectra DataProduct item."""
+    item: dict[str, Any] = {
+        "PK": _NOVA_ID,
+        "SK": f"PRODUCT#SPECTRA#{provider}#{data_product_id}",
+        "entity_type": "DataProduct",
+        "data_product_id": data_product_id,
+        "nova_id": _NOVA_ID,
+        "provider": provider,
+        "product_type": "SPECTRA",
+        "validation_status": "VALID",
+        "observation_date_mjd": Decimal(str(observation_date_mjd)),
+        "instrument": instrument,
+        "telescope": "SOAR",
+        "flux_unit": "erg/s/cm2/A",
+        "wavelength_min_nm": Decimal("400.0"),
+        "wavelength_max_nm": Decimal("700.0"),
+    }
+    if snr is not None:
+        item["snr"] = Decimal(str(snr))
+    if hints_snr is not None:
+        item["hints"] = {"snr": Decimal(str(hints_snr))}
+    table.put_item(Item=item)
+
+
+def _seed_csv(s3: Any, data_product_id: str, csv_body: str) -> None:
+    """Upload a web-ready CSV to moto S3."""
+    s3.put_object(
+        Bucket=_BUCKET,
+        Key=f"derived/spectra/{_NOVA_ID}/{data_product_id}/web_ready.csv",
+        Body=csv_body.encode(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Display gate helper
+# ---------------------------------------------------------------------------
+
+
+def _spectra_ids_in_output(result: dict[str, Any]) -> set[str]:
+    """Extract the set of spectrum_ids present in the spectra.json output.
+
+    The output schema uses ``spectrum_id`` (which equals ``data_product_id``).
+    Spectra appear in the top-level ``spectra`` list and optionally nested
+    inside ``regimes[].spectra``.
+    """
+    ids: set[str] = set()
+    for spectrum in result.get("spectra", []):
+        sid = spectrum.get("spectrum_id")
+        if sid:
+            ids.add(sid)
+    for regime in result.get("regimes", []):
+        for spectrum in regime.get("spectra", []):
+            sid = spectrum.get("spectrum_id")
+            if sid:
+                ids.add(sid)
+    return ids
+
+
+# ===================================================================
+# Display gate tests
+# ===================================================================
+
+
+class TestDisplayGate:
+    """Tests for the absolute SNR display gate in spectra.py.
+
+    The gate excludes spectra with ``0 < effective_snr < 5.0`` from
+    the waterfall output.
+    """
+
+    @staticmethod
+    def _run_generate(
+        table: Any,
+        s3: Any,
+    ) -> dict[str, Any]:
+        """Import and call ``generate_spectra_json`` inside mock context."""
+        from generators.spectra import generate_spectra_json
+
+        nova_context: dict[str, Any] = {
+            "outburst_mjd": 56080.0,
+            "outburst_mjd_is_estimated": False,
+        }
+        return generate_spectra_json(
+            nova_id=_NOVA_ID,
+            table=table,
+            s3_client=s3,
+            private_bucket=_BUCKET,
+            nova_context=nova_context,
+        )
+
+    def test_stored_snr_above_floor_included(self) -> None:
+        """Spectrum with stored snr=10 passes the display gate."""
+        with mock_aws():
+            dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+            table = _create_table(dynamodb)
+            s3 = boto3.client("s3", region_name=_REGION)
+            s3.create_bucket(Bucket=_BUCKET)
+
+            dp_id = "dp-high-snr-stored"
+            _seed_spectra_product(table, dp_id, snr=10.0)
+            _seed_csv(s3, dp_id, _make_csv(_make_high_snr_fluxes()))
+
+            result = self._run_generate(table, s3)
+            assert dp_id in _spectra_ids_in_output(result)
+
+    def test_stored_snr_below_floor_excluded(self) -> None:
+        """Spectrum with stored snr=2 is excluded by the display gate."""
+        with mock_aws():
+            dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+            table = _create_table(dynamodb)
+            s3 = boto3.client("s3", region_name=_REGION)
+            s3.create_bucket(Bucket=_BUCKET)
+
+            dp_id = "dp-low-snr-stored"
+            _seed_spectra_product(table, dp_id, snr=2.0)
+            _seed_csv(s3, dp_id, _make_csv(_make_high_snr_fluxes()))
+
+            result = self._run_generate(table, s3)
+            assert dp_id not in _spectra_ids_in_output(result)
+
+    def test_der_snr_fallback_above_floor_included(self) -> None:
+        """Spectrum with no stored SNR but high DER_SNR estimate passes."""
+        high_fluxes = _make_high_snr_fluxes()
+        # Sanity-check the synthetic flux array actually has high SNR.
+        estimated = der_snr(high_fluxes)
+        assert estimated > 5.0, f"Expected DER_SNR >> 5, got {estimated:.2f}"
+
+        with mock_aws():
+            dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+            table = _create_table(dynamodb)
+            s3 = boto3.client("s3", region_name=_REGION)
+            s3.create_bucket(Bucket=_BUCKET)
+
+            dp_id = "dp-high-snr-dersnr"
+            _seed_spectra_product(table, dp_id)  # no snr field
+            _seed_csv(s3, dp_id, _make_csv(high_fluxes))
+
+            result = self._run_generate(table, s3)
+            assert dp_id in _spectra_ids_in_output(result)
+
+    def test_der_snr_fallback_below_floor_excluded(self) -> None:
+        """Spectrum with no stored SNR and low DER_SNR estimate is excluded."""
+        low_fluxes = _make_low_snr_fluxes()
+        estimated = der_snr(low_fluxes)
+        assert 0 < estimated < 5.0, f"Expected 0 < DER_SNR < 5, got {estimated:.2f}"
+
+        with mock_aws():
+            dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+            table = _create_table(dynamodb)
+            s3 = boto3.client("s3", region_name=_REGION)
+            s3.create_bucket(Bucket=_BUCKET)
+
+            dp_id = "dp-low-snr-dersnr"
+            _seed_spectra_product(table, dp_id)  # no snr field
+            _seed_csv(s3, dp_id, _make_csv(low_fluxes))
+
+            result = self._run_generate(table, s3)
+            assert dp_id not in _spectra_ids_in_output(result)
+
+    def test_boundary_snr_exactly_five_is_included(self) -> None:
+        """Boundary: snr=5.0 is included (gate condition is strict less-than).
+
+        Observed behavior: the gate checks ``0 < eff_snr < 5.0`` (spectra.py:487),
+        so SNR exactly 5.0 does NOT satisfy the exclusion condition and is kept.
+        """
+        with mock_aws():
+            dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+            table = _create_table(dynamodb)
+            s3 = boto3.client("s3", region_name=_REGION)
+            s3.create_bucket(Bucket=_BUCKET)
+
+            dp_id = "dp-boundary-snr-5"
+            _seed_spectra_product(table, dp_id, snr=5.0)
+            _seed_csv(s3, dp_id, _make_csv(_make_high_snr_fluxes()))
+
+            result = self._run_generate(table, s3)
+            # SNR=5.0 is included — the condition ``0 < 5.0 < 5.0`` is False.
+            assert dp_id in _spectra_ids_in_output(result)
+
+
+# ===================================================================
+# Composite relative gate tests
+# ===================================================================
+
+
+def _make_synthetic_fits_arrays(
+    n: int = 3000,
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Return (wavelengths, fluxes) arrays with enough points for compositing.
+
+    MIN_POINTS_FOR_COMPOSITE is 2000; we use 3000 to be safe.
+    """
+    wavelengths = np.linspace(400.0, 700.0, n)
+    fluxes = np.ones(n) * 100.0
+    return wavelengths, fluxes
+
+
+class TestCompositeRelativeGate:
+    """Tests for the compositing relative SNR gate in compositing.py.
+
+    The gate excludes spectra with ``0 < snr < (group_median × 1/3)``
+    from the composite.  Only applies to groups with ≥ 2 members.
+    """
+
+    @staticmethod
+    def _make_product(
+        data_product_id: str,
+        *,
+        snr: float,
+        observation_date_mjd: float = 56083.5,
+        provider: str = "TestProvider",
+        instrument: str = "Goodman",
+        sha256: str = "aabbccdd",
+    ) -> dict[str, Any]:
+        """Build a minimal product dict for compositing."""
+        return {
+            "PK": _NOVA_ID,
+            "SK": f"PRODUCT#SPECTRA#{provider}#{data_product_id}",
+            "data_product_id": data_product_id,
+            "nova_id": _NOVA_ID,
+            "provider": provider,
+            "instrument": instrument,
+            "telescope": "SOAR",
+            "observation_date_mjd": Decimal(str(observation_date_mjd)),
+            "sha256": sha256,
+            "snr": Decimal(str(snr)),
+            "raw_s3_key": f"raw/spectra/{_NOVA_ID}/{data_product_id}.fits",
+            "validation_status": "VALID",
+            "product_type": "SPECTRA",
+        }
+
+    def _run_compositing_group(
+        self,
+        products: list[dict[str, Any]],
+        instrument: str = "Goodman",
+    ) -> dict[str, Any]:
+        """Call ``_process_compositing_group`` and return the composite DDB item.
+
+        Mocks ``read_fits_spectrum`` to return synthetic arrays and sets up
+        moto DDB + S3 for the writes.
+        """
+        from generators.compositing import (
+            CompositingGroup,
+            CompositingSweepResult,
+            _process_compositing_group,
+        )
+
+        group = CompositingGroup(instrument=instrument, products=products)
+        result = CompositingSweepResult(groups_found=1, skipped=0, built=0, degenerate=0, errors=0)
+
+        with mock_aws():
+            dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+            table = _create_table(dynamodb)
+            s3 = boto3.client("s3", region_name=_REGION)
+            s3.create_bucket(Bucket=_BUCKET)
+
+            synthetic = _make_synthetic_fits_arrays()
+            with patch(
+                "generators.fits_reader.read_fits_spectrum",
+                return_value=synthetic,
+            ):
+                _process_compositing_group(
+                    nova_id=_NOVA_ID,
+                    group=group,
+                    existing_by_fp={},
+                    table=table,
+                    s3_client=s3,
+                    bucket=_BUCKET,
+                    result=result,
+                )
+
+            # Read back all composite items written to DDB.
+            resp = table.scan()
+            composites = [
+                item for item in resp.get("Items", []) if "COMPOSITE" in item.get("SK", "")
+            ]
+            assert len(composites) == 1, f"Expected 1 composite item, got {len(composites)}"
+            composite: dict[str, Any] = composites[0]
+            return composite
+
+    def test_all_high_snr_all_included(self) -> None:
+        """Group [30, 25, 20]: all above 1/3 × median(25) ≈ 8.33 → all included."""
+        products = [
+            self._make_product("dp-a", snr=30.0, sha256="aa"),
+            self._make_product("dp-b", snr=25.0, sha256="bb"),
+            self._make_product("dp-c", snr=20.0, sha256="cc"),
+        ]
+        composite = self._run_compositing_group(products)
+        assert sorted(composite["constituent_data_product_ids"]) == ["dp-a", "dp-b", "dp-c"]
+        assert composite["rejected_data_product_ids"] == []
+
+    def test_low_snr_member_excluded(self) -> None:
+        """Group [30, 25, 5]: snr=5 < 1/3 × median(25) ≈ 8.33 → excluded."""
+        products = [
+            self._make_product("dp-a", snr=30.0, sha256="aa"),
+            self._make_product("dp-b", snr=25.0, sha256="bb"),
+            self._make_product("dp-c", snr=5.0, sha256="cc"),
+        ]
+        composite = self._run_compositing_group(products)
+        assert sorted(composite["constituent_data_product_ids"]) == ["dp-a", "dp-b"]
+        assert sorted(composite["rejected_data_product_ids"]) == ["dp-c"]
+
+    def test_single_spectrum_group_relative_gate_noop(self) -> None:
+        """Single-spectrum group: relative gate requires ≥ 2 members, so it's a no-op.
+
+        The function writes a degenerate composite pointing at the survivor.
+        """
+        from generators.compositing import (
+            CompositingGroup,
+            CompositingSweepResult,
+            _process_compositing_group,
+        )
+
+        products = [self._make_product("dp-solo", snr=30.0, sha256="aa")]
+        group = CompositingGroup(instrument="Goodman", products=products)
+        result = CompositingSweepResult(groups_found=1, skipped=0, built=0, degenerate=0, errors=0)
+
+        with mock_aws():
+            dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+            table = _create_table(dynamodb)
+            s3 = boto3.client("s3", region_name=_REGION)
+            s3.create_bucket(Bucket=_BUCKET)
+
+            synthetic = _make_synthetic_fits_arrays()
+            with patch(
+                "generators.fits_reader.read_fits_spectrum",
+                return_value=synthetic,
+            ):
+                _process_compositing_group(
+                    nova_id=_NOVA_ID,
+                    group=group,
+                    existing_by_fp={},
+                    table=table,
+                    s3_client=s3,
+                    bucket=_BUCKET,
+                    result=result,
+                )
+
+            # Degenerate composite: single survivor is included.
+            assert result["degenerate"] == 1
+            resp = table.scan()
+            composites = [
+                item for item in resp.get("Items", []) if "COMPOSITE" in item.get("SK", "")
+            ]
+            assert len(composites) == 1
+            assert composites[0]["constituent_data_product_ids"] == ["dp-solo"]
+            assert composites[0]["rejected_data_product_ids"] == []
+
+    def test_interaction_display_gate_and_relative_gate(self) -> None:
+        """Interaction: relative gate is computed over FITS-readable constituents.
+
+        The relative SNR gate in ``_process_compositing_group`` operates on
+        products that passed the MIN_POINTS_FOR_COMPOSITE check and had a
+        successful FITS read.  It does NOT re-apply the display gate (that's
+        a separate concern in ``generate_spectra_json``).
+
+        Here we verify that within a group of [30, 25, 3], the snr=3 member
+        is excluded by the relative gate (3 < 1/3 × 25 ≈ 8.33), and the
+        relative gate threshold is computed over all three products (the
+        display gate is not applied inside the compositing pipeline).
+        """
+        products = [
+            self._make_product("dp-a", snr=30.0, sha256="aa"),
+            self._make_product("dp-b", snr=25.0, sha256="bb"),
+            self._make_product("dp-c", snr=3.0, sha256="cc"),
+        ]
+        composite = self._run_compositing_group(products)
+
+        # snr=3 is excluded by relative gate (3 < 8.33).
+        assert sorted(composite["constituent_data_product_ids"]) == ["dp-a", "dp-b"]
+        assert sorted(composite["rejected_data_product_ids"]) == ["dp-c"]

--- a/tests/services/test_generators_catalog.py
+++ b/tests/services/test_generators_catalog.py
@@ -190,11 +190,11 @@ def _find_nova(catalog: dict[str, Any], nova_id: str) -> dict[str, Any]:
 class TestOutputSchema:
     """Top-level schema fields and versioning."""
 
-    def test_schema_version_is_1_1(self, table: Any) -> None:
-        """§11.9: schema_version bumped to '1.1'."""
+    def test_schema_version_is_1_2(self, table: Any) -> None:
+        """§11.9, §F9: schema_version bumped to '1.2'."""
         _seed_nova(table, _NOVA_A)
         result = generate_catalog_json([], table)
-        assert result["schema_version"] == "1.1"
+        assert result["schema_version"] == "1.2"
 
     def test_generated_at_is_iso_8601(self, table: Any) -> None:
         """generated_at matches YYYY-MM-DDTHH:MM:SSZ format."""
@@ -592,6 +592,7 @@ class TestRecordFields:
             "photometry_count",
             "references_count",
             "has_sparkline",
+            "sources",
         }
         assert set(nova.keys()) == expected_keys
 
@@ -644,3 +645,264 @@ class TestSpectralVisits:
         result = generate_catalog_json(sweep, table)
         nova = _find_nova(result, _NOVA_A)
         assert nova["spectral_visits"] == 5
+
+
+# ===========================================================================
+# Sources field (§F9)
+# ===========================================================================
+
+
+def _seed_data_product(
+    table: Any,
+    nova_id: str,
+    data_product_id: str,
+    *,
+    provider: str = "ESO",
+    locator_identity: str = "provider_product_id:abc123",
+    validation_status: str = "VALID",
+) -> None:
+    """Write a SPECTRA DataProduct item to the mocked table."""
+    sk = f"PRODUCT#SPECTRA#{provider}#{data_product_id}"
+    table.put_item(
+        Item={
+            "PK": nova_id,
+            "SK": sk,
+            "data_product_id": data_product_id,
+            "nova_id": nova_id,
+            "product_type": "SPECTRA",
+            "provider": provider,
+            "locator_identity": locator_identity,
+            "validation_status": validation_status,
+        }
+    )
+
+
+class TestSources:
+    """Sources field populated from DataProduct scan (§F9)."""
+
+    def test_ticket_ingested_nova_has_bibcode_source(self, table: Any) -> None:
+        """Ticket-ingested DataProduct → bibcode appears in sources."""
+        _seed_nova(table, _NOVA_A, primary_name="V1674 Her")
+        _seed_data_product(
+            table,
+            _NOVA_A,
+            "dp-001",
+            provider="ticket_ingestion",
+            locator_identity="ticket_ingestion:2021ApJ...910..134C:spec_01.csv",
+        )
+        result = generate_catalog_json([], table)
+        nova = _find_nova(result, _NOVA_A)
+        assert nova["sources"] == [
+            {"type": "bibcode", "bibcode": "2021ApJ...910..134C"},
+        ]
+
+    def test_archive_ingested_nova_has_provider_source(self, table: Any) -> None:
+        """Archive-ingested DataProduct → provider appears in sources."""
+        _seed_nova(table, _NOVA_A, primary_name="RS Oph")
+        _seed_data_product(
+            table,
+            _NOVA_A,
+            "dp-002",
+            provider="ESO",
+            locator_identity="provider_product_id:ESO-12345",
+        )
+        result = generate_catalog_json([], table)
+        nova = _find_nova(result, _NOVA_A)
+        assert nova["sources"] == [
+            {"type": "archive", "provider": "ESO"},
+        ]
+
+    def test_no_spurious_bibcode_for_archive_nova(self, table: Any) -> None:
+        """Archive-only nova must not have any bibcode source entry."""
+        _seed_nova(table, _NOVA_A, primary_name="GK Per")
+        _seed_data_product(
+            table,
+            _NOVA_A,
+            "dp-003",
+            provider="AAVSO",
+            locator_identity="url:https://aavso.org/data/gk-per",
+        )
+        result = generate_catalog_json([], table)
+        nova = _find_nova(result, _NOVA_A)
+        assert all(s["type"] == "archive" for s in nova["sources"])
+        assert not any(s.get("bibcode") for s in nova["sources"])
+
+    def test_mixed_sources_both_present(self, table: Any) -> None:
+        """Nova with both archive and ticket data shows both source types."""
+        _seed_nova(table, _NOVA_A, primary_name="V1405 Cas")
+        _seed_data_product(
+            table,
+            _NOVA_A,
+            "dp-004",
+            provider="ESO",
+            locator_identity="provider_product_id:ESO-99",
+        )
+        _seed_data_product(
+            table,
+            _NOVA_A,
+            "dp-005",
+            provider="ticket_ingestion",
+            locator_identity="ticket_ingestion:2022MNRAS.512.2003M:spec_01.csv",
+        )
+        result = generate_catalog_json([], table)
+        nova = _find_nova(result, _NOVA_A)
+        types = {s["type"] for s in nova["sources"]}
+        assert types == {"archive", "bibcode"}
+
+    def test_no_data_products_empty_sources(self, table: Any) -> None:
+        """Nova with no DataProducts gets an empty sources list."""
+        _seed_nova(table, _NOVA_A, primary_name="Lonely Nova")
+        result = generate_catalog_json([], table)
+        nova = _find_nova(result, _NOVA_A)
+        assert nova["sources"] == []
+
+    def test_duplicate_bibcodes_deduplicated(self, table: Any) -> None:
+        """Multiple DataProducts from the same bibcode produce one entry."""
+        _seed_nova(table, _NOVA_A, primary_name="V1674 Her")
+        bibcode = "2021ApJ...910..134C"
+        _seed_data_product(
+            table,
+            _NOVA_A,
+            "dp-006",
+            provider="ticket_ingestion",
+            locator_identity=f"ticket_ingestion:{bibcode}:spec_01.csv",
+        )
+        _seed_data_product(
+            table,
+            _NOVA_A,
+            "dp-007",
+            provider="ticket_ingestion",
+            locator_identity=f"ticket_ingestion:{bibcode}:spec_02.csv",
+        )
+        result = generate_catalog_json([], table)
+        nova = _find_nova(result, _NOVA_A)
+        bibcode_entries = [s for s in nova["sources"] if s["type"] == "bibcode"]
+        assert len(bibcode_entries) == 1
+
+    def test_invalid_data_products_excluded(self, table: Any) -> None:
+        """DataProducts not VALID are excluded from sources."""
+        _seed_nova(table, _NOVA_A, primary_name="V1674 Her")
+        _seed_data_product(
+            table,
+            _NOVA_A,
+            "dp-008",
+            provider="ESO",
+            locator_identity="provider_product_id:ESO-1",
+            validation_status="INVALID",
+        )
+        result = generate_catalog_json([], table)
+        nova = _find_nova(result, _NOVA_A)
+        assert nova["sources"] == []
+
+    def test_duplicate_providers_deduplicated(self, table: Any) -> None:
+        """Multiple DataProducts from the same provider produce one entry."""
+        _seed_nova(table, _NOVA_A, primary_name="GK Per")
+        _seed_data_product(table, _NOVA_A, "dp-010", provider="ESO", locator_identity="id:e1")
+        _seed_data_product(table, _NOVA_A, "dp-011", provider="ESO", locator_identity="id:e2")
+        _seed_data_product(table, _NOVA_A, "dp-012", provider="AAVSO", locator_identity="id:a1")
+        result = generate_catalog_json([], table)
+        nova = _find_nova(result, _NOVA_A)
+        assert nova["sources"] == [
+            {"type": "archive", "provider": "AAVSO"},
+            {"type": "archive", "provider": "ESO"},
+        ]
+
+    def test_malformed_locator_empty_bibcode(self, table: Any) -> None:
+        """locator_identity='ticket_ingestion:' — empty bibcode, skipped."""
+        _seed_nova(table, _NOVA_A, primary_name="V1674 Her")
+        _seed_data_product(
+            table,
+            _NOVA_A,
+            "dp-020",
+            provider="ticket_ingestion",
+            locator_identity="ticket_ingestion:",
+        )
+        result = generate_catalog_json([], table)
+        nova = _find_nova(result, _NOVA_A)
+        assert nova["sources"] == []
+
+    def test_malformed_locator_missing_filename(self, table: Any) -> None:
+        """locator_identity with no filename segment still extracts bibcode."""
+        _seed_nova(table, _NOVA_A, primary_name="V1674 Her")
+        _seed_data_product(
+            table,
+            _NOVA_A,
+            "dp-021",
+            provider="ticket_ingestion",
+            locator_identity="ticket_ingestion:2021ApJ...910..134C",
+        )
+        result = generate_catalog_json([], table)
+        nova = _find_nova(result, _NOVA_A)
+        assert nova["sources"] == [
+            {"type": "bibcode", "bibcode": "2021ApJ...910..134C"},
+        ]
+
+    def test_malformed_locator_wrong_prefix(self, table: Any) -> None:
+        """locator_identity with wrong prefix — silently skipped."""
+        _seed_nova(table, _NOVA_A, primary_name="V1674 Her")
+        _seed_data_product(
+            table,
+            _NOVA_A,
+            "dp-022",
+            provider="ticket_ingestion",
+            locator_identity="something_else:foo:bar",
+        )
+        result = generate_catalog_json([], table)
+        nova = _find_nova(result, _NOVA_A)
+        assert nova["sources"] == []
+
+    def test_malformed_locator_empty_string(self, table: Any) -> None:
+        """locator_identity='' — silently skipped."""
+        _seed_nova(table, _NOVA_A, primary_name="V1674 Her")
+        _seed_data_product(
+            table,
+            _NOVA_A,
+            "dp-023",
+            provider="ticket_ingestion",
+            locator_identity="",
+        )
+        result = generate_catalog_json([], table)
+        nova = _find_nova(result, _NOVA_A)
+        assert nova["sources"] == []
+
+    def test_malformed_locator_missing_field(self, table: Any) -> None:
+        """locator_identity field missing entirely — silently skipped."""
+        _seed_nova(table, _NOVA_A, primary_name="V1674 Her")
+        # Seed manually without locator_identity.
+        table.put_item(
+            Item={
+                "PK": _NOVA_A,
+                "SK": "PRODUCT#SPECTRA#ticket_ingestion#dp-024",
+                "data_product_id": "dp-024",
+                "nova_id": _NOVA_A,
+                "product_type": "SPECTRA",
+                "provider": "ticket_ingestion",
+                "validation_status": "VALID",
+            }
+        )
+        result = generate_catalog_json([], table)
+        nova = _find_nova(result, _NOVA_A)
+        assert nova["sources"] == []
+
+    def test_malformed_locator_does_not_block_other_products(self, table: Any) -> None:
+        """Malformed locator on one DataProduct doesn't affect others."""
+        _seed_nova(table, _NOVA_A, primary_name="V1674 Her")
+        # Malformed ticket DataProduct.
+        _seed_data_product(
+            table,
+            _NOVA_A,
+            "dp-025",
+            provider="ticket_ingestion",
+            locator_identity="something_else:foo:bar",
+        )
+        # Valid archive DataProduct.
+        _seed_data_product(
+            table,
+            _NOVA_A,
+            "dp-026",
+            provider="ESO",
+            locator_identity="provider_product_id:ESO-1",
+        )
+        result = generate_catalog_json([], table)
+        nova = _find_nova(result, _NOVA_A)
+        assert nova["sources"] == [{"type": "archive", "provider": "ESO"}]


### PR DESCRIPTION
## Summary
- Added SNR gate integration tests (S22) — 9 cases covering both the display floor (SNR < 5) and compositing relative threshold (< 1/3 group median)
- Added Sources column to the catalog (F9) — discriminated union contract (ArchiveSource / BibcodeSource), catalog generator populating from DataProduct scan, frontend column with stacked rendering
- Added dated bug list with new entries identified during today's session

## Why
- S22 locks in the SNR gating behavior from epic/29 so future changes can't silently regress the thresholds
- F9 closes a visibility gap — ticket-ingested data had no indication of which paper contributed observations. Users scanning the catalog now see the originating ADS bibcode alongside archive provider names.

## Testing
- S22: 9 integration tests with synthetic spectra and controlled SNR values, exercising both gates end-to-end via mock_aws
- F9: 14 unit tests covering source extraction, dedup (bibcodes and providers independently), malformed locator_identity handling, and INVALID product exclusion
- Full CI green: pytest, ruff check, ruff format, mypy strict, next build
- Frontend tests skipped (Vitest installed but unconfigured — T1 tracks this)

## Notes
- S22 discovery surfaced a real gap: spectra with SNR ≤ 0 (including -0.1 values from ESO) slip through both gates. Tracked as B30 — not addressed in this PR.
- F9 bumps catalog schema to 1.2. Mock catalog.json updated to match, including a `spectral_visits` field that was already declared in the TS type but missing from the mock fixture.
- Malformed `locator_identity` handling required a small code fix in catalog.py — ticket-ingestion DataProducts with unparseable locators were falling through to the archive-provider branch instead of being silently skipped.

## Out of Scope
- B30: non-positive / non-finite SNR gate fix (follow-up, prompt ready)
- ADS hyperlinks on bibcodes (post-v1)
- Frontend test infrastructure (T1)
- F7: spectral visits in stats display (prompt ready)
- S21: DER_SNR at ingestion time (prompt ready)