### PR TITLE
feat: spectra quality hardening, catalog sources column, and test hygiene

### DIFF
--- a/contracts/models/entities.py
+++ b/contracts/models/entities.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import re
 from datetime import UTC, datetime
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator, model_validator
@@ -836,7 +836,16 @@ class DataProduct(PersistentBase):
     snr: float | None = Field(
         default=None,
         ge=0,
-        description="Median signal-to-noise ratio per pixel, from FITS SNR column when available.",
+        description="Median signal-to-noise ratio per pixel, from FITS SNR column or DER_SNR estimate.",
+    )
+    snr_provenance: Literal["source", "estimated_der_snr"] | None = Field(
+        default=None,
+        description=(
+            "How the SNR value was obtained. "
+            "'source' = extracted from FITS header/column during validation; "
+            "'estimated_der_snr' = computed via DER_SNR (Stoehr et al. 2008) at ingestion time; "
+            "None = SNR not available."
+        ),
     )
 
     # --- composite spectra fields (ADR-033) ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,6 @@ quote-style = "double"
 testpaths = ["tests","infra/tests", "services"]
 addopts = "-q"
 pythonpath = [".", "services/spectra_validator", "services/spectra_acquirer", "services/photometry_ingestor", "services/nova_common_layer/python", "services/artifact_generator"]
+filterwarnings = [
+    "ignore:ERFA function.*dubious year:erfa.core.ErfaWarning",
+]

--- a/services/artifact_generator/generators/compositing.py
+++ b/services/artifact_generator/generators/compositing.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import math
 import uuid
 from datetime import UTC, datetime
 from typing import Any, TypedDict
@@ -1054,13 +1055,29 @@ def _process_compositing_group(
     # These are moved to the rejected list, not silently dropped.
     if len(constituents) >= 2:
         snr_values = [_effective_snr_for_product(p) for p in constituents]
-        group_median_snr = float(np.median(snr_values))
+
+        # B30: reject non-finite and non-positive SNR before computing the
+        # group median — these are physically meaningless and would poison
+        # the median (e.g. NaN makes np.median return NaN).
+        finite_positive: list[dict[str, Any]] = []
+        for p, snr in zip(constituents, snr_values, strict=False):
+            if not math.isfinite(snr) or snr <= 0:
+                rejected.append(p)
+            else:
+                finite_positive.append(p)
+
+        if len(finite_positive) != len(constituents):
+            constituents = finite_positive
+            # Recompute SNR values for survivors only.
+            snr_values = [_effective_snr_for_product(p) for p in constituents]
+
+        group_median_snr = float(np.median(snr_values)) if len(constituents) >= 2 else 0.0
 
         if group_median_snr > 0:
             snr_floor = group_median_snr * _COMPOSITING_SNR_RELATIVE_THRESHOLD
             snr_passed: list[dict[str, Any]] = []
             for p, snr in zip(constituents, snr_values, strict=False):
-                if 0 < snr < snr_floor:
+                if snr < snr_floor:
                     _logger.info(
                         "Spectrum excluded from composite by relative SNR gate",
                         extra={

--- a/services/artifact_generator/generators/compositing.py
+++ b/services/artifact_generator/generators/compositing.py
@@ -488,8 +488,16 @@ def combine_spectra(
         raise ValueError(f"Need ≥ 2 flux arrays for combination, got {len(resampled_fluxes)}")
 
     stacked = np.vstack(resampled_fluxes)
-    with np.errstate(all="ignore"):
-        combined: NDArray[np.float64] = np.nanmedian(stacked, axis=0)
+    # Detect columns where every constituent is NaN (chip gaps, dead
+    # detector regions, dichroic gaps). nanmedian would produce NaN for
+    # these anyway but emits a RuntimeWarning — handle them explicitly.
+    all_nan_mask = np.all(np.isnan(stacked), axis=0)
+    if np.all(all_nan_mask):
+        combined: NDArray[np.float64] = np.full(stacked.shape[1], np.nan)
+    else:
+        combined = np.full(stacked.shape[1], np.nan)
+        valid = ~all_nan_mask
+        combined[valid] = np.nanmedian(stacked[:, valid], axis=0)
     return combined
 
 

--- a/services/artifact_generator/generators/spectra.py
+++ b/services/artifact_generator/generators/spectra.py
@@ -24,6 +24,7 @@ import csv
 import hashlib
 import io
 import logging
+import math
 import statistics
 import time
 import uuid
@@ -484,7 +485,7 @@ def generate_spectra_json(
     for rec in parsed:
         eff_snr = _compute_effective_snr(rec)
         rec["effective_snr"] = eff_snr
-        if 0 < eff_snr < _SNR_DISPLAY_FLOOR:
+        if not math.isfinite(eff_snr) or eff_snr < _SNR_DISPLAY_FLOOR:
             _logger.info(
                 "Spectrum excluded by SNR display gate",
                 extra={

--- a/services/spectra_validator/handler.py
+++ b/services/spectra_validator/handler.py
@@ -73,6 +73,7 @@ from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
 from nova_common.errors import RetryableError
 from nova_common.logging import configure_logging, logger
+from nova_common.spectral import der_snr
 from nova_common.timing import log_duration
 from nova_common.tracing import tracer
 from nova_common.web_ready_csv import build_web_ready_csv, write_web_ready_csv_to_s3
@@ -403,6 +404,7 @@ def _handle_validate_bytes(event: dict[str, Any], context: object) -> dict[str, 
     wavelength_min_nm: float | None = None
     wavelength_max_nm: float | None = None
     snr_median: float | None = None
+    snr_provenance: str | None = None
 
     if spectrum:
         axis = spectrum.spectral_axis
@@ -421,7 +423,18 @@ def _handle_validate_bytes(event: dict[str, Any], context: object) -> dict[str, 
             # else: assume already nm
             wavelength_min_nm = round(wl_min, 4)
             wavelength_max_nm = round(wl_max, 4)
-        snr_median = spectrum.snr
+
+        # SNR: prefer profile-extracted source value, fall back to DER_SNR.
+        if spectrum.snr is not None:
+            snr_median = spectrum.snr
+            snr_provenance = "source"
+        else:
+            flux = spectrum.flux_axis
+            if len(flux) > 0:
+                estimated = der_snr(flux.tolist())
+                if estimated > 0.0:
+                    snr_median = round(estimated, 4)
+                    snr_provenance = "estimated_der_snr"
 
     # --- Write web-ready CSV (ADR-031 P-4) ---
     # Best-effort: a failed write logs a warning but does not fail the
@@ -484,6 +497,7 @@ def _handle_validate_bytes(event: dict[str, Any], context: object) -> dict[str, 
         "wavelength_min_nm": wavelength_min_nm,
         "wavelength_max_nm": wavelength_max_nm,
         "snr": snr_median,
+        "snr_provenance": snr_provenance,
     }
 
 
@@ -627,6 +641,10 @@ def _handle_record_validation_result(event: dict[str, Any], context: object) -> 
     if validation.get("snr") is not None:
         set_expr_parts.append("snr = :snr")
         values[":snr"] = Decimal(str(validation["snr"]))
+
+    if validation.get("snr_provenance") is not None:
+        set_expr_parts.append("snr_provenance = :snr_prov")
+        values[":snr_prov"] = validation["snr_provenance"]
 
     update_expression = "SET " + ", ".join(set_expr_parts) + " REMOVE GSI1PK, GSI1SK"
 

--- a/services/ticket_ingestor/spectra_reader.py
+++ b/services/ticket_ingestor/spectra_reader.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+from nova_common.spectral import der_snr
 
 from contracts.models.tickets import SpectraTicket
 from ticket_ingestor.fits_builder import FloatArray, build_fits
@@ -73,6 +74,10 @@ class SpectrumResult:
     telescope: str | None = None
     observation_date_mjd: float | None = None
     flux_unit: str | None = None
+
+    # --- SNR (S21: DER_SNR at ingestion time) ---
+    snr: float | None = None
+    snr_provenance: str | None = None  # "estimated_der_snr" or None
 
 
 @dataclass(frozen=True)
@@ -428,6 +433,18 @@ def read_spectra(
                 # ── Construct FITS bytes ─────────────────────────────────
                 fits_bytes = build_fits(wav_arr, flux_arr, ferr_arr, keywords)
 
+                # ── S21: estimate SNR via DER_SNR ───────────────────────
+                # Ticket-ingested spectra have no source-provided SNR, so
+                # we always attempt DER_SNR.  A result of 0.0 means the
+                # estimator couldn't produce a value (degenerate flux).
+                snr_value: float | None = None
+                snr_prov: str | None = None
+                if len(flux_arr) > 0:
+                    estimated = der_snr(flux_arr.tolist())
+                    if estimated > 0.0:
+                        snr_value = round(estimated, 4)
+                        snr_prov = "estimated_der_snr"
+
                 # ── Derive stable identity ───────────────────────────────
                 data_product_id = _derive_data_product_id(
                     ticket.bibcode, spectrum_filename, nova_id
@@ -446,6 +463,8 @@ def read_spectra(
                         telescope=enrichment["telescope"],
                         observation_date_mjd=enrichment["observation_date_mjd"],
                         flux_unit=enrichment["flux_unit"],
+                        snr=snr_value,
+                        snr_provenance=snr_prov,
                     )
                 )
 

--- a/services/ticket_ingestor/spectra_writer.py
+++ b/services/ticket_ingestor/spectra_writer.py
@@ -193,6 +193,12 @@ def write_spectrum(
     if result.flux_unit is not None:
         dp_item["flux_unit"] = result.flux_unit
 
+    # --- S21: ingestion-time SNR ---
+    if result.snr is not None:
+        dp_item["snr"] = _coerce_for_ddb(result.snr)
+    if result.snr_provenance is not None:
+        dp_item["snr_provenance"] = result.snr_provenance
+
     table.put_item(Item=dp_item)
 
     # ── 2b. Web-ready CSV (ADR-031 P-4) ────────────────────────────────

--- a/tests/integration/test_acquire_and_validate_spectra_integration.py
+++ b/tests/integration/test_acquire_and_validate_spectra_integration.py
@@ -656,6 +656,158 @@ class TestHappyPathValid:
 
 
 # ---------------------------------------------------------------------------
+# S21: SNR provenance through validation path
+# ---------------------------------------------------------------------------
+
+
+def _make_uves_fits_bytes_with_snr_column(*, n: int = 1000) -> bytes:
+    """Build a synthetic UVES FITS with an SNR_REDUCED column (source-provided SNR)."""
+    primary = fits.PrimaryHDU()
+    hdr = primary.header
+    hdr["INSTRUME"] = "UVES"
+    hdr["TELESCOP"] = "ESO-VLT-U2"
+    hdr["MJD-OBS"] = 56082.05
+    hdr["DATE-OBS"] = "2012-06-04"
+    hdr["EXPTIME"] = 7200.0
+    hdr["SPEC_RES"] = 42000.0
+    hdr["FLUXCAL"] = "ABSOLUTE"
+
+    wave = np.linspace(3200.0, 10000.0, n).astype(np.float32)
+    flux = np.ones(n, dtype=np.float32) * 1.5e-16
+    err = np.ones(n, dtype=np.float32) * 1.0e-17
+    qual = np.zeros(n, dtype=np.int32)
+    snr = np.ones(n, dtype=np.float32) * 25.0  # source-provided SNR
+
+    cols = fits.ColDefs(
+        [
+            fits.Column(name="WAVE", format=f"{n}E", array=wave.reshape(1, n)),
+            fits.Column(name="FLUX", format=f"{n}E", array=flux.reshape(1, n)),
+            fits.Column(name="ERR", format=f"{n}E", array=err.reshape(1, n)),
+            fits.Column(name="QUAL", format=f"{n}J", array=qual.reshape(1, n)),
+            fits.Column(name="SNR_REDUCED", format=f"{n}E", array=snr.reshape(1, n)),
+        ]
+    )
+    spectrum_hdu = fits.BinTableHDU.from_columns(cols, name="SPECTRUM")
+
+    buf = io.BytesIO()
+    fits.HDUList([primary, spectrum_hdu]).writeto(buf)
+    return buf.getvalue()
+
+
+def _make_uves_fits_bytes_noisy_flux(*, n: int = 1000) -> bytes:
+    """Build a synthetic UVES FITS with noisy flux (no SNR column) → DER_SNR fallback."""
+    primary = fits.PrimaryHDU()
+    hdr = primary.header
+    hdr["INSTRUME"] = "UVES"
+    hdr["TELESCOP"] = "ESO-VLT-U2"
+    hdr["MJD-OBS"] = 56082.05
+    hdr["DATE-OBS"] = "2012-06-04"
+    hdr["EXPTIME"] = 7200.0
+    hdr["SPEC_RES"] = 42000.0
+    hdr["FLUXCAL"] = "ABSOLUTE"
+
+    rng = np.random.default_rng(42)
+    wave = np.linspace(3200.0, 10000.0, n).astype(np.float32)
+    flux = (1.5e-16 + rng.normal(0, 1.0e-18, n)).astype(np.float32)
+    err = np.ones(n, dtype=np.float32) * 1.0e-17
+    qual = np.zeros(n, dtype=np.int32)
+
+    cols = fits.ColDefs(
+        [
+            fits.Column(name="WAVE", format=f"{n}E", array=wave.reshape(1, n)),
+            fits.Column(name="FLUX", format=f"{n}E", array=flux.reshape(1, n)),
+            fits.Column(name="ERR", format=f"{n}E", array=err.reshape(1, n)),
+            fits.Column(name="QUAL", format=f"{n}J", array=qual.reshape(1, n)),
+        ]
+    )
+    spectrum_hdu = fits.BinTableHDU.from_columns(cols, name="SPECTRUM")
+
+    buf = io.BytesIO()
+    fits.HDUList([primary, spectrum_hdu]).writeto(buf)
+    return buf.getvalue()
+
+
+class TestSnrProvenanceValidationPath:
+    """S21: snr_provenance flows through the validation path into DDB."""
+
+    def test_source_snr_provenance(self, aws_resources: tuple[Any, Any]) -> None:
+        """FITS with SNR_REDUCED column → snr_provenance='source' on DDB item."""
+        table, _ = aws_resources
+        fits_bytes = _make_uves_fits_bytes_with_snr_column()
+
+        with mock_aws():
+            _seed_data_product(table)
+            h = _load_handlers()
+            state = _run_prefix(h)
+            status = _run_check_status(h, state)
+            acquisition = _run_acquire(h, state, status, fits_bytes)
+            validation = _run_validate(h, state, status, acquisition)
+
+            assert validation["snr"] is not None
+            assert validation["snr"] > 0.0
+            assert validation["snr_provenance"] == "source"
+
+            _run_record_result(h, state, status, acquisition, validation)
+            _finalize_success(h, state)
+
+        dp = _get_data_product(table)
+        assert dp is not None
+        assert "snr" in dp
+        assert float(dp["snr"]) > 0.0
+        assert dp["snr_provenance"] == "source"
+
+    def test_estimated_der_snr_provenance(self, aws_resources: tuple[Any, Any]) -> None:
+        """FITS with noisy flux, no SNR column → snr_provenance='estimated_der_snr'."""
+        table, _ = aws_resources
+        fits_bytes = _make_uves_fits_bytes_noisy_flux()
+
+        with mock_aws():
+            _seed_data_product(table)
+            h = _load_handlers()
+            state = _run_prefix(h)
+            status = _run_check_status(h, state)
+            acquisition = _run_acquire(h, state, status, fits_bytes)
+            validation = _run_validate(h, state, status, acquisition)
+
+            assert validation["snr"] is not None
+            assert validation["snr"] > 0.0
+            assert validation["snr_provenance"] == "estimated_der_snr"
+
+            _run_record_result(h, state, status, acquisition, validation)
+            _finalize_success(h, state)
+
+        dp = _get_data_product(table)
+        assert dp is not None
+        assert "snr" in dp
+        assert float(dp["snr"]) > 0.0
+        assert dp["snr_provenance"] == "estimated_der_snr"
+
+    def test_no_snr_when_constant_flux(self, aws_resources: tuple[Any, Any]) -> None:
+        """Constant flux, no SNR column → DER_SNR returns 0 → snr absent from DDB."""
+        table, _ = aws_resources
+        fits_bytes = _make_uves_fits_bytes()  # constant flux, no SNR column
+
+        with mock_aws():
+            _seed_data_product(table)
+            h = _load_handlers()
+            state = _run_prefix(h)
+            status = _run_check_status(h, state)
+            acquisition = _run_acquire(h, state, status, fits_bytes)
+            validation = _run_validate(h, state, status, acquisition)
+
+            assert validation["snr"] is None
+            assert validation["snr_provenance"] is None
+
+            _run_record_result(h, state, status, acquisition, validation)
+            _finalize_success(h, state)
+
+        dp = _get_data_product(table)
+        assert dp is not None
+        assert "snr" not in dp
+        assert "snr_provenance" not in dp
+
+
+# ---------------------------------------------------------------------------
 # Path 2–4: CheckOperationalStatusOutcome skip paths
 # ---------------------------------------------------------------------------
 

--- a/tests/integration/test_snr_gates.py
+++ b/tests/integration/test_snr_gates.py
@@ -27,6 +27,7 @@ from unittest.mock import patch
 
 import boto3
 import numpy as np
+import pytest
 from moto import mock_aws
 from nova_common.spectral import der_snr
 from numpy.typing import NDArray
@@ -287,6 +288,66 @@ class TestDisplayGate:
             # SNR=5.0 is included — the condition ``0 < 5.0 < 5.0`` is False.
             assert dp_id in _spectra_ids_in_output(result)
 
+    # ---------------------------------------------------------------
+    # B30 regression: non-positive and non-finite SNR exclusion
+    # ---------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "label,snr_value",
+        [
+            ("negative", -0.1),
+            ("zero", 0.0),
+        ],
+        ids=["snr=-0.1", "snr=0.0"],
+    )
+    def test_non_positive_snr_excluded(self, label: str, snr_value: float) -> None:
+        """Non-positive stored SNR is excluded by the display gate (B30)."""
+        with mock_aws():
+            dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+            table = _create_table(dynamodb)
+            s3 = boto3.client("s3", region_name=_REGION)
+            s3.create_bucket(Bucket=_BUCKET)
+
+            dp_id = f"dp-non-positive-{label}"
+            _seed_spectra_product(table, dp_id, snr=snr_value)
+            _seed_csv(s3, dp_id, _make_csv(_make_high_snr_fluxes()))
+
+            result = self._run_generate(table, s3)
+            assert dp_id not in _spectra_ids_in_output(result)
+
+    @pytest.mark.parametrize(
+        "label,snr_value",
+        [
+            ("nan", float("nan")),
+            ("pos_inf", float("inf")),
+            ("neg_inf", float("-inf")),
+        ],
+        ids=["snr=NaN", "snr=+inf", "snr=-inf"],
+    )
+    def test_non_finite_snr_excluded(self, label: str, snr_value: float) -> None:
+        """Non-finite effective SNR is excluded by the display gate (B30).
+
+        NaN/inf cannot be stored in DynamoDB, so we patch
+        ``_compute_effective_snr`` to return the problematic value directly.
+        """
+        with mock_aws():
+            dynamodb = boto3.resource("dynamodb", region_name=_REGION)
+            table = _create_table(dynamodb)
+            s3 = boto3.client("s3", region_name=_REGION)
+            s3.create_bucket(Bucket=_BUCKET)
+
+            dp_id = f"dp-non-finite-{label}"
+            # Seed with a high SNR that would normally pass; the patch overrides it.
+            _seed_spectra_product(table, dp_id, snr=10.0)
+            _seed_csv(s3, dp_id, _make_csv(_make_high_snr_fluxes()))
+
+            with patch(
+                "generators.spectra._compute_effective_snr",
+                return_value=snr_value,
+            ):
+                result = self._run_generate(table, s3)
+            assert dp_id not in _spectra_ids_in_output(result)
+
 
 # ===================================================================
 # Composite relative gate tests
@@ -477,5 +538,58 @@ class TestCompositeRelativeGate:
         composite = self._run_compositing_group(products)
 
         # snr=3 is excluded by relative gate (3 < 8.33).
+        assert sorted(composite["constituent_data_product_ids"]) == ["dp-a", "dp-b"]
+        assert sorted(composite["rejected_data_product_ids"]) == ["dp-c"]
+
+    # ---------------------------------------------------------------
+    # B30 regression: non-positive and non-finite SNR in compositing
+    # ---------------------------------------------------------------
+
+    def test_negative_snr_excluded_from_composite(self) -> None:
+        """Group [30, 25, -0.1]: the -0.1 spectrum is excluded (B30)."""
+        products = [
+            self._make_product("dp-a", snr=30.0, sha256="aa"),
+            self._make_product("dp-b", snr=25.0, sha256="bb"),
+            self._make_product("dp-c", snr=-0.1, sha256="cc"),
+        ]
+        composite = self._run_compositing_group(products)
+        assert sorted(composite["constituent_data_product_ids"]) == ["dp-a", "dp-b"]
+        assert sorted(composite["rejected_data_product_ids"]) == ["dp-c"]
+
+    def test_zero_snr_excluded_from_composite(self) -> None:
+        """Group [30, 25, 0.0]: the 0.0 spectrum is excluded (B30)."""
+        products = [
+            self._make_product("dp-a", snr=30.0, sha256="aa"),
+            self._make_product("dp-b", snr=25.0, sha256="bb"),
+            self._make_product("dp-c", snr=0.0, sha256="cc"),
+        ]
+        composite = self._run_compositing_group(products)
+        assert sorted(composite["constituent_data_product_ids"]) == ["dp-a", "dp-b"]
+        assert sorted(composite["rejected_data_product_ids"]) == ["dp-c"]
+
+    def test_nan_snr_excluded_from_composite(self) -> None:
+        """Group [30, 25, NaN]: the NaN spectrum is excluded (B30).
+
+        NaN cannot be stored in DynamoDB Decimals, so we patch
+        ``_effective_snr_for_product`` to return NaN for the target product.
+        """
+        from generators.compositing import _effective_snr_for_product as _real_eff_snr
+
+        products = [
+            self._make_product("dp-a", snr=30.0, sha256="aa"),
+            self._make_product("dp-b", snr=25.0, sha256="bb"),
+            self._make_product("dp-c", snr=10.0, sha256="cc"),  # will be overridden
+        ]
+
+        def _patched_eff_snr(product: dict[str, Any]) -> float:
+            if product["data_product_id"] == "dp-c":
+                return float("nan")
+            return _real_eff_snr(product)
+
+        with patch(
+            "generators.compositing._effective_snr_for_product",
+            side_effect=_patched_eff_snr,
+        ):
+            composite = self._run_compositing_group(products)
         assert sorted(composite["constituent_data_product_ids"]) == ["dp-a", "dp-b"]
         assert sorted(composite["rejected_data_product_ids"]) == ["dp-c"]

--- a/tests/services/artifact_generator/test_compositing_d1.py
+++ b/tests/services/artifact_generator/test_compositing_d1.py
@@ -65,6 +65,7 @@ def _put_spectrum(
     sha256: str = "sha_default",
     raw_s3_key: str | None = "raw/test.fits",
     validation_status: str = "VALID",
+    snr: float = 30.0,
 ) -> None:
     """Write an individual spectra DataProduct item."""
     item: dict[str, Any] = {
@@ -79,6 +80,7 @@ def _put_spectrum(
         "observation_date_mjd": Decimal(str(observation_date_mjd)),
         "sha256": sha256,
         "telescope": "VLT-UT2",
+        "snr": Decimal(str(snr)),
     }
     if raw_s3_key is not None:
         item["raw_s3_key"] = raw_s3_key

--- a/tests/services/artifact_generator/test_generators_spectra.py
+++ b/tests/services/artifact_generator/test_generators_spectra.py
@@ -25,6 +25,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import boto3
+import numpy as np
 import pytest
 from generators.shared import (
     LTTB_THRESHOLD,
@@ -358,10 +359,12 @@ class TestDisplayWavelengthFields:
     """Top-level display_wavelength_min/max in artifact output."""
 
     def _make_csv(self, wl_min: float, wl_max: float, n: int = 50) -> str:
+        rng = np.random.default_rng(42)
         step = (wl_max - wl_min) / max(n - 1, 1)
         rows = ["wavelength_nm,flux"]
         for i in range(n):
-            rows.append(f"{wl_min + i * step:.2f},1.0")
+            # Signal=1000 + low noise → DER_SNR well above the 5.0 display floor.
+            rows.append(f"{wl_min + i * step:.2f},{1000.0 + rng.normal(0, 5):.6f}")
         return "\n".join(rows)
 
     def _make_product(
@@ -380,6 +383,7 @@ class TestDisplayWavelengthFields:
             "PK": "nova-test",
             "SK": f"PRODUCT#SPECTRA#{dp_id}",
             "validation_status": "VALID",
+            "snr": Decimal("10.0"),
         }
 
     def test_display_fields_present(self) -> None:

--- a/tests/services/artifact_generator/test_spectra_regimes.py
+++ b/tests/services/artifact_generator/test_spectra_regimes.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import Any
 
+import numpy as np
 import pytest
 from generators.spectra import (
     _assign_and_split_regimes,
@@ -61,11 +62,12 @@ def _make_stage1_rec(
 
 
 def _make_csv(wl_min: float, wl_max: float, n: int = 50) -> str:
-    """Generate a web-ready CSV string."""
+    """Generate a web-ready CSV string with realistic flux (DER_SNR >> 5)."""
+    rng = np.random.default_rng(42)
     step = (wl_max - wl_min) / max(n - 1, 1)
     rows = ["wavelength_nm,flux"]
     for i in range(n):
-        rows.append(f"{wl_min + i * step:.4f},1.0")
+        rows.append(f"{wl_min + i * step:.4f},{1000.0 + rng.normal(0, 5):.6f}")
     return "\n".join(rows)
 
 
@@ -88,6 +90,7 @@ def _make_product(
         "PK": "nova-test",
         "SK": f"PRODUCT#SPECTRA#{dp_id}",
         "validation_status": "VALID",
+        "snr": Decimal("10.0"),
     }
 
 

--- a/tests/services/spectra_validator/test_handler_enrichment.py
+++ b/tests/services/spectra_validator/test_handler_enrichment.py
@@ -214,14 +214,19 @@ class TestValidateBytesWavelengthAndSnr:
         assert result["validation_outcome"] == "VALID"
         assert result["snr"] is not None
         assert abs(result["snr"] - expected_median) < 0.01
+        assert result["snr_provenance"] == "source"
 
-    def test_validate_bytes_returns_snr_none_when_absent(self, _moto_infra: dict[str, Any]) -> None:
-        """No SNR column → snr is None."""
+    def test_validate_bytes_falls_back_to_der_snr_when_no_column(
+        self, _moto_infra: dict[str, Any]
+    ) -> None:
+        """No SNR column → DER_SNR fallback populates snr with estimated value."""
         fits_bytes = _make_uves_fits_bytes(include_snr=False)
         result = self._run_validate_bytes(_moto_infra, fits_bytes)
 
         assert result["validation_outcome"] == "VALID"
-        assert result["snr"] is None
+        assert result["snr"] is not None
+        assert result["snr"] > 0.0
+        assert result["snr_provenance"] == "estimated_der_snr"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_spectra_merge.py
+++ b/tests/services/test_spectra_merge.py
@@ -22,6 +22,7 @@ from decimal import Decimal
 from typing import Any
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 from generators.shared import LTTB_THRESHOLD, segment_aware_lttb
 from generators.spectra import (
@@ -67,12 +68,13 @@ def _make_stage1(
 
 
 def _make_csv_body(wl_min: float, wl_max: float, n: int = 50) -> str:
-    """Generate a web-ready CSV string."""
+    """Generate a web-ready CSV string with realistic flux (DER_SNR >> 5)."""
+    rng = np.random.default_rng(42)
     step = (wl_max - wl_min) / max(n - 1, 1)
     rows = ["wavelength_nm,flux"]
     for i in range(n):
         wl = wl_min + i * step
-        rows.append(f"{wl:.4f},1.0")
+        rows.append(f"{wl:.4f},{1000.0 + rng.normal(0, 5):.6f}")
     return "\n".join(rows)
 
 
@@ -480,6 +482,7 @@ class TestEndToEndMerge:
                 "PK": "nova-e2e",
                 "SK": "PRODUCT#SPECTRA#dp-uvb",
                 "validation_status": "VALID",
+                "snr": Decimal("10.0"),
             },
             {
                 "data_product_id": "dp-vis",
@@ -491,6 +494,7 @@ class TestEndToEndMerge:
                 "PK": "nova-e2e",
                 "SK": "PRODUCT#SPECTRA#dp-vis",
                 "validation_status": "VALID",
+                "snr": Decimal("10.0"),
             },
             {
                 "data_product_id": "dp-nir",
@@ -502,6 +506,7 @@ class TestEndToEndMerge:
                 "PK": "nova-e2e",
                 "SK": "PRODUCT#SPECTRA#dp-nir",
                 "validation_status": "VALID",
+                "snr": Decimal("10.0"),
             },
         ]
 

--- a/tests/services/test_ticket_ingestor_spectra.py
+++ b/tests/services/test_ticket_ingestor_spectra.py
@@ -664,3 +664,116 @@ class TestEnrichmentFieldsOnDdbItem:
         assert "telescope" not in dp
         assert "observation_date_mjd" not in dp
         assert "flux_unit" not in dp
+
+
+# ===================================================================
+# S21: DER_SNR at ingestion time
+# ===================================================================
+
+
+def _write_high_snr_spectrum_csv(
+    tmp_path: Path,
+    *,
+    filename: str = "spectrum_a.csv",
+    n: int = 200,
+) -> Path:
+    """Write a two-column spectrum CSV with enough points for DER_SNR >> 0."""
+    import numpy as np
+
+    rng = np.random.default_rng(42)
+    wavelengths = np.linspace(3100.0, 7450.0, n)
+    fluxes = 1.0e-14 + rng.normal(0, 1.0e-16, n)
+    path = tmp_path / filename
+    path.write_text("\n".join(f"{w},{f}" for w, f in zip(wavelengths, fluxes, strict=False)) + "\n")
+    return path
+
+
+class TestSnrAtIngestionTime:
+    """S21: DER_SNR is computed at ingestion time and stored on SpectrumResult / DDB."""
+
+    def test_der_snr_estimated_on_spectrum_result(self, tmp_path: Path) -> None:
+        """With sufficient flux points, SpectrumResult.snr is populated via DER_SNR."""
+        _write_high_snr_spectrum_csv(tmp_path)
+        _write_metadata_csv(tmp_path, rows=[_standard_metadata_row()])
+        ticket = _make_ticket()
+
+        read_result = read_spectra(tmp_path / "metadata.csv", tmp_path, ticket, _NOVA_ID)
+        sr = read_result.results[0]
+
+        assert sr.snr is not None
+        assert sr.snr > 0.0
+        assert sr.snr_provenance == "estimated_der_snr"
+
+    def test_der_snr_none_for_degenerate_flux(self, tmp_path: Path) -> None:
+        """With too few flux points, SNR is left unset (artifact-gen fallback remains)."""
+        # Default _write_spectrum_csv produces only 3 points → DER_SNR returns 0.0
+        _write_spectrum_csv(tmp_path)
+        _write_metadata_csv(tmp_path, rows=[_standard_metadata_row()])
+        ticket = _make_ticket()
+
+        read_result = read_spectra(tmp_path / "metadata.csv", tmp_path, ticket, _NOVA_ID)
+        sr = read_result.results[0]
+
+        assert sr.snr is None
+        assert sr.snr_provenance is None
+
+    def test_snr_written_to_ddb(self, tmp_path: Path, aws_resources: dict[str, Any]) -> None:
+        """write_spectrum persists snr and snr_provenance on the DataProduct DDB item."""
+        _write_high_snr_spectrum_csv(tmp_path)
+        _write_metadata_csv(tmp_path, rows=[_standard_metadata_row()])
+        ticket = _make_ticket()
+
+        read_result = read_spectra(tmp_path / "metadata.csv", tmp_path, ticket, _NOVA_ID)
+        sr = read_result.results[0]
+
+        table = aws_resources["table"]
+        write_spectrum(
+            result=sr,
+            nova_id=_NOVA_ID,
+            job_run_id=_JOB_RUN_ID,
+            bucket=aws_resources["bucket"],
+            s3=aws_resources["s3"],
+            table=table,
+        )
+
+        dp = table.get_item(
+            Key={
+                "PK": str(_NOVA_ID),
+                "SK": f"PRODUCT#SPECTRA#ticket_ingestion#{sr.data_product_id}",
+            }
+        )["Item"]
+
+        assert "snr" in dp
+        assert float(dp["snr"]) > 0.0
+        assert dp["snr_provenance"] == "estimated_der_snr"
+
+    def test_snr_absent_from_ddb_when_degenerate(
+        self, tmp_path: Path, aws_resources: dict[str, Any]
+    ) -> None:
+        """When DER_SNR fails, snr and snr_provenance are absent from the DDB item."""
+        _write_spectrum_csv(tmp_path)  # 3 points → degenerate
+        _write_metadata_csv(tmp_path, rows=[_standard_metadata_row()])
+        ticket = _make_ticket()
+
+        read_result = read_spectra(tmp_path / "metadata.csv", tmp_path, ticket, _NOVA_ID)
+        sr = read_result.results[0]
+
+        table = aws_resources["table"]
+        write_spectrum(
+            result=sr,
+            nova_id=_NOVA_ID,
+            job_run_id=_JOB_RUN_ID,
+            bucket=aws_resources["bucket"],
+            s3=aws_resources["s3"],
+            table=table,
+        )
+
+        dp = table.get_item(
+            Key={
+                "PK": str(_NOVA_ID),
+                "SK": f"PRODUCT#SPECTRA#ticket_ingestion#{sr.data_product_id}",
+            }
+        )["Item"]
+
+        assert "snr" not in dp
+        assert "snr_provenance" not in dp


### PR DESCRIPTION
## Summary
- Added 9 SNR gate integration tests locking in display floor (SNR < 5) and compositing relative threshold (< 1/3 group median) behavior (S22)
- Added Sources column to the catalog table — discriminated union contract (ArchiveSource / BibcodeSource), catalog generator populating from DataProduct scan, frontend column with stacked rendering between References and Light Curve (F9)
- Tightened both SNR gates to exclude non-positive and non-finite values, fixing a bug where SNR ≤ 0 (including -0.1 from ESO) and NaN/inf passed through to display and composites. Also fixed a secondary bug where NaN poisoned np.median in the composite gate, silently disabling the entire relative threshold (B30)
- Added DER_SNR computation at ingestion time with `snr_provenance` tracking ("source" / "estimated_der_snr" / null) on the DataProduct contract, covering both ticket spectra and validation profile paths (S21)
- Eliminated all persistent test warnings: explicit per-column all-NaN handling in compositing.py, narrow ErfaWarning suppression for the "dubious year" variant in pyproject.toml

## Why
- S22 locks in SNR gating behavior from the epic so future changes can't silently regress the thresholds
- F9 closes a visibility gap — ticket-ingested data had no indication of which paper contributed observations, and archive-ingested data had no provider attribution in the catalog view
- B30 fixes a real data integrity issue discovered during S22 — ESO spectra with physically impossible negative SNR values were slipping through both gates and entering composites
- S21 shifts SNR computation left so new DataProducts carry SNR at write time rather than re-estimating on every artifact sweep. Provenance tracking distinguishes source-provided from estimated values for downstream consumers
- Test warnings were a persistent irritant — the suite hasn't been fully green in a while, and persistent warnings train you to ignore the output, which is how real warnings get missed

## Testing
- S22: 9 integration tests with synthetic spectra and controlled SNR values exercising both gates end-to-end via mock_aws
- F9: 14 unit tests covering source extraction (ticket bibcode, archive provider, mixed), dedup (bibcodes and providers independently), malformed locator_identity handling (6 edge cases), and INVALID product exclusion
- B30: 8 regression tests covering -0.1, 0.0, NaN, inf, -inf for both display and composite gates. Updated 4 existing test files to use realistic flux arrays (constant 1.0 flux → DER_SNR returns 0.0, which the tightened gate now correctly excludes)
- S21: 7 new tests across ticket ingestion and validation paths covering source provenance, estimated provenance, and degenerate-flux cases
- Warnings: full suite passes with `-W error::RuntimeWarning`, confirming zero RuntimeWarnings anywhere in the codebase
- All gates green: 1620 tests passing, ruff check, ruff format, mypy strict, next build

## Notes
- F9 bumps catalog schema to 1.2. Mock catalog.json updated to match.
- B30 discovered that NaN values were poisoning `np.median()` in the composite gate — the median became NaN, the floor became NaN, and all comparisons returned False, so the entire relative threshold silently did nothing. This was a bonus find beyond the original -0.1 bug.
- S21 does not backfill existing DDB items — the artifact generator's DER_SNR fallback remains as a safety net for older items. Backfill is a separate deferred task.
- Frontend tests skipped throughout (Vitest installed but unconfigured — T1 tracks this).
- ErfaWarning suppression is narrow by design: only the "dubious year" variant. Classical novae predate the UTC leap-second table; this is inherent to the domain.

## Bugs Fixed
- B30: non-positive / non-finite SNR pass-through in display and compositing gates
- Composite gate NaN-poisoning of np.median (discovered during B30, not previously tracked)
- All-NaN RuntimeWarning in compositing.py (not previously tracked as a bug)

## Out of Scope
- ADS hyperlinks on bibcodes in the Sources column (post-v1)
- Frontend test infrastructure (T1)
- DDB backfill for existing items missing SNR (separate task)
- B18 fake dataset / end-to-end test suite

## Next Steps
- F7: spectral visits in stats display (prompt ready)
- PI2: CloudWatch log group retention policy (prompt ready)
- B31/B32: frontend bugs from 4/16 bug list
- DQ section items feeding into Active Data Integrity DESIGN