### PR TITLE
refactor(references): collapse refresh_references into single-Lambda pattern

### DIFF
--- a/contracts/models/outputs.py
+++ b/contracts/models/outputs.py
@@ -675,6 +675,39 @@ class LinkNovaReferenceOutput(BaseModel):
     linked: Literal[True]  # from handler (always True — failures raise, not return)
 
 
+class FetchAndReconcileReferencesOutput(BaseModel):
+    """
+    Returned by the FetchAndReconcileReferences combined task.
+    ResultPath: $.reconcile_summary
+
+    Replaces the FetchReferenceCandidates → ReconcileReferences Map pattern.
+    Fetches ADS candidates and reconciles each one internally (normalize →
+    upsert → link). Per-item failures are quarantined inside the Lambda.
+    The full candidate list never transits through SFn state.
+
+    Source: services/reference_manager/handler.py :: _handle_fetchAndReconcileReferences()
+    """
+
+    model_config = _OUTPUT_CONFIG
+
+    nova_id: str  # from handler
+    total_candidates: int = Field(
+        description="Total number of ADS candidate docs returned by the query."
+    )  # from handler
+    reconciled: int = Field(
+        description="Number of candidates successfully reconciled (normalize + upsert + link)."
+    )  # from handler
+    quarantined: int = Field(
+        description="Number of candidates that failed and were quarantined."
+    )  # from handler
+    quarantined_bibcodes: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Bibcodes of quarantined candidates. 'unknown' for candidates missing a bibcode."
+        ),
+    )  # from handler
+
+
 class ComputeDiscoveryDateOutput(BaseModel):
     """
     Returned by the ComputeDiscoveryDate task.
@@ -1161,44 +1194,28 @@ class RefreshReferencesTerminalOutput(BaseModel):
 
     ── Path-by-path field presence ───────────────────────────────────────
     SUCCEEDED (normal completion — all references reconciled, discovery_date updated):
-      job_run ✓ | idempotency ✓ | fetch ✓ | reconcile ✓ | discovery ✓
+      job_run ✓ | idempotency ✓ | reconcile_summary ✓ | discovery ✓
       discovery_upsert ✓ | finalize ✓
 
     FAILED:
       job_run ✓ | terminal_fail ✓ | finalize ✓
       all other fields present only if the failure occurred after that task ran
 
-    ── $.reconcile shape ─────────────────────────────────────────────────
-    $.reconcile is the ReconcileReferences Map result: a list of per-candidate
-    iteration outputs (MaxConcurrency=5). Element shape depends on path taken:
+    ── $.reconcile_summary shape ─────────────────────────────────────────
+    $.reconcile_summary is the FetchAndReconcileReferences output: a lightweight
+    summary with counts and quarantined bibcodes. The full candidate list never
+    transits through SFn state (eliminating the 256KB payload limit).
 
-    Success path (reached LinkNovaReference End:true, no ResultPath):
-      LinkNovaReferenceOutput-shaped dict
-      {nova_id, bibcode, publication_date, linked}
-
-    Failed path (ItemFailureHandler ran, ResultPath: $.quarantine):
-      Accumulated iteration state at point of failure, plus:
-      {quarantine: QuarantineHandlerOutput}
-
-    Both shapes are present in the same list if any individual references fail.
-    Item-level failures do NOT abort the Map (no ToleratedFailurePercentage
-    override needed — ItemFailureHandler produces a successful iteration result).
+    Per-item failures are quarantined inside the Lambda and reported in
+    quarantined_bibcodes. Item-level quarantine writes diagnostics to the
+    JobRun record directly (DDB update_item, no SNS — see handler for details).
     """
 
     model_config = _OUTPUT_CONFIG
 
     job_run: BeginJobRunOutput
     idempotency: AcquireIdempotencyLockOutput | None = None
-    fetch: FetchReferenceCandidatesOutput | None = None
-    reconcile: list[dict[str, Any]] | None = Field(
-        default=None,
-        description=(
-            "ReconcileReferences Map result. Each element is either a "
-            "LinkNovaReferenceOutput dict (success) or a dict containing "
-            "$.quarantine (QuarantineHandlerOutput) on item-level failure. "
-            "See class docstring for full shape description."
-        ),
-    )
+    reconcile_summary: FetchAndReconcileReferencesOutput | None = None
     discovery: ComputeDiscoveryDateOutput | None = None
     discovery_upsert: UpsertDiscoveryDateMetadataOutput | None = None
     terminal_fail: TerminalFailHandlerOutput | None = None

--- a/infra/nova_constructs/compute.py
+++ b/infra/nova_constructs/compute.py
@@ -267,7 +267,7 @@ _FUNCTION_SPECS: dict[str, _FunctionSpec] = {
             "Fetches ADS references, upserts Reference entities, links NovaReference "
             "records, and computes discovery_date. Used by: refresh_references."
         ),
-        timeout=cdk.Duration.seconds(90),  # ADS API calls
+        timeout=cdk.Duration.seconds(180),  # ADS API + sequential per-candidate reconcile
     ),
     "spectra_acquirer": _FunctionSpec(
         service_dir="spectra_acquirer",

--- a/infra/workflows/refresh_references.asl.json
+++ b/infra/workflows/refresh_references.asl.json
@@ -1,5 +1,5 @@
 {
-    "Comment": "refresh_references workflow \u2014 fetches ADS references for a nova, upserts global Reference entities, links them via NovaReference, and computes discovery_date.",
+    "Comment": "refresh_references workflow — fetches ADS references for a nova, upserts global Reference entities, links them via NovaReference, and computes discovery_date.",
     "StartAt": "BeginJobRun",
     "States": {
         "BeginJobRun": {
@@ -76,37 +76,38 @@
         },
         "EnsureAttributes": {
             "Type": "Choice",
-            "Comment": "Guard for the optional $.attributes field. FetchReferenceCandidates uses a hard JSONPath reference (\"attributes.$\": \"$.attributes\") which throws States.Runtime if the field is absent. When refresh_references is launched by workflow_launcher (the normal path), no attributes field is present \u2014 only operator-triggered re-runs include it. This Choice + Pass pair guarantees $.attributes exists before FetchReferenceCandidates runs.",
+            "Comment": "Guard for the optional $.attributes field. FetchAndReconcileReferences uses a hard JSONPath reference (\"attributes.$\": \"$.attributes\") which throws States.Runtime if the field is absent. When refresh_references is launched by workflow_launcher (the normal path), no attributes field is present — only operator-triggered re-runs include it. This Choice + Pass pair guarantees $.attributes exists before FetchAndReconcileReferences runs.",
             "Choices": [
                 {
                     "Variable": "$.attributes",
                     "IsPresent": true,
-                    "Next": "FetchReferenceCandidates"
+                    "Next": "FetchAndReconcileReferences"
                 }
             ],
             "Default": "DefaultAttributes"
         },
         "DefaultAttributes": {
             "Type": "Pass",
-            "Comment": "Inject an empty attributes dict so FetchReferenceCandidates can safely dereference $.attributes.",
+            "Comment": "Inject an empty attributes dict so FetchAndReconcileReferences can safely dereference $.attributes.",
             "Result": {},
             "ResultPath": "$.attributes",
-            "Next": "FetchReferenceCandidates"
+            "Next": "FetchAndReconcileReferences"
         },
-        "FetchReferenceCandidates": {
+        "FetchAndReconcileReferences": {
             "Type": "Task",
-            "Comment": "Load nova aliases, query ADS by name, return raw candidate docs. Output stored at $.fetch; $.fetch.candidates feeds the ReconcileReferences Map.",
+            "Comment": "Load nova aliases, query ADS, then for each candidate: normalize, upsert Reference entity, link NovaReference. Per-item failures are quarantined inside the Lambda. Returns a lightweight summary (counts + quarantined bibcodes). The full candidate list never transits through SFn state.",
             "Resource": "${ReferenceManagerFunctionArn}",
             "Parameters": {
-                "task_name": "FetchReferenceCandidates",
+                "task_name": "FetchAndReconcileReferences",
                 "workflow_name": "refresh_references",
                 "nova_id.$": "$.nova_id",
                 "correlation_id.$": "$.job_run.correlation_id",
                 "job_run_id.$": "$.job_run.job_run_id",
+                "job_run.$": "$.job_run",
                 "attributes.$": "$.attributes"
             },
-            "ResultPath": "$.fetch",
-            "TimeoutSeconds": 60,
+            "ResultPath": "$.reconcile_summary",
+            "TimeoutSeconds": 180,
             "Retry": [
                 {
                     "ErrorEquals": [
@@ -120,184 +121,6 @@
                     "JitterStrategy": "FULL"
                 }
             ],
-            "Catch": [
-                {
-                    "ErrorEquals": [
-                        "States.ALL"
-                    ],
-                    "Next": "TerminalFailHandler",
-                    "ResultPath": "$.error"
-                }
-            ],
-            "Next": "ReconcileReferences"
-        },
-        "ReconcileReferences": {
-            "Type": "Map",
-            "Comment": "For each ADS candidate doc: normalize, upsert global Reference entity, link to nova. Item-level failures are quarantined and skipped; they do not fail the Map. All ADS_FIELDS are explicitly requested so all keys are present in each item (null when absent from ADS).",
-            "ItemsPath": "$.fetch.candidates",
-            "ItemSelector": {
-                "nova_id.$": "$$.Execution.Input.nova_id",
-                "correlation_id.$": "$$.Execution.Input.correlation_id",
-                "job_run.$": "$.job_run",
-                "bibcode.$": "$$.Map.Item.Value.bibcode",
-                "doctype.$": "$$.Map.Item.Value.doctype",
-                "title.$": "$$.Map.Item.Value.title",
-                "date.$": "$$.Map.Item.Value.date",
-                "author.$": "$$.Map.Item.Value.author",
-                "doi.$": "$$.Map.Item.Value.doi",
-                "identifier.$": "$$.Map.Item.Value.identifier"
-            },
-            "MaxConcurrency": 5,
-            "ResultPath": "$.reconcile",
-            "Iterator": {
-                "StartAt": "NormalizeReference",
-                "States": {
-                    "NormalizeReference": {
-                        "Type": "Task",
-                        "Resource": "${ReferenceManagerFunctionArn}",
-                        "Parameters": {
-                            "task_name": "NormalizeReference",
-                            "nova_id.$": "$.nova_id",
-                            "bibcode.$": "$.bibcode",
-                            "doctype.$": "$.doctype",
-                            "title.$": "$.title",
-                            "date.$": "$.date",
-                            "author.$": "$.author",
-                            "doi.$": "$.doi",
-                            "identifier.$": "$.identifier"
-                        },
-                        "TimeoutSeconds": 20,
-                        "Retry": [
-                            {
-                                "ErrorEquals": [
-                                    "RetryableError",
-                                    "Lambda.TooManyRequestsException",
-                                    "Lambda.ServiceException"
-                                ],
-                                "IntervalSeconds": 2,
-                                "MaxAttempts": 2,
-                                "BackoffRate": 4,
-                                "JitterStrategy": "FULL"
-                            }
-                        ],
-                        "Catch": [
-                            {
-                                "ErrorEquals": [
-                                    "States.ALL"
-                                ],
-                                "Next": "ItemFailureHandler",
-                                "ResultPath": "$.error"
-                            }
-                        ],
-                        "Next": "UpsertReferenceEntity"
-                    },
-                    "UpsertReferenceEntity": {
-                        "Type": "Task",
-                        "Comment": "Write or update global Reference item. PK=REFERENCE#<bibcode>, SK=METADATA. Preserves created_at on update.",
-                        "Resource": "${ReferenceManagerFunctionArn}",
-                        "Parameters": {
-                            "task_name": "UpsertReferenceEntity",
-                            "nova_id.$": "$.nova_id",
-                            "bibcode.$": "$.bibcode",
-                            "reference_type.$": "$.reference_type",
-                            "title.$": "$.title",
-                            "year.$": "$.year",
-                            "publication_date.$": "$.publication_date",
-                            "authors.$": "$.authors",
-                            "doi.$": "$.doi",
-                            "arxiv_id.$": "$.arxiv_id"
-                        },
-                        "TimeoutSeconds": 20,
-                        "Retry": [
-                            {
-                                "ErrorEquals": [
-                                    "RetryableError",
-                                    "Lambda.TooManyRequestsException",
-                                    "Lambda.ServiceException"
-                                ],
-                                "IntervalSeconds": 2,
-                                "MaxAttempts": 2,
-                                "BackoffRate": 4,
-                                "JitterStrategy": "FULL"
-                            }
-                        ],
-                        "Catch": [
-                            {
-                                "ErrorEquals": [
-                                    "States.ALL"
-                                ],
-                                "Next": "ItemFailureHandler",
-                                "ResultPath": "$.error"
-                            }
-                        ],
-                        "Next": "LinkNovaReference"
-                    },
-                    "LinkNovaReference": {
-                        "Type": "Task",
-                        "Comment": "Idempotent upsert of NOVAREF link. PK=<nova_id>, SK=NOVAREF#<bibcode>. ConditionalCheckFailed is silently swallowed.",
-                        "Resource": "${ReferenceManagerFunctionArn}",
-                        "Parameters": {
-                            "task_name": "LinkNovaReference",
-                            "nova_id.$": "$.nova_id",
-                            "bibcode.$": "$.bibcode",
-                            "publication_date.$": "$.publication_date"
-                        },
-                        "TimeoutSeconds": 20,
-                        "Retry": [
-                            {
-                                "ErrorEquals": [
-                                    "RetryableError",
-                                    "Lambda.TooManyRequestsException",
-                                    "Lambda.ServiceException"
-                                ],
-                                "IntervalSeconds": 2,
-                                "MaxAttempts": 2,
-                                "BackoffRate": 4,
-                                "JitterStrategy": "FULL"
-                            }
-                        ],
-                        "Catch": [
-                            {
-                                "ErrorEquals": [
-                                    "States.ALL"
-                                ],
-                                "Next": "ItemFailureHandler",
-                                "ResultPath": "$.error"
-                            }
-                        ],
-                        "End": true
-                    },
-                    "ItemFailureHandler": {
-                        "Type": "Task",
-                        "Resource": "${QuarantineHandlerFunctionArn}",
-                        "Parameters": {
-                            "task_name": "QuarantineHandler",
-                            "workflow_name": "refresh_references",
-                            "quarantine_reason_code": "OTHER",
-                            "nova_id.$": "$.nova_id",
-                            "bibcode.$": "$.bibcode",
-                            "correlation_id.$": "$.correlation_id",
-                            "job_run.$": "$.job_run"
-                        },
-                        "ResultPath": "$.quarantine",
-                        "TimeoutSeconds": 10,
-                        "Retry": [
-                            {
-                                "ErrorEquals": [
-                                    "RetryableError",
-                                    "Lambda.TooManyRequestsException",
-                                    "Lambda.ServiceException"
-                                ],
-                                "IntervalSeconds": 2,
-                                "MaxAttempts": 2,
-                                "BackoffRate": 4,
-                                "JitterStrategy": "FULL"
-                            }
-                        ],
-                        "End": true
-                    }
-                }
-            },
             "Catch": [
                 {
                     "ErrorEquals": [
@@ -348,7 +171,7 @@
         },
         "UpsertDiscoveryDateMetadata": {
             "Type": "Task",
-            "Comment": "Write discovery_date to Nova item only if strictly earlier than current value (monotonically earlier invariant, ADR-005 \u00a74). No-op if unchanged or no date computed.",
+            "Comment": "Write discovery_date to Nova item only if strictly earlier than current value (monotonically earlier invariant, ADR-005 §4). No-op if unchanged or no date computed.",
             "Resource": "${ReferenceManagerFunctionArn}",
             "Parameters": {
                 "task_name": "UpsertDiscoveryDateMetadata",

--- a/services/reference_manager/handler.py
+++ b/services/reference_manager/handler.py
@@ -24,9 +24,12 @@ Environment variables (injected by CDK):
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import os
+import random
 import re
+import time
 from collections.abc import Callable
 from datetime import UTC, datetime
 from urllib.parse import urlencode
@@ -589,6 +592,194 @@ def _handle_upsertDiscoveryDateMetadata(event: dict, context: object) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Combined task: FetchAndReconcileReferences
+# ---------------------------------------------------------------------------
+
+# Quarantine classification reason for refresh_references item-level failures.
+# Matches the "OTHER" reason code used by the ASL ItemFailureHandler.
+_QUARANTINE_REASON_CODE = "OTHER"
+_QUARANTINE_CLASSIFICATION_REASON = (
+    "Quarantine triggered — ambiguous or inconclusive results. Manual review required."
+)
+
+# Per-item retry parameters — matches the ASL Map Iterator retry policy:
+#   MaxAttempts=2, IntervalSeconds=2, BackoffRate=4, JitterStrategy=FULL
+_ITEM_MAX_RETRIES = 2
+_ITEM_RETRY_BASE_SECONDS = 2
+_ITEM_RETRY_BACKOFF_RATE = 4
+
+
+def _compute_quarantine_fingerprint(reason_code: str, workflow_name: str, primary_id: str) -> str:
+    """Short hex digest for cross-referencing quarantine logs.
+
+    Mirrors quarantine_handler._compute_error_fingerprint — same algorithm,
+    kept local to avoid cross-service import.
+    """
+    raw = f"{reason_code}:{workflow_name}:{primary_id}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:12]
+
+
+def _persist_quarantine_to_job_run(
+    *,
+    job_run: dict,
+    nova_id: str,
+    workflow_name: str = "refresh_references",
+) -> str:
+    """Write quarantine diagnostics onto the JobRun DDB record.
+
+    Returns the computed error_fingerprint for inclusion in the summary.
+    """
+    now = _utcnow_iso()
+    fingerprint = _compute_quarantine_fingerprint(_QUARANTINE_REASON_CODE, workflow_name, nova_id)
+
+    _table.update_item(
+        Key={"PK": job_run["pk"], "SK": job_run["sk"]},
+        UpdateExpression=(
+            "SET quarantine_reason_code = :reason_code, "
+            "classification_reason = :classification_reason, "
+            "error_fingerprint = :error_fingerprint, "
+            "quarantined_at = :quarantined_at, "
+            "updated_at = :updated_at"
+        ),
+        ExpressionAttributeValues={
+            ":reason_code": _QUARANTINE_REASON_CODE,
+            ":classification_reason": _QUARANTINE_CLASSIFICATION_REASON,
+            ":error_fingerprint": fingerprint,
+            ":quarantined_at": now,
+            ":updated_at": now,
+        },
+    )
+    return fingerprint
+
+
+def _reconcile_one_candidate(candidate: dict, nova_id: str, context: object) -> dict:
+    """Run normalize → upsert → link for a single ADS candidate.
+
+    Wraps each phase with the per-item retry policy (2 retries, exponential
+    backoff with factor 4, full jitter) for RetryableError only.
+
+    Returns the LinkNovaReference output dict on success.
+    Raises on terminal (non-retryable) errors.
+    """
+
+    def _with_retry(fn: Callable[..., dict], event: dict) -> dict:
+        last_exc: Exception | None = None
+        for attempt in range(_ITEM_MAX_RETRIES + 1):
+            try:
+                return fn(event, context)
+            except RetryableError as exc:
+                last_exc = exc
+                if attempt < _ITEM_MAX_RETRIES:
+                    delay = _ITEM_RETRY_BASE_SECONDS * (_ITEM_RETRY_BACKOFF_RATE**attempt)
+                    time.sleep(random.uniform(0, delay))  # noqa: S311
+                    logger.warning(
+                        "Retrying after RetryableError",
+                        extra={
+                            "attempt": attempt + 1,
+                            "max_retries": _ITEM_MAX_RETRIES,
+                            "error": str(exc),
+                        },
+                    )
+        raise last_exc  # type: ignore[misc]
+
+    # Step 1: Normalize
+    normalize_event = {**candidate, "nova_id": nova_id}
+    normalized = _with_retry(_handle_normalizeReference, normalize_event)
+
+    # Step 2: Upsert Reference entity
+    upserted = _with_retry(_handle_upsertReferenceEntity, normalized)
+
+    # Step 3: Link NovaReference
+    linked = _with_retry(_handle_linkNovaReference, upserted)
+
+    return linked
+
+
+@tracer.capture_method
+def _handle_fetchAndReconcileReferences(event: dict, context: object) -> dict:
+    """
+    Combined task: fetch ADS candidates then reconcile each one internally.
+
+    Replaces the FetchReferenceCandidates → ReconcileReferences Map pattern.
+    The full ADS candidate list never transits through Step Functions state,
+    eliminating the 256KB payload limit bottleneck.
+
+    Per-item error isolation: a single candidate's failure is quarantined
+    (logged + persisted to JobRun) without aborting the loop. Processing
+    continues to the next candidate.
+
+    Output shape (lightweight summary only):
+        {
+            "nova_id": "<uuid>",
+            "total_candidates": N,
+            "reconciled": M,
+            "quarantined": Q,
+            "quarantined_bibcodes": ["bibcode1", ...],
+        }
+    """
+    nova_id: str | None = event.get("nova_id")
+    if not nova_id:
+        raise TerminalError("Missing required field: nova_id")
+
+    correlation_id: str = event.get("correlation_id", "unknown")
+    job_run: dict | None = event.get("job_run")
+
+    # Phase 1: Fetch ADS candidates (reuse existing logic)
+    fetch_result = _handle_fetchReferenceCandidates(event, context)
+    candidates: list[dict] = fetch_result["candidates"]
+
+    # Phase 2: Reconcile each candidate sequentially
+    reconciled = 0
+    quarantined_bibcodes: list[str] = []
+
+    for candidate in candidates:
+        bibcode = candidate.get("bibcode") or "unknown"
+        try:
+            _reconcile_one_candidate(candidate, nova_id, context)
+            reconciled += 1
+        except Exception as exc:
+            quarantined_bibcodes.append(bibcode)
+
+            # Structured quarantine log line — replaces SNS notification
+            logger.warning(
+                "Reference candidate quarantined",
+                extra={
+                    "bibcode": bibcode,
+                    "error_type": type(exc).__name__,
+                    "error_message": str(exc),
+                    "nova_id": nova_id,
+                    "correlation_id": correlation_id,
+                },
+            )
+
+            # Persist quarantine diagnostics to the JobRun record
+            if job_run:
+                _persist_quarantine_to_job_run(
+                    job_run=job_run,
+                    nova_id=nova_id,
+                )
+
+    logger.info(
+        "FetchAndReconcileReferences complete",
+        extra={
+            "nova_id": nova_id,
+            "total_candidates": len(candidates),
+            "reconciled": reconciled,
+            "quarantined": len(quarantined_bibcodes),
+            "quarantined_bibcodes": quarantined_bibcodes,
+        },
+    )
+
+    return {
+        "nova_id": nova_id,
+        "total_candidates": len(candidates),
+        "reconciled": reconciled,
+        "quarantined": len(quarantined_bibcodes),
+        "quarantined_bibcodes": quarantined_bibcodes,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
@@ -631,6 +822,7 @@ _TASK_HANDLERS: dict[str, Callable[[dict, object], dict]] = {
     "NormalizeReference": _handle_normalizeReference,
     "UpsertReferenceEntity": _handle_upsertReferenceEntity,
     "LinkNovaReference": _handle_linkNovaReference,
+    "FetchAndReconcileReferences": _handle_fetchAndReconcileReferences,
     "ComputeDiscoveryDate": _handle_computeDiscoveryDate,
     "UpsertDiscoveryDateMetadata": _handle_upsertDiscoveryDateMetadata,
 }

--- a/tests/infra/test_synth.py
+++ b/tests/infra/test_synth.py
@@ -257,7 +257,7 @@ _ZIP_FUNCTIONS: dict[str, dict[str, int]] = {
     "nova-cat-job-run-manager": {"memory": 256, "timeout": 30},
     "nova-cat-idempotency-guard": {"memory": 256, "timeout": 30},
     "nova-cat-workflow-launcher": {"memory": 256, "timeout": 300},
-    "nova-cat-reference-manager": {"memory": 256, "timeout": 90},
+    "nova-cat-reference-manager": {"memory": 256, "timeout": 180},
     "nova-cat-spectra-acquirer": {"memory": 512, "timeout": 900},
     "nova-cat-photometry-ingestor": {"memory": 512, "timeout": 300},
     "nova-cat-quarantine-handler": {"memory": 256, "timeout": 30},

--- a/tests/integration/test_refresh_references_integration.py
+++ b/tests/integration/test_refresh_references_integration.py
@@ -6,39 +6,37 @@ directly in ASL order, sharing a single mocked AWS environment (DynamoDB,
 Secrets Manager, SNS) via moto. ADS HTTP calls are patched via requests.
 
 Workflow order (per refresh_references.asl.json):
-  BeginJobRun → AcquireIdempotencyLock → FetchReferenceCandidates →
-  ReconcileReferences (Map: NormalizeReference → UpsertReferenceEntity →
-  LinkNovaReference | ItemFailureHandler) → ComputeDiscoveryDate →
-  UpsertDiscoveryDateMetadata → FinalizeJobRunSuccess |
-  TerminalFailHandler → FinalizeJobRunFailed
+  BeginJobRun → AcquireIdempotencyLock → FetchAndReconcileReferences →
+  ComputeDiscoveryDate → UpsertDiscoveryDateMetadata →
+  FinalizeJobRunSuccess | TerminalFailHandler → FinalizeJobRunFailed
 
-Map ResultPath notes (from ASL):
-  NormalizeReference:      no ResultPath → replaces entire item state
-  UpsertReferenceEntity:   no ResultPath → replaces entire item state
-  LinkNovaReference:       no ResultPath → replaces entire item state (End)
-  ItemFailureHandler:      ResultPath=$.quarantine → preserves item state
+FetchAndReconcileReferences is a single Lambda invocation that internally
+performs: ADS query → per-candidate (normalize → upsert → link), with
+per-item error isolation (quarantine). The full candidate list never
+transits through SFn state.
 
 Top-level ResultPath notes:
-  FetchReferenceCandidates:    ResultPath=$.fetch
-  ReconcileReferences:         ResultPath=$.reconcile
-  ComputeDiscoveryDate:        ResultPath=$.discovery
-  UpsertDiscoveryDateMetadata: ResultPath=$.discovery_upsert
-  FinalizeJobRunSuccess:       ResultPath=$.finalize
+  FetchAndReconcileReferences:   ResultPath=$.reconcile_summary
+  ComputeDiscoveryDate:          ResultPath=$.discovery
+  UpsertDiscoveryDateMetadata:   ResultPath=$.discovery_upsert
+  FinalizeJobRunSuccess:         ResultPath=$.finalize
 
 Paths covered:
-  1. Happy path — ADS returns two candidates; all Map items succeed; earlier
+  1. Happy path — ADS returns two candidates; all items succeed; earlier
      discovery date is written to the Nova item; JobRun ends SUCCEEDED
-  2. Empty candidates — ADS returns no results; Map is a no-op; workflow
-     still reaches FinalizeJobRunSuccess; no discovery date is set
+  2. Empty candidates — ADS returns no results; reconcile is a no-op;
+     workflow still reaches FinalizeJobRunSuccess; no discovery date is set
   3. Discovery date no-op — Nova already has an earlier date;
      UpsertDiscoveryDateMetadata is a no-op (updated: False)
-  4. Item-level quarantine — one candidate fails NormalizeReference;
-     ItemFailureHandler (QuarantineHandler) fires and continues; remaining
+  4. Item-level quarantine — one candidate fails NormalizeReference inside
+     the combined Lambda; quarantine diagnostics are persisted; remaining
      items succeed; JobRun ends SUCCEEDED
-  5. Terminal failure — FetchReferenceCandidates raises TerminalError; ASL
-     routes to TerminalFailHandler → FinalizeJobRunFailed; JobRun ends FAILED
-  6. Idempotency — running the Map tasks twice for the same nova does not
-     produce duplicate NOVAREF items (LinkNovaReference is idempotent)
+  5. Terminal failure — FetchAndReconcileReferences raises TerminalError
+     (nova not found); ASL routes to TerminalFailHandler →
+     FinalizeJobRunFailed; JobRun ends FAILED
+  6. Idempotency — running the combined function twice for the same nova
+     does not produce duplicate NOVAREF items (LinkNovaReference is
+     idempotent)
 """
 
 from __future__ import annotations
@@ -253,62 +251,36 @@ def _run_prefix(h: dict[str, types.ModuleType]) -> dict[str, Any]:
     }
 
 
-def _run_map_item(
-    h: dict[str, types.ModuleType],
-    state: dict[str, Any],
-    raw_doc: dict[str, Any],
-) -> None:
-    """
-    Run one Map item through the full happy path:
-      NormalizeReference → UpsertReferenceEntity → LinkNovaReference.
-
-    Mirrors the ASL chain: each task's output (with no ResultPath) becomes
-    the next task's input. task_name is injected at each step as the ASL
-    Parameters block would.
-    """
-    # NormalizeReference: receives ItemSelector fields (no ResultPath → replaces state)
-    normalized = cast(
-        dict[str, Any],
-        h["reference_manager"].handle(
-            {
-                "task_name": "NormalizeReference",
-                "nova_id": state["nova_id"],
-                "correlation_id": state["job_run"]["correlation_id"],
-                "job_run": state["job_run"],
-                **raw_doc,
-            },
-            None,
-        ),
-    )
-
-    # UpsertReferenceEntity: receives NormalizeReference output (no ResultPath → replaces state)
-    upserted = cast(
-        dict[str, Any],
-        h["reference_manager"].handle(
-            {
-                "task_name": "UpsertReferenceEntity",
-                **normalized,
-            },
-            None,
-        ),
-    )
-
-    # LinkNovaReference: receives UpsertReferenceEntity output (no ResultPath, End: true)
-    h["reference_manager"].handle(
-        {
-            "task_name": "LinkNovaReference",
-            **upserted,
-        },
-        None,
-    )
-
-
-def _run_post_map(
+def _run_fetch_and_reconcile(
     h: dict[str, types.ModuleType],
     state: dict[str, Any],
 ) -> dict[str, Any]:
     """
-    Run the post-Map states: ComputeDiscoveryDate → UpsertDiscoveryDateMetadata.
+    Run the combined FetchAndReconcileReferences task.
+    Returns the lightweight summary.
+    """
+    return cast(
+        dict[str, Any],
+        h["reference_manager"].handle(
+            {
+                "task_name": "FetchAndReconcileReferences",
+                "workflow_name": "refresh_references",
+                "nova_id": _NOVA_ID,
+                "correlation_id": state["job_run"]["correlation_id"],
+                "job_run_id": state["job_run"]["job_run_id"],
+                "job_run": state["job_run"],
+            },
+            None,
+        ),
+    )
+
+
+def _run_post_reconcile(
+    h: dict[str, types.ModuleType],
+    state: dict[str, Any],
+) -> dict[str, Any]:
+    """
+    Run the post-reconcile states: ComputeDiscoveryDate → UpsertDiscoveryDateMetadata.
 
     Both use ResultPath so the top-level state is preserved. Returns the
     UpsertDiscoveryDateMetadata result for assertion.
@@ -403,21 +375,13 @@ class TestHappyPath:
                 mock_requests.exceptions.RequestException = Exception
 
                 state = _run_prefix(h)
+                summary = _run_fetch_and_reconcile(h, state)
 
-                h["reference_manager"].handle(
-                    {
-                        "task_name": "FetchReferenceCandidates",
-                        "workflow_name": "refresh_references",
-                        "nova_id": _NOVA_ID,
-                        "correlation_id": state["job_run"]["correlation_id"],
-                        "job_run_id": state["job_run"]["job_run_id"],
-                    },
-                    None,
-                )
+                assert summary["total_candidates"] == 2
+                assert summary["reconciled"] == 2
+                assert summary["quarantined"] == 0
 
-                _run_map_item(h, state, _RAW_DOC_A)
-                _run_map_item(h, state, _RAW_DOC_B)
-                _run_post_map(h, state)
+                _run_post_reconcile(h, state)
                 _run_finalize_success(h, state)
 
         job_run_item = _get_job_run(table, state)
@@ -435,18 +399,7 @@ class TestHappyPath:
                 mock_requests.exceptions.RequestException = Exception
 
                 state = _run_prefix(h)
-                h["reference_manager"].handle(
-                    {
-                        "task_name": "FetchReferenceCandidates",
-                        "workflow_name": "refresh_references",
-                        "nova_id": _NOVA_ID,
-                        "correlation_id": state["job_run"]["correlation_id"],
-                        "job_run_id": state["job_run"]["job_run_id"],
-                    },
-                    None,
-                )
-                _run_map_item(h, state, _RAW_DOC_A)
-                _run_map_item(h, state, _RAW_DOC_B)
+                _run_fetch_and_reconcile(h, state)
 
         ref_a = table.get_item(Key={"PK": f"REFERENCE#{_BIBCODE_A}", "SK": "METADATA"})["Item"]
         ref_b = table.get_item(Key={"PK": f"REFERENCE#{_BIBCODE_B}", "SK": "METADATA"})["Item"]
@@ -467,18 +420,7 @@ class TestHappyPath:
                 mock_requests.exceptions.RequestException = Exception
 
                 state = _run_prefix(h)
-                h["reference_manager"].handle(
-                    {
-                        "task_name": "FetchReferenceCandidates",
-                        "workflow_name": "refresh_references",
-                        "nova_id": _NOVA_ID,
-                        "correlation_id": state["job_run"]["correlation_id"],
-                        "job_run_id": state["job_run"]["job_run_id"],
-                    },
-                    None,
-                )
-                _run_map_item(h, state, _RAW_DOC_A)
-                _run_map_item(h, state, _RAW_DOC_B)
+                _run_fetch_and_reconcile(h, state)
 
         novarefs = _list_novarefs(table)
         bibcodes = {item["bibcode"] for item in novarefs}
@@ -499,19 +441,8 @@ class TestHappyPath:
                 mock_requests.exceptions.RequestException = Exception
 
                 state = _run_prefix(h)
-                h["reference_manager"].handle(
-                    {
-                        "task_name": "FetchReferenceCandidates",
-                        "workflow_name": "refresh_references",
-                        "nova_id": _NOVA_ID,
-                        "correlation_id": state["job_run"]["correlation_id"],
-                        "job_run_id": state["job_run"]["job_run_id"],
-                    },
-                    None,
-                )
-                _run_map_item(h, state, _RAW_DOC_A)
-                _run_map_item(h, state, _RAW_DOC_B)
-                _run_post_map(h, state)
+                _run_fetch_and_reconcile(h, state)
+                _run_post_reconcile(h, state)
                 _run_finalize_success(h, state)
 
         nova = _get_nova(table)
@@ -539,17 +470,7 @@ class TestHappyPath:
                 mock_requests.exceptions.RequestException = Exception
 
                 state = _run_prefix(h)
-                h["reference_manager"].handle(
-                    {
-                        "task_name": "FetchReferenceCandidates",
-                        "workflow_name": "refresh_references",
-                        "nova_id": _NOVA_ID,
-                        "correlation_id": state["job_run"]["correlation_id"],
-                        "job_run_id": state["job_run"]["job_run_id"],
-                    },
-                    None,
-                )
-                _run_map_item(h, state, _RAW_DOC_A)
+                _run_fetch_and_reconcile(h, state)
 
         ref = table.get_item(Key={"PK": f"REFERENCE#{_BIBCODE_A}", "SK": "METADATA"})["Item"]
         assert ref["publication_date"] == "2013-06-00"
@@ -573,23 +494,11 @@ class TestEmptyCandidates:
                 mock_requests.exceptions.RequestException = Exception
 
                 state = _run_prefix(h)
-                fetch = cast(
-                    dict[str, Any],
-                    h["reference_manager"].handle(
-                        {
-                            "task_name": "FetchReferenceCandidates",
-                            "workflow_name": "refresh_references",
-                            "nova_id": _NOVA_ID,
-                            "correlation_id": state["job_run"]["correlation_id"],
-                            "job_run_id": state["job_run"]["job_run_id"],
-                        },
-                        None,
-                    ),
-                )
+                summary = _run_fetch_and_reconcile(h, state)
 
-            # Map receives zero items — skip directly to post-Map states
-            assert fetch["candidate_count"] == 0
-            _run_post_map(h, state)
+            assert summary["total_candidates"] == 0
+            assert summary["reconciled"] == 0
+            _run_post_reconcile(h, state)
             _run_finalize_success(h, state)
 
         job_run_item = _get_job_run(table, state)
@@ -607,18 +516,8 @@ class TestEmptyCandidates:
                 mock_requests.exceptions.RequestException = Exception
 
                 state = _run_prefix(h)
-                h["reference_manager"].handle(
-                    {
-                        "task_name": "FetchReferenceCandidates",
-                        "workflow_name": "refresh_references",
-                        "nova_id": _NOVA_ID,
-                        "correlation_id": state["job_run"]["correlation_id"],
-                        "job_run_id": state["job_run"]["job_run_id"],
-                    },
-                    None,
-                )
-                # No Map items to run
-                _run_post_map(h, state)
+                _run_fetch_and_reconcile(h, state)
+                _run_post_reconcile(h, state)
 
         assert _list_novarefs(table) == []
 
@@ -634,17 +533,8 @@ class TestEmptyCandidates:
                 mock_requests.exceptions.RequestException = Exception
 
                 state = _run_prefix(h)
-                h["reference_manager"].handle(
-                    {
-                        "task_name": "FetchReferenceCandidates",
-                        "workflow_name": "refresh_references",
-                        "nova_id": _NOVA_ID,
-                        "correlation_id": state["job_run"]["correlation_id"],
-                        "job_run_id": state["job_run"]["job_run_id"],
-                    },
-                    None,
-                )
-                upsert_result = _run_post_map(h, state)
+                _run_fetch_and_reconcile(h, state)
+                upsert_result = _run_post_reconcile(h, state)
 
         assert upsert_result["updated"] is False
         assert upsert_result["discovery_date"] is None
@@ -675,19 +565,8 @@ class TestDiscoveryDateNoOp:
                 mock_requests.exceptions.RequestException = Exception
 
                 state = _run_prefix(h)
-                h["reference_manager"].handle(
-                    {
-                        "task_name": "FetchReferenceCandidates",
-                        "workflow_name": "refresh_references",
-                        "nova_id": _NOVA_ID,
-                        "correlation_id": state["job_run"]["correlation_id"],
-                        "job_run_id": state["job_run"]["job_run_id"],
-                    },
-                    None,
-                )
-                _run_map_item(h, state, _RAW_DOC_A)
-                _run_map_item(h, state, _RAW_DOC_B)
-                upsert_result = _run_post_map(h, state)
+                _run_fetch_and_reconcile(h, state)
+                upsert_result = _run_post_reconcile(h, state)
 
         assert upsert_result["updated"] is False
         nova = _get_nova(table)
@@ -705,207 +584,175 @@ class TestDiscoveryDateNoOp:
                 mock_requests.exceptions.RequestException = Exception
 
                 state = _run_prefix(h)
-                h["reference_manager"].handle(
-                    {
-                        "task_name": "FetchReferenceCandidates",
-                        "workflow_name": "refresh_references",
-                        "nova_id": _NOVA_ID,
-                        "correlation_id": state["job_run"]["correlation_id"],
-                        "job_run_id": state["job_run"]["job_run_id"],
-                    },
-                    None,
-                )
-                _run_map_item(h, state, _RAW_DOC_B)
-                upsert_result = _run_post_map(h, state)
+                _run_fetch_and_reconcile(h, state)
+                upsert_result = _run_post_reconcile(h, state)
 
         assert upsert_result["updated"] is False
 
 
 # ---------------------------------------------------------------------------
-# Path 4: Item-level quarantine — one candidate fails, Map continues
+# Path 4: Item-level quarantine — one candidate fails, processing continues
 # ---------------------------------------------------------------------------
 
 
 class TestItemLevelQuarantine:
-    def test_quarantine_handler_fires_on_normalize_failure(self, table: Any) -> None:
+    def test_bad_bibcode_quarantined_good_bibcode_succeeds(self, table: Any) -> None:
         """
-        When NormalizeReference raises (simulated by passing a doc with no
-        bibcode), the ASL routes to ItemFailureHandler (QuarantineHandler).
-        The handler should persist quarantine diagnostics onto the JobRun.
+        When one candidate has no bibcode (fails NormalizeReference), the
+        combined function quarantines it and continues. The remaining good
+        candidate is linked and its date is computed.
         """
-        with mock_aws():
-            _seed_nova(table)
-            h = _load_handlers()
+        bad_doc: dict[str, Any] = {
+            "bibcode": None,
+            "doctype": "article",
+            "title": None,
+            "date": None,
+            "author": [],
+            "doi": None,
+            "identifier": [],
+        }
 
-            state = _run_prefix(h)
-
-            # Simulate NormalizeReference failing — bad_doc has no bibcode
-            bad_doc: dict[str, Any] = {
-                "bibcode": None,
-                "doctype": "article",
-                "title": None,
-                "date": None,
-                "author": [],
-                "doi": None,
-                "identifier": [],
-            }
-
-            from nova_common.errors import TerminalError
-
-            with pytest.raises(TerminalError, match="bibcode"):
-                h["reference_manager"].handle(
-                    {
-                        "task_name": "NormalizeReference",
-                        "nova_id": state["nova_id"],
-                        "correlation_id": state["job_run"]["correlation_id"],
-                        "job_run": state["job_run"],
-                        **bad_doc,
-                    },
-                    None,
-                )
-
-            # ASL Catch routes to ItemFailureHandler (QuarantineHandler).
-            # The item state at this point still has nova_id, bibcode (None here),
-            # correlation_id, and job_run from the ItemSelector projection.
-            quarantine_result = cast(
-                dict[str, Any],
-                h["quarantine_handler"].handle(
-                    {
-                        "task_name": "QuarantineHandler",
-                        "workflow_name": "refresh_references",
-                        "quarantine_reason_code": "OTHER",
-                        "nova_id": state["nova_id"],
-                        "bibcode": bad_doc["bibcode"],
-                        "correlation_id": state["job_run"]["correlation_id"],
-                        "job_run": state["job_run"],
-                    },
-                    None,
-                ),
-            )
-
-        assert quarantine_result["quarantine_reason_code"] == "OTHER"
-        assert "error_fingerprint" in quarantine_result
-        assert "quarantined_at" in quarantine_result
-
-    def test_quarantine_diagnostics_written_to_job_run(self, table: Any) -> None:
-        """QuarantineHandler persists quarantine fields onto the existing JobRun."""
-        with mock_aws():
-            _seed_nova(table)
-            h = _load_handlers()
-
-            state = _run_prefix(h)
-
-            h["quarantine_handler"].handle(
-                {
-                    "task_name": "QuarantineHandler",
-                    "workflow_name": "refresh_references",
-                    "quarantine_reason_code": "OTHER",
-                    "nova_id": state["nova_id"],
-                    "bibcode": _BIBCODE_A,
-                    "correlation_id": state["job_run"]["correlation_id"],
-                    "job_run": state["job_run"],
-                },
-                None,
-            )
-
-        job_run_item = _get_job_run(table, state)
-        assert job_run_item["quarantine_reason_code"] == "OTHER"
-        assert "error_fingerprint" in job_run_item
-        assert "quarantined_at" in job_run_item
-
-    def test_remaining_items_succeed_after_quarantine(self, table: Any) -> None:
-        """
-        After one item is quarantined, the Map continues. The remaining
-        good candidate (_RAW_DOC_B) is linked and its date is computed.
-        """
         with mock_aws():
             _seed_nova(table)
             h = _load_handlers()
 
             with patch.object(h["reference_manager"], "requests") as mock_requests:
-                mock_requests.get.return_value = _mock_ads_response([_RAW_DOC_B])
+                mock_requests.get.return_value = _mock_ads_response([bad_doc, _RAW_DOC_B])
                 mock_requests.exceptions.Timeout = Exception
                 mock_requests.exceptions.RequestException = Exception
 
                 state = _run_prefix(h)
-                h["reference_manager"].handle(
-                    {
-                        "task_name": "FetchReferenceCandidates",
-                        "workflow_name": "refresh_references",
-                        "nova_id": _NOVA_ID,
-                        "correlation_id": state["job_run"]["correlation_id"],
-                        "job_run_id": state["job_run"]["job_run_id"],
-                    },
-                    None,
-                )
+                summary = _run_fetch_and_reconcile(h, state)
 
-            # Simulate first item quarantined — skip its Map steps
-            h["quarantine_handler"].handle(
-                {
-                    "task_name": "QuarantineHandler",
-                    "workflow_name": "refresh_references",
-                    "quarantine_reason_code": "OTHER",
-                    "nova_id": state["nova_id"],
-                    "bibcode": _BIBCODE_A,
-                    "correlation_id": state["job_run"]["correlation_id"],
-                    "job_run": state["job_run"],
-                },
-                None,
-            )
-
-            # Second item (_RAW_DOC_B) succeeds
-            _run_map_item(h, state, _RAW_DOC_B)
-            _run_post_map(h, state)
-            _run_finalize_success(h, state)
+        assert summary["total_candidates"] == 2
+        assert summary["reconciled"] == 1
+        assert summary["quarantined"] == 1
+        assert "unknown" in summary["quarantined_bibcodes"]
 
         # Only _BIBCODE_B should be linked
         novarefs = _list_novarefs(table)
         assert len(novarefs) == 1
         assert novarefs[0]["bibcode"] == _BIBCODE_B
 
-        job_run_item = _get_job_run(table, state)
-        assert job_run_item["status"] == "SUCCEEDED"
+    def test_quarantine_diagnostics_written_to_job_run(self, table: Any) -> None:
+        """
+        When a candidate is quarantined, the combined function persists
+        quarantine diagnostics (reason_code, fingerprint, timestamp) onto
+        the existing JobRun record.
+        """
+        bad_doc: dict[str, Any] = {
+            "bibcode": None,
+            "doctype": "article",
+            "title": None,
+            "date": None,
+            "author": [],
+            "doi": None,
+            "identifier": [],
+        }
 
-    def test_job_run_ends_succeeded_despite_quarantined_item(self, table: Any) -> None:
-        """
-        The Map's item-level quarantine path does not fail the workflow.
-        FinalizeJobRunSuccess is still reachable after a quarantined item.
-        """
         with mock_aws():
             _seed_nova(table)
             h = _load_handlers()
-            state = _run_prefix(h)
 
-            h["quarantine_handler"].handle(
-                {
-                    "task_name": "QuarantineHandler",
-                    "workflow_name": "refresh_references",
-                    "quarantine_reason_code": "OTHER",
-                    "nova_id": state["nova_id"],
-                    "bibcode": _BIBCODE_A,
-                    "correlation_id": state["job_run"]["correlation_id"],
-                    "job_run": state["job_run"],
-                },
-                None,
-            )
+            with patch.object(h["reference_manager"], "requests") as mock_requests:
+                mock_requests.get.return_value = _mock_ads_response([bad_doc, _RAW_DOC_B])
+                mock_requests.exceptions.Timeout = Exception
+                mock_requests.exceptions.RequestException = Exception
 
-            _run_post_map(h, state)
-            _run_finalize_success(h, state)
+                state = _run_prefix(h)
+                _run_fetch_and_reconcile(h, state)
+
+        job_run_item = _get_job_run(table, state)
+        assert job_run_item["quarantine_reason_code"] == "OTHER"
+        assert "error_fingerprint" in job_run_item
+        assert "quarantined_at" in job_run_item
+
+    def test_job_run_ends_succeeded_despite_quarantined_item(self, table: Any) -> None:
+        """
+        Item-level quarantine does not fail the workflow. FinalizeJobRunSuccess
+        is still reachable after a quarantined item.
+        """
+        bad_doc: dict[str, Any] = {
+            "bibcode": None,
+            "doctype": "article",
+            "title": None,
+            "date": None,
+            "author": [],
+            "doi": None,
+            "identifier": [],
+        }
+
+        with mock_aws():
+            _seed_nova(table)
+            h = _load_handlers()
+
+            with patch.object(h["reference_manager"], "requests") as mock_requests:
+                mock_requests.get.return_value = _mock_ads_response([bad_doc, _RAW_DOC_B])
+                mock_requests.exceptions.Timeout = Exception
+                mock_requests.exceptions.RequestException = Exception
+
+                state = _run_prefix(h)
+                _run_fetch_and_reconcile(h, state)
+                _run_post_reconcile(h, state)
+                _run_finalize_success(h, state)
 
         job_run_item = _get_job_run(table, state)
         assert job_run_item["status"] == "SUCCEEDED"
 
+    def test_quarantined_bibcodes_in_summary(self, table: Any) -> None:
+        """
+        The combined function returns quarantined_bibcodes in the summary
+        so downstream states (or operator tooling) can see which ones failed.
+        """
+        bad_doc_1: dict[str, Any] = {
+            "bibcode": None,
+            "doctype": "article",
+            "title": None,
+            "date": None,
+            "author": [],
+            "doi": None,
+            "identifier": [],
+        }
+        bad_doc_2: dict[str, Any] = {
+            "bibcode": "FAKE.BIBCODE.001",
+            "doctype": None,
+            "title": None,
+            "date": "not-a-date",
+            "author": [],
+            "doi": None,
+            "identifier": [],
+        }
+
+        with mock_aws():
+            _seed_nova(table)
+            h = _load_handlers()
+
+            with patch.object(h["reference_manager"], "requests") as mock_requests:
+                mock_requests.get.return_value = _mock_ads_response(
+                    [bad_doc_1, _RAW_DOC_B, bad_doc_2]
+                )
+                mock_requests.exceptions.Timeout = Exception
+                mock_requests.exceptions.RequestException = Exception
+
+                state = _run_prefix(h)
+                summary = _run_fetch_and_reconcile(h, state)
+
+        # bad_doc_1 has no bibcode → quarantined as "unknown"
+        # bad_doc_2 has a bibcode but is otherwise valid (normalize will succeed)
+        # _RAW_DOC_B succeeds
+        assert summary["reconciled"] + summary["quarantined"] == 3
+
 
 # ---------------------------------------------------------------------------
-# Path 5: Terminal failure — FetchReferenceCandidates raises TerminalError
+# Path 5: Terminal failure — FetchAndReconcileReferences raises TerminalError
 # ---------------------------------------------------------------------------
 
 
 class TestTerminalFailure:
     def test_missing_nova_raises_terminal_error(self, table: Any) -> None:
         """
-        FetchReferenceCandidates raises TerminalError when the nova does not
-        exist in DDB. The ASL Catch routes to TerminalFailHandler.
+        FetchAndReconcileReferences raises TerminalError when the nova does
+        not exist in DDB. The ASL Catch routes to TerminalFailHandler.
         """
         with mock_aws():
             # Deliberately do NOT seed the nova
@@ -920,16 +767,7 @@ class TestTerminalFailure:
                 from nova_common.errors import TerminalError
 
                 with pytest.raises(TerminalError, match="Nova not found"):
-                    h["reference_manager"].handle(
-                        {
-                            "task_name": "FetchReferenceCandidates",
-                            "workflow_name": "refresh_references",
-                            "nova_id": _NOVA_ID,
-                            "correlation_id": state["job_run"]["correlation_id"],
-                            "job_run_id": state["job_run"]["job_run_id"],
-                        },
-                        None,
-                    )
+                    _run_fetch_and_reconcile(h, state)
 
             # ASL routes to TerminalFailHandler then FinalizeJobRunFailed
             h["job_run_manager"].handle(
@@ -1014,26 +852,31 @@ class TestTerminalFailure:
 
 
 # ---------------------------------------------------------------------------
-# Path 6: Idempotency — Map tasks are safe to run twice
+# Path 6: Idempotency — combined function is safe to run twice
 # ---------------------------------------------------------------------------
 
 
 class TestIdempotency:
-    def test_running_map_items_twice_does_not_duplicate_novaref(self, table: Any) -> None:
+    def test_running_combined_function_twice_does_not_duplicate_novaref(self, table: Any) -> None:
         """
-        LinkNovaReference uses a conditional put. Running the same item through
-        the Map chain twice produces exactly one NOVAREF item, not two.
-        This covers the case where a Map execution is retried.
+        LinkNovaReference uses a conditional put. Running the combined function
+        twice for the same nova produces exactly one NOVAREF item per bibcode,
+        not two. This covers the case where the Lambda is retried.
         """
         with mock_aws():
             _seed_nova(table)
             h = _load_handlers()
-            state = _run_prefix(h)
 
-            # First pass
-            _run_map_item(h, state, _RAW_DOC_A)
-            # Second pass — simulates a Map retry
-            _run_map_item(h, state, _RAW_DOC_A)
+            with patch.object(h["reference_manager"], "requests") as mock_requests:
+                mock_requests.get.return_value = _mock_ads_response([_RAW_DOC_A])
+                mock_requests.exceptions.Timeout = Exception
+                mock_requests.exceptions.RequestException = Exception
+
+                state = _run_prefix(h)
+                # First pass
+                _run_fetch_and_reconcile(h, state)
+                # Second pass — simulates a Lambda retry
+                _run_fetch_and_reconcile(h, state)
 
         novarefs = _list_novarefs(table)
         assert len(novarefs) == 1
@@ -1047,18 +890,25 @@ class TestIdempotency:
         with mock_aws():
             _seed_nova(table)
             h = _load_handlers()
-            state = _run_prefix(h)
 
-            _run_map_item(h, state, _RAW_DOC_A)
-            original_created = table.get_item(
-                Key={"PK": f"REFERENCE#{_BIBCODE_A}", "SK": "METADATA"}
-            )["Item"]["created_at"]
+            with patch.object(h["reference_manager"], "requests") as mock_requests:
+                mock_requests.get.return_value = _mock_ads_response([_RAW_DOC_A])
+                mock_requests.exceptions.Timeout = Exception
+                mock_requests.exceptions.RequestException = Exception
 
-            # Second pass
-            _run_map_item(h, state, _RAW_DOC_A)
-            item_after_retry = table.get_item(
-                Key={"PK": f"REFERENCE#{_BIBCODE_A}", "SK": "METADATA"}
-            )["Item"]
+                state = _run_prefix(h)
+                _run_fetch_and_reconcile(h, state)
+
+                original_created = table.get_item(
+                    Key={"PK": f"REFERENCE#{_BIBCODE_A}", "SK": "METADATA"}
+                )["Item"]["created_at"]
+
+                # Second pass
+                _run_fetch_and_reconcile(h, state)
+
+                item_after_retry = table.get_item(
+                    Key={"PK": f"REFERENCE#{_BIBCODE_A}", "SK": "METADATA"}
+                )["Item"]
 
         assert item_after_retry["created_at"] == original_created
 
@@ -1070,16 +920,21 @@ class TestIdempotency:
         with mock_aws():
             _seed_nova(table)
             h = _load_handlers()
-            state = _run_prefix(h)
 
-            _run_map_item(h, state, _RAW_DOC_B)
+            with patch.object(h["reference_manager"], "requests") as mock_requests:
+                mock_requests.get.return_value = _mock_ads_response([_RAW_DOC_B])
+                mock_requests.exceptions.Timeout = Exception
+                mock_requests.exceptions.RequestException = Exception
 
-            # First post-map run writes the date
-            first_result = _run_post_map(h, state)
-            assert first_result["updated"] is True
-            assert first_result["discovery_date"] == "1992-01-00"
+                state = _run_prefix(h)
+                _run_fetch_and_reconcile(h, state)
 
-            # Second post-map run with the same date is a no-op
-            second_result = _run_post_map(h, state)
-            assert second_result["updated"] is False
-            assert second_result["discovery_date"] == "1992-01-00"
+                # First post-reconcile run writes the date
+                first_result = _run_post_reconcile(h, state)
+                assert first_result["updated"] is True
+                assert first_result["discovery_date"] == "1992-01-00"
+
+                # Second post-reconcile run with the same date is a no-op
+                second_result = _run_post_reconcile(h, state)
+                assert second_result["updated"] is False
+                assert second_result["discovery_date"] == "1992-01-00"

--- a/tests/services/test_asl_contracts.py
+++ b/tests/services/test_asl_contracts.py
@@ -169,6 +169,13 @@ TASK_RETURN_SHAPES: dict[str, set[str]] = {
         "publication_date",
         "linked",
     },
+    "FetchAndReconcileReferences": {
+        "nova_id",
+        "total_candidates",
+        "reconciled",
+        "quarantined",
+        "quarantined_bibcodes",
+    },
     "ComputeDiscoveryDate": {
         "nova_id",
         "earliest_bibcode",

--- a/tests/services/test_bookend_logging.py
+++ b/tests/services/test_bookend_logging.py
@@ -97,7 +97,11 @@ _STANDARD_HANDLERS: list[tuple[str, str, str]] = [
     ("workflow_launcher.handler", "workflow_launcher.handler.logger", "PublishIngestNewNova"),
     ("quarantine_handler.handler", "quarantine_handler.handler.logger", "QuarantineHandler"),
     ("artifact_finalizer.handler", "artifact_finalizer.handler.logger", "Finalize"),
-    ("reference_manager.handler", "reference_manager.handler.logger", "FetchReferenceCandidates"),
+    (
+        "reference_manager.handler",
+        "reference_manager.handler.logger",
+        "FetchAndReconcileReferences",
+    ),
     ("spectra_acquirer.handler", "spectra_acquirer.handler.logger", "AcquireArtifact"),
 ]
 

--- a/tests/services/test_reference_manager.py
+++ b/tests/services/test_reference_manager.py
@@ -1045,7 +1045,7 @@ class TestDispatch:
             with pytest.raises(ValueError, match="Unknown task_name"):
                 h.handle(_base_event(task_name="NonExistentTask"), None)
 
-    def test_all_six_task_names_are_registered(self, table: Any) -> None:
+    def test_all_seven_task_names_are_registered(self, table: Any) -> None:
         with mock_aws():
             h = _load_handler()
             expected = {
@@ -1053,6 +1053,7 @@ class TestDispatch:
                 "NormalizeReference",
                 "UpsertReferenceEntity",
                 "LinkNovaReference",
+                "FetchAndReconcileReferences",
                 "ComputeDiscoveryDate",
                 "UpsertDiscoveryDateMetadata",
             }
@@ -1147,3 +1148,114 @@ class TestADSCollectionFilter:
         with mock_aws():
             h = _load_handler()
             assert h._ADS_COLLECTION_FILTER == "collection:(astronomy OR physics)"
+
+
+# ===========================================================================
+# TestFetchAndReconcileReferences
+# ===========================================================================
+
+
+class TestFetchAndReconcileReferences:
+    """Unit tests for the combined FetchAndReconcileReferences task."""
+
+    def _run(
+        self,
+        table: Any,
+        ads_docs: list[dict[str, Any]],
+        job_run: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        _seed_nova(table)
+        _create_ads_secret()
+        h = _load_handler()
+        with patch.object(h, "requests") as mock_requests:
+            mock_requests.get.return_value = _mock_ads_response(ads_docs)
+            mock_requests.exceptions.Timeout = Exception
+            mock_requests.exceptions.RequestException = Exception
+            event: dict[str, Any] = {
+                "task_name": "FetchAndReconcileReferences",
+                "workflow_name": "refresh_references",
+                "nova_id": _NOVA_ID,
+                "correlation_id": "corr-ref-001",
+            }
+            if job_run is not None:
+                event["job_run"] = job_run
+            return cast(dict[str, Any], h.handle(event, None))
+
+    def test_returns_correct_summary_shape(self, table: Any) -> None:
+        with mock_aws():
+            result = self._run(table, [_RAW_DOC_A, _RAW_DOC_B])
+        assert result["nova_id"] == _NOVA_ID
+        assert result["total_candidates"] == 2
+        assert result["reconciled"] == 2
+        assert result["quarantined"] == 0
+        assert result["quarantined_bibcodes"] == []
+
+    def test_references_written_to_ddb(self, table: Any) -> None:
+        with mock_aws():
+            self._run(table, [_RAW_DOC_A, _RAW_DOC_B])
+            ref_a = table.get_item(Key={"PK": f"REFERENCE#{_BIBCODE_A}", "SK": "METADATA"})["Item"]
+            ref_b = table.get_item(Key={"PK": f"REFERENCE#{_BIBCODE_B}", "SK": "METADATA"})["Item"]
+        assert ref_a["bibcode"] == _BIBCODE_A
+        assert ref_b["bibcode"] == _BIBCODE_B
+
+    def test_novaref_links_written(self, table: Any) -> None:
+        with mock_aws():
+            self._run(table, [_RAW_DOC_A, _RAW_DOC_B])
+            novarefs = table.query(
+                KeyConditionExpression=(Key("PK").eq(_NOVA_ID) & Key("SK").begins_with("NOVAREF#"))
+            )["Items"]
+        bibcodes = {item["bibcode"] for item in novarefs}
+        assert bibcodes == {_BIBCODE_A, _BIBCODE_B}
+
+    def test_empty_candidates(self, table: Any) -> None:
+        with mock_aws():
+            result = self._run(table, [])
+        assert result["total_candidates"] == 0
+        assert result["reconciled"] == 0
+        assert result["quarantined"] == 0
+
+    def test_bad_bibcode_quarantined_good_succeeds(self, table: Any) -> None:
+        bad_doc: dict[str, Any] = {
+            "bibcode": None,
+            "doctype": "article",
+            "title": None,
+            "date": None,
+            "author": [],
+            "doi": None,
+            "identifier": [],
+        }
+        with mock_aws():
+            result = self._run(table, [bad_doc, _RAW_DOC_B])
+        assert result["reconciled"] == 1
+        assert result["quarantined"] == 1
+        assert "unknown" in result["quarantined_bibcodes"]
+
+    def test_quarantine_persists_to_job_run(self, table: Any) -> None:
+        """When a job_run dict is provided, quarantine diagnostics are written."""
+        bad_doc: dict[str, Any] = {
+            "bibcode": None,
+            "doctype": "article",
+            "title": None,
+            "date": None,
+            "author": [],
+            "doi": None,
+            "identifier": [],
+        }
+        # Seed a fake JobRun record
+        with mock_aws():
+            job_run_pk = "WORKFLOW#corr-ref-001"
+            job_run_sk = "JOBRUN#refresh_references#2024-01-01T00:00:00Z#jr-001"
+            table.put_item(
+                Item={
+                    "PK": job_run_pk,
+                    "SK": job_run_sk,
+                    "status": "IN_PROGRESS",
+                }
+            )
+            job_run = {"pk": job_run_pk, "sk": job_run_sk}
+            self._run(table, [bad_doc], job_run=job_run)
+
+            jr_item = table.get_item(Key={"PK": job_run_pk, "SK": job_run_sk})["Item"]
+        assert jr_item["quarantine_reason_code"] == "OTHER"
+        assert "error_fingerprint" in jr_item
+        assert "quarantined_at" in jr_item

--- a/tests/smoke/test_workflows.py
+++ b/tests/smoke/test_workflows.py
@@ -56,7 +56,7 @@ from contracts.models.outputs import (
     AcquireAndValidateSpectraTerminalOutput,
     DiscoverSpectraProductsFinalizeOutput,
     DiscoverSpectraProductsTerminalOutput,
-    FetchReferenceCandidatesOutput,
+    FetchAndReconcileReferencesOutput,
     IngestNewNovaFinalizeOutput,
     IngestNewNovaTerminalOutput,
     InitializeNovaFinalizeOutput,
@@ -1002,12 +1002,10 @@ class TestRefreshReferences:
         )
         assert model.finalize.outcome == "SUCCEEDED"
         assert model.idempotency is not None, "idempotency absent on happy path"
-        assert model.fetch is not None, "fetch absent on happy path"
-        assert isinstance(model.fetch, FetchReferenceCandidatesOutput)
-        assert model.fetch.candidate_count >= 0
-        assert model.fetch.nova_id == nova_id
-        assert model.reconcile is not None, "reconcile absent on happy path"
-        assert isinstance(model.reconcile, list)
+        assert model.reconcile_summary is not None, "reconcile_summary absent on happy path"
+        assert isinstance(model.reconcile_summary, FetchAndReconcileReferencesOutput)
+        assert model.reconcile_summary.total_candidates >= 0
+        assert model.reconcile_summary.nova_id == nova_id
         assert model.discovery is not None, "discovery absent on happy path"
         assert model.discovery.nova_id == nova_id
         assert model.discovery_upsert is not None, "discovery_upsert absent on happy path"
@@ -1068,14 +1066,9 @@ class TestRefreshReferences:
         )
         assert model.finalize.outcome == "SUCCEEDED"
 
-        assert model.fetch is not None
-        assert model.fetch.candidate_count == 0
-        assert model.fetch.candidates == []
-
-        assert model.reconcile is not None
-        assert model.reconcile == [], (
-            f"Expected empty reconcile list for zero-ADS-hit nova, got {model.reconcile}"
-        )
+        assert model.reconcile_summary is not None
+        assert model.reconcile_summary.total_candidates == 0
+        assert model.reconcile_summary.reconciled == 0
 
         assert model.discovery is not None
         assert model.discovery.earliest_bibcode is None


### PR DESCRIPTION
## Summary
- Replaced the `FetchReferenceCandidates` → `ReconcileReferences` Map pattern with a single `FetchAndReconcileReferences` Lambda invocation
- ADS candidate list now processed entirely within the Lambda — never transits through SFn state, eliminating the 256KB payload ceiling
- Per-item error isolation preserved: each candidate gets a try/except with retry logic (2 retries, exponential backoff, full jitter) and inline quarantine writes on failure
- Old dispatch entries (`NormalizeReference`, `UpsertReferenceEntity`, `LinkNovaReference`, `FetchReferenceCandidates`) kept as internal helpers with existing unit test coverage preserved
- `reference_manager` Lambda timeout increased from 90s to 180s to accommodate sequential processing of 200+ candidates
- New `FetchAndReconcileReferencesOutput` contract with `quarantined_bibcodes` list — actually captures *more* failure context than the old Map did

## Why
- `refresh_references` hit the 256KB Step Functions state payload limit for recurrent novae with extensive literature (e.g., IM Nor). The full ADS candidate array — author lists, titles, DOIs, identifiers per candidate — exceeded the ceiling on the state transition between `FetchReferenceCandidates` and the Map.
- This is the same class of problem `discover_spectra_products` had, solved the same way: collapse multi-step SFn processing into a single Lambda that returns only a lightweight summary. Proven pattern.
- Discovery during this refactor revealed an existing quarantine gap: the Map's `ItemFailureHandler` wrote per-item quarantine to the **JobRun record**, not per-bibcode records. Multiple failures raced on the same DDB item — only the last writer's fingerprint survived, and the offending bibcode was passed to the handler but **never stored anywhere**. The combined function improves this by capturing all quarantined bibcodes in the summary and emitting structured log lines with full context per failure.

## Testing
- 1626 tests passing, all gates green (pytest, ruff, mypy, CDK synth test)
- Integration tests (`test_refresh_references_integration.py`) fully rewritten: all 6 test paths now exercise the combined function, including quarantine and idempotency
- 6 new unit tests for `FetchAndReconcileReferences`: summary shape, DDB writes, novaref links, empty candidates, quarantine flow, quarantine persistence to JobRun
- ASL contract tests and bookend logging tests updated
- Smoke test imports updated for new output model

## Notes
- **ASL review recommended.** The workflow structure fundamentally changed — Map removed, single state replaces fetch + reconcile. Flow should read: `BeginJobRun` → `AcquireIdempotencyLock` → `EnsureAttributes` → `FetchAndReconcileReferences` → `ComputeDiscoveryDate` → ... → `FinalizeJobRunSuccess`, with `TerminalFailHandler` on Catch.
- `$.reconcile` (the old Map ResultPath) was confirmed to be dead code — never read by any downstream state. Removed cleanly.
- SNS notifications are not published for per-item quarantine. The `reference_manager` Lambda lacks `sns:Publish` IAM grants, and the SNS notification was best-effort operational alerting. Structured log lines with `bibcode`, `error_type`, `error_message`, `nova_id`, `correlation_id` replace it — queryable via Logs Insights, which is arguably better for diagnosis than an SNS alert that lost the bibcode.
- CDK synth via CLI fails due to `aws_cdk` not on system Python — pre-existing issue, not introduced by this PR. `test_synth.py` passes.

## Bugs Fixed
- **256KB payload ceiling** on `refresh_references` for well-studied novae (PI1)
- **Quarantine data loss** for multi-bibcode failures — previous Map behavior silently dropped all but the last failed bibcode's fingerprint. Combined function now captures all failures in `quarantined_bibcodes` summary + per-item structured logs.

## Out of Scope
- Incremental reference reconciliation / delta detection (PI4 — future task)
- Per-bibcode quarantine records in DDB (future design question, ties into Active Data Integrity work)
- SNS IAM grant for per-item quarantine alerts (not worth the CDK change given the current quarantine model)
- Express → Standard workflow migration (would require stack replacement)

## Next Steps
- PI4: incremental reference reconciliation with fingerprint-based delta detection and `force_full` override
- Active Data Integrity DESIGN: formalize quarantine audit trail, per-bibcode failure records, temporal anomaly detection
- Manual verification: run `refresh_references` against a well-studied nova (IM Nor) to confirm the payload constraint is eliminated