### PR TITLE
fix(references): normalize whitespace in ADS query alias quoting

### DIFF
--- a/docs/worklog/bugs_list_4_17_26.md
+++ b/docs/worklog/bugs_list_4_17_26.md
@@ -1,0 +1,14 @@
+
+1. When exploding out references list, data in the photometry plot migrates outside of the plot (see, GK Per).
+2. When you click to, e.g., sort by references, it only sorts by references on that page (likely an issue with the splash page not being the catalog.)
+3. Add discovery date and peak mag into initialize_nova
+4. Modify documentation post-`refresh_references` rebuild
+5. Add a "Date Completed" to the list of finished items on master-list, for change auditing purposes (e.g., we want to know if there's more docuentation that might need to be updated).
+6. Add time stamps to tools that I run (e.g., `sweep.py` ), so I can figure out how much time it has been since the code finished (and if I should be worried that I still don't see any changes!)
+7. Figure out where to store discovery dates and peak magnitudes files.
+8. Implement fundemental change in logic for refresh references
+   1. Add in discovery date check; if pre-1960 (I just pulled that out of my butt), then just primary name in ADS query (no aliases).
+   2. If query returns >1000 references, search just by primary name (most famous nova, RS Oph, only has ~850 references)
+   3. If you initially can't find any sources, do a full text search
+   4. Ultimate fallback is to use sources from Simbad search
+9. (After item 3 on this list has been finished) Add in logic to photometric and spectroscopic ingestion pipelines that gives better hints for truncated mjd (e.g., if the nova went off on 27783, and the date in the file says 7890, the missing digit is likely a 2).

--- a/docs/worklog/master-tasks.md
+++ b/docs/worklog/master-tasks.md
@@ -1,6 +1,6 @@
 # Nova Cat — Post-MVP Master Task List
 
-_Generated: 2026-04-04 · Updated: 2026-04-14 (v8) · Living document_
+_Generated: 2026-04-04 · Updated: 2026-04-16 (v9) · Living document_
 
 ---
 
@@ -22,8 +22,11 @@ Each task has:
 | ID | Task | CC | Dep | Status |
 |----|------|----|-----|--------|
 | B17 | **Fargate logger sorting, blank rows, and structured formatting.** Log format doesn't support chronological sorting in CloudWatch. Also ensure Fargate logs are structured correctly so they can be parsed by the reader app and Logs Insights. | 🟡 | — | ⬜ |
-| B18 | **Radio band registry test fixture missing radio entries.** All 17 `test_band_registry_radio.py` tests fail — resolver returns `None` for every lookup. Radio entries were likely dropped from the test fixture during a band registry rebuild. | 🟢 | — | ⬜ |
+| B18 | **Fake dataset and end-to-end ingestion test suite.** Create a synthetic dataset (spectra + photometry) to ingest as part of a new integration test suite. Validates the full pipeline from ticket ingestion through artifact generation. Related to T2. | 🟡 | — | ⬜ |
 | B19 | **Hard floor for spectra y-axis.** When plotting individual spectra, large chunks get cut off — not just the bottom spectrum. Need hard controls on the minimum y-value. Includes log-scale variant. Part of the long-range spectra.py rebuild (R10). | 🟡 | — | ⬜ |
+| B30 | **Non-positive / non-finite SNR pass-through in display and compositing gates.** Both SNR gates use `0 < snr < floor`, so spectra with `snr ≤ 0` (including `snr = -0.1` values from ESO) and `NaN`/`inf` are not excluded — they display and can enter composites. Fix: tighten both gates to exclude non-positive and non-finite SNR. Silent exclusion per policy decision. | 🟢 | — | ⬜ |
+| B31 | **Catalog pagination lost on browser back.** Navigating to the third page of the catalog, clicking into a nova, then pressing the browser back button returns to the first page instead of the page the user was on. | 🟡 | — | ⬜ |
+| B32 | **Zoom + spectral feature toggle state in waterfall plot.** Toggling spectral features while zoomed in on the waterfall plot causes display issues. Possibly related to B22 (which fixed a similar toggle bug in single-spectrum mode). | 🟡 | — | ⬜ |
 
 ---
 
@@ -43,7 +46,6 @@ Each task has:
 | ID | Task | CC | Dep | Status |
 |----|------|----|-----|--------|
 | S21 | **DER_SNR at ingestion time.** Add DER_SNR computation to the ticket validation profile so new ingestions get SNR at write time, rather than relying solely on the artifact generator fallback. | 🟢 | — | ⬜ |
-| S22 | **SNR gate integration tests.** Tests for the display gate (SNR < 5 excluded from waterfall) and compositing relative gate (< 1/3 group median → rejected). | 🟢 | — | ⬜ |
 
 ---
 
@@ -61,6 +63,7 @@ Each task has:
 |----|------|----|-----|--------|
 | DR1 | **Gamma-ray nova detection pipeline.** Add support for detecting gamma-ray novae via Fermi-LAT references. | 🔴 | — | ⬜ |
 | DR2 | **Gamma-ray visualization.** Add support for visualizing gamma-ray detections in the light curve panel. | 🟡 | DR1 | ⬜ |
+| DR3 | **Gaia and 2MASS catalog cross-match.** Pull positional and photometric data from Gaia and 2MASS for enrichment (distances, NIR magnitudes, proper motions). | 🟡 | — | ⬜ |
 
 ---
 
@@ -71,7 +74,7 @@ Each task has:
 | F6 | **Splash page = catalog page.** Merge so people access the catalog without navigating away. Show stats on every page. | 🟡 | — | ⬜ |
 | F7 | **Total unique spectral visits in stats display.** | 🟢 | — | ⬜ |
 | F8 | **Stats broken out by spectral regime.** Separate stats per regime (optical, UV, NIR, etc.). | 🟡 | — | ⬜ |
-| F9 | **Sources column for ticket-ingested data should show bibcode.** | 🟢 | — | ⬜ |
+| F13 | **Photometry observation table.** Add an observation table for photometry on the nova page, parallel to the existing spectra observations table. | 🟡 | — | ⬜ |
 
 ---
 
@@ -92,6 +95,20 @@ Each task has:
 | ID | Task | CC | Dep | Status |
 |----|------|----|-----|--------|
 | F10 | **Change nova "Type" field to a list.** Currently a string; should support multiple types (e.g., classical + symbiotic). Prerequisite for PI3 automatic type assignment. | 🟡 | — | ⬜ |
+
+---
+
+## Data Quality & Integrity
+
+_New section. Items 1–5 are data-quality checks and display gates identified during the 2026-04-16 session. These will be formalized under the Active Data Integrity Enforcement DESIGN when that document is written._
+
+| ID | Task | CC | Dep | Status |
+|----|------|----|-----|--------|
+| DQ1 | **Nova page rendering audit.** Automated check that every nova page loads without crashing. Can be a headless-browser smoke test or a simpler artifact-completeness check. | 🟡 | — | ⬜ |
+| DQ2 | **Temporal anomaly flagging.** Flag novae whose observations are all >100 days from discovery or have data >5000 days past outburst or pre-outburst — potential mislabelling or date-calculation errors. | 🟡 | — | ⬜ |
+| DQ3 | **Flag novae without any references.** Every nova should have at least one literature reference; absence suggests an ingestion or reference-linking gap. | 🟢 | — | ⬜ |
+| DQ4 | **Metadata-incomplete spectra gate.** Flag, quarantine, and hide spectra missing any of: source, telescope, instrument. Similar enforcement pattern to the SNR display gate. | 🟡 | — | ⬜ |
+| DQ5 | **Source-less photometry gate.** Flag and hide photometry rows that lack a source attribution. | 🟡 | — | ⬜ |
 
 ---
 
@@ -127,7 +144,7 @@ Each task has:
 
 | ID | Task | CC | Dep | Status |
 |----|------|----|-----|--------|
-| D1 | **Update current-architecture.md.** Dated 2026-03-28. Reflects pre-Epic-5 state. | 🟡 | — | ⬜ |
+| D1 | **Update current-architecture.md.** Dated 2026-04-08. Reflects pre-Epic-30 state. | 🟡 | — | ⬜ |
 | D2 | **Recurrent novae design.** Multiple outbursts, cross-outburst identity, epoch disambiguation. Includes redesigning spectra and photometry viewer to accommodate multiple outburst epochs per object. | 🔴 | — | ⬜ |
 | D3 | **Audit .py file documentation.** Ensure docstrings and inline comments across services are accurate and up to date. | 🟡 | — | 🔲 |
 
@@ -147,64 +164,75 @@ Each task has:
 
 | Category | Count |
 |----------|-------|
-| ✅ Done | 104 |
-| ⬜ Remaining (bugs) | 3 |
-| ⬜ Remaining (features/tasks) | 31 |
-| **Total open** | **34** |
+| ✅ Done | 106 |
+| ⬜ Remaining (bugs) | 6 |
+| ⬜ Remaining (features/tasks) | 37 |
+| **Total open** | **43** |
 
 ---
 
 ## Suggested Priority Order
 
 **Quick wins / high impact:**
-1. B18 — Radio test fixture rebuild (10 min, unblocks 17 tests)
-2. S22 — SNR gate integration tests (close out the epic)
-3. F9 — Sources bibcode column (small artifact generator + frontend change)
-4. F7 — Spectral visits in stats display
+1. B30 — Non-positive SNR gate fix (minimal diff, CC-autonomous)
+2. F7 — Spectral visits in stats display
+3. S21 — DER_SNR at ingestion time
+4. PI2 — CloudWatch log group retention policy
+5. DQ3 — Flag novae without references
 
 **Spectra quality & display:**
-5. S6 — Spectra quality audit
-6. B19 — Spectra y-axis hard floor
-7. S18 — sqrt(flux) scaling
-8. S19 — X-ray keV x-axis
-9. S20 — Non-optical spectral features
+6. S6 — Spectra quality audit
+7. B19 — Spectra y-axis hard floor
+8. S18 — sqrt(flux) scaling
+9. S19 — X-ray keV x-axis
+10. S20 — Non-optical spectral features
+
+**Frontend bugs & features:**
+11. B31 — Catalog pagination on back button
+12. B32 — Zoom + toggle in waterfall
+13. F13 — Photometry observation table
+14. F6 — Splash page = catalog page
+15. F8 — Stats by regime
+16. P4 — Photometry color palette
 
 **Data model & ingestion enrichment:**
-10. F10 — Nova Type as list
-11. PI3 — Initial ingestion enrichment (discovery date, types)
-12. S21 — DER_SNR at ingestion time
+17. F10 — Nova Type as list
+18. PI3 — Initial ingestion enrichment (discovery date, types)
+19. DR3 — Gaia and 2MASS cross-match
+
+**Data quality & integrity:**
+20. DQ1 — Nova page rendering audit
+21. DQ2 — Temporal anomaly flagging
+22. DQ4 — Metadata-incomplete spectra gate
+23. DQ5 — Source-less photometry gate
 
 **Pipeline robustness:**
-13. PI1 — refresh_references payload reduction
-14. PI2 — CloudWatch log group cleanup formalization
-15. L5 — Reduce Logs Insights cost
-16. L6 — Minimize per-item logging
-
-**Frontend overhaul:**
-17. F6 — Splash page = catalog page
-18. F8 — Stats by regime
-19. P4 — Photometry color palette
+24. PI1 — refresh_references payload reduction
+25. B17 — Fargate logger formatting
+26. L5 — Reduce Logs Insights cost
+27. L6 — Minimize per-item logging
 
 **New capabilities:**
-20. DR1/DR2 — Gamma-ray pipeline + visualization
-21. I2 — Coordinate dedup ASL wiring
+28. DR1/DR2 — Gamma-ray pipeline + visualization
+29. I2 — Coordinate dedup ASL wiring
 
 **Bigger arcs:**
-22. R5 — Unified operator app
-23. T1, T2 — Test suites
-24. L1 — Log enrichment
-25. D1 — Architecture doc update
-26. D2 — Recurrent novae design
-27. OT8 — UVES reduction pipeline
-28. R10 — spectra.py rebuild
-29. LR1/LR2 — Data donation + provenance
-30. R4 — Smooth pipeline (capstone)
+30. B18 — Fake dataset + end-to-end test suite
+31. R5 — Unified operator app
+32. T1, T2 — Test suites
+33. L1 — Log enrichment
+34. D1 — Architecture doc update
+35. D2 — Recurrent novae design
+36. OT8 — UVES reduction pipeline
+37. R10 — spectra.py rebuild
+38. LR1/LR2 — Data donation + provenance
+39. R4 — Smooth pipeline (capstone)
 
 ---
 
 # Completed Tasks
 
-_104 tasks completed across all workstreams._
+_106 tasks completed across all workstreams._
 
 | ID | Task |
 |----|------|
@@ -236,7 +264,7 @@ _104 tasks completed across all workstreams._
 | B29 | Spectral visits regression (pre-feature novae missing DDB field) |
 | BN1 | Bundle generator hardcoded S3 path |
 | BN2 | Bundle metadata.json count vs README count mismatch |
-| BN3 | Empty .bib on partial sweeps (references pre-population) |
+| BN3 | Empty .bib on partial sweeps (reference pre-population) |
 | BN4 | Empty sources.json spectra array |
 | S1 | LTTB downsampling / flat spectra fix |
 | S2 | X-axis truncation |
@@ -256,6 +284,7 @@ _104 tasks completed across all workstreams._
 | S15 | Spectral line feature units Å → nm |
 | S16 | STIS adapter for spectra (MAST HASP discovery + FITS profile) |
 | S17 | Spectral visits catalog column |
+| S22 | SNR gate integration tests (display floor + compositing relative gate) |
 | S23 | ADR-033 spectra compositing pipeline (full implementation) |
 | S24 | DER_SNR fallback + SNR display gate + compositing relative gate |
 | S25 | Equitable vertical spacing (gap capping attempted + reverted; pending R10) |
@@ -271,7 +300,8 @@ _104 tasks completed across all workstreams._
 | F3 | Nova page alias display |
 | F4 | Empty state placeholders |
 | F5 | Observations table (rename + DataProduct fields) |
-| F11 | Discovery date MJD on nova page |
+| F9 | Sources column with archive provider and bibcode display |
+| F11 | Discovery date on nova page |
 | F12 | Spectral visits on nova page |
 | I1 | Underscore normalization |
 | R1 | Idempotency override |

--- a/services/reference_manager/handler.py
+++ b/services/reference_manager/handler.py
@@ -110,7 +110,7 @@ def _get_ads_token() -> str:
 
 def _quote(name: str) -> str:
     """Wrap a name in double-quotes for an ADS query; escape internal quotes."""
-    name = (name or "").strip()
+    name = " ".join((name or "").split())
     return '"' + name.replace('"', r"\"") + '"' if name else ""
 
 

--- a/tests/services/test_reference_manager.py
+++ b/tests/services/test_reference_manager.py
@@ -1155,6 +1155,32 @@ class TestADSCollectionFilter:
 # ===========================================================================
 
 
+class TestQuoteWhitespaceNormalization:
+    @pytest.mark.parametrize(
+        "input_name,expected",
+        [
+            ("HD  21629", '"HD 21629"'),  # internal multi-space collapsed
+            ("  GK Per  ", '"GK Per"'),  # leading/trailing stripped
+            ("AN\t  3.1901", '"AN 3.1901"'),  # tabs and mixed whitespace
+            ("GK Per", '"GK Per"'),  # single-spaced unchanged
+            ("", ""),  # empty string
+            (None, ""),  # None input
+        ],
+    )
+    def test_whitespace_normalization(
+        self, table: Any, input_name: str | None, expected: str
+    ) -> None:
+        with mock_aws():
+            h = _load_handler()
+            result = h._quote(input_name)
+            assert result == expected
+
+
+# ===========================================================================
+# TestFetchAndReconcileReferences
+# ===========================================================================
+
+
 class TestFetchAndReconcileReferences:
     """Unit tests for the combined FetchAndReconcileReferences task."""
 

--- a/tools/catalog-expansion/recurrent_novae.md
+++ b/tools/catalog-expansion/recurrent_novae.md
@@ -1,0 +1,10 @@
+T Pyx — outbursts in 1890, 1902, 1920, 1944, 1966, 2011
+RS Oph — outbursts in 1898, 1933, 1958, 1967, 1985, 2006, 2021
+T CrB — 1866, 1946 (and widely expected to erupt again soon)
+U Sco — 1863, 1906, 1936, 1979, 1987, 1999, 2010, 2022
+V2487 Oph (Nova Oph 1998) — 1900, 1998
+V3890 Sgr — 1962, 1990, 2019
+V745 Sco — 1937, 1989, 2014
+IM Nor — 1920, 2002
+CI Aql — 1917, 1941(?), 2000
+Nova LMC 1968 (YY Dor) — 1937(?), 1968, 2004 (extragalactic, in the LMC)

--- a/tools/run_refresh_references.py
+++ b/tools/run_refresh_references.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+"""
+run_refresh_references.py — Operator tool for running refresh_references
+on individual novae or batches filtered by reference count.
+
+Usage:
+    # 1. List all novae with reference counts
+    python tools/run_refresh_references.py --list
+
+    # 2. Run for a single nova (by name), wait for completion
+    python tools/run_refresh_references.py --name "V5668 Sgr"
+
+    # 3. Run for a single nova (by UUID)
+    python tools/run_refresh_references.py --nova-id <uuid>
+
+    # 4. Run for all novae with fewer than X references
+    python tools/run_refresh_references.py --below 5
+
+    # 5. Dry run (show what would be launched, don't launch)
+    python tools/run_refresh_references.py --below 5 --dry-run
+
+    # 6. Skip waiting (fire and forget)
+    python tools/run_refresh_references.py --name "IM Nor" --no-wait
+
+Personal operator tooling — not subject to CI, mypy strict, or ruff.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import uuid
+
+import boto3
+from boto3.dynamodb.conditions import Key
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+_TABLE_NAME = os.environ.get("NOVA_CAT_TABLE_NAME", "nova-cat")
+_POLL_INTERVAL_S = 10
+_DEFAULT_TIMEOUT_S = 300  # 5 min per execution
+
+# ---------------------------------------------------------------------------
+# Colors
+# ---------------------------------------------------------------------------
+
+_GREEN = "\033[92m"
+_RED = "\033[91m"
+_YELLOW = "\033[93m"
+_CYAN = "\033[96m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+_RESET = "\033[0m"
+
+# ---------------------------------------------------------------------------
+# AWS clients (lazy init)
+# ---------------------------------------------------------------------------
+
+_ddb = None
+_sfn = None
+_table = None
+_sm_arn = None
+
+
+def _init_clients():
+    global _ddb, _sfn, _table
+    _ddb = boto3.resource("dynamodb", region_name=_REGION)
+    _sfn = boto3.client("stepfunctions", region_name=_REGION)
+    _table = _ddb.Table(_TABLE_NAME)
+
+
+def _get_state_machine_arn() -> str:
+    """Find the refresh-references state machine ARN."""
+    global _sm_arn
+    if _sm_arn:
+        return _sm_arn
+
+    paginator = _sfn.get_paginator("list_state_machines")
+    for page in paginator.paginate():
+        for sm in page["stateMachines"]:
+            if "refresh-references" in sm["name"] and "nova-cat" in sm["name"]:
+                _sm_arn = sm["stateMachineArn"]
+                return _sm_arn
+
+    print(f"  {_RED}✗ Could not find nova-cat-refresh-references state machine{_RESET}")
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# DDB queries
+# ---------------------------------------------------------------------------
+
+
+def _resolve_name_to_nova_id(name: str) -> str | None:
+    """Resolve a nova name to nova_id via the NAME# partition."""
+    normalized = name.strip().lower().replace("_", " ")
+    pk = f"NAME#{normalized}"
+    resp = _table.query(
+        KeyConditionExpression=Key("PK").eq(pk),
+        Limit=1,
+    )
+    items = resp.get("Items", [])
+    if not items:
+        return None
+    return items[0].get("nova_id")
+
+
+def _scan_active_novae() -> list[dict]:
+    """Scan for all ACTIVE Nova items."""
+    items = []
+    kwargs = {
+        "FilterExpression": "entity_type = :et AND #s = :status",
+        "ExpressionAttributeNames": {"#s": "status"},
+        "ExpressionAttributeValues": {":et": "Nova", ":status": "ACTIVE"},
+        "ProjectionExpression": "nova_id, primary_name",
+    }
+    while True:
+        resp = _table.scan(**kwargs)
+        items.extend(resp.get("Items", []))
+        if resp.get("LastEvaluatedKey") is None:
+            break
+        kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+    items.sort(key=lambda x: x.get("primary_name", ""))
+    return items
+
+
+def _count_references(nova_id: str) -> int:
+    """Count NOVAREF# items for a nova."""
+    count = 0
+    kwargs = {
+        "KeyConditionExpression": Key("PK").eq(nova_id) & Key("SK").begins_with("NOVAREF#"),
+        "Select": "COUNT",
+    }
+    while True:
+        resp = _table.query(**kwargs)
+        count += resp.get("Count", 0)
+        if resp.get("LastEvaluatedKey") is None:
+            break
+        kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+    return count
+
+
+def _list_novae_with_ref_counts() -> list[dict]:
+    """Return all ACTIVE novae with their reference counts, sorted by count ascending."""
+    novae = _scan_active_novae()
+    results = []
+    for nova in novae:
+        nova_id = nova["nova_id"]
+        name = nova.get("primary_name", "(unnamed)")
+        ref_count = _count_references(nova_id)
+        results.append(
+            {
+                "nova_id": nova_id,
+                "primary_name": name,
+                "ref_count": ref_count,
+            }
+        )
+    results.sort(key=lambda x: (x["ref_count"], x["primary_name"]))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Workflow execution
+# ---------------------------------------------------------------------------
+
+
+def _start_refresh_references(nova_id: str) -> str:
+    """Start a refresh_references execution. Returns execution ARN."""
+    sm_arn = _get_state_machine_arn()
+    correlation_id = f"manual-refresh-{uuid.uuid4().hex[:12]}"
+    job_run_id = str(uuid.uuid4())
+    execution_name = f"{nova_id[:30]}-{job_run_id[:8]}"
+
+    resp = _sfn.start_execution(
+        stateMachineArn=sm_arn,
+        name=execution_name,
+        input=json.dumps(
+            {
+                "nova_id": nova_id,
+                "correlation_id": correlation_id,
+            }
+        ),
+    )
+    return resp["executionArn"]
+
+
+def _poll_execution(exec_arn: str, timeout: int) -> str:
+    """Poll an execution until terminal. Returns final status."""
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        desc = _sfn.describe_execution(executionArn=exec_arn)
+        status = desc["status"]
+        remaining = int(deadline - time.time())
+
+        print(
+            f"\r    {_DIM}⏳ {status}  ({remaining}s remaining){_RESET}      ",
+            end="",
+            flush=True,
+        )
+
+        if status in ("SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED"):
+            print()  # newline after the \r line
+            return status
+
+        time.sleep(_POLL_INTERVAL_S)
+
+    print()
+    return "TIMEOUT_LOCAL"
+
+
+def _run_single(
+    nova_id: str,
+    name: str,
+    wait: bool = True,
+    timeout: int = _DEFAULT_TIMEOUT_S,
+) -> str:
+    """Run refresh_references for a single nova. Returns final status."""
+    print(f"\n  {_BOLD}Launching refresh_references{_RESET}")
+    print(f"    Nova:    {_CYAN}{name}{_RESET}")
+    print(f"    nova_id: {_DIM}{nova_id}{_RESET}")
+
+    try:
+        exec_arn = _start_refresh_references(nova_id)
+    except Exception as e:
+        error_msg = str(e)
+        # Handle ExecutionAlreadyExists — idempotent success
+        if "ExecutionAlreadyExists" in error_msg:
+            print(f"    {_YELLOW}⚠ Execution already exists (idempotent){_RESET}")
+            return "ALREADY_EXISTS"
+        print(f"    {_RED}✗ Failed to start: {e}{_RESET}")
+        return "LAUNCH_FAILED"
+
+    exec_name = exec_arn.split(":")[-1]
+    print(f"    Exec:    {_DIM}{exec_name}{_RESET}")
+
+    if not wait:
+        print(f"    {_DIM}Launched (not waiting){_RESET}")
+        return "LAUNCHED"
+
+    status = _poll_execution(exec_arn, timeout)
+
+    if status == "SUCCEEDED":
+        print(f"    {_GREEN}✓ Succeeded{_RESET}")
+    elif status == "TIMEOUT_LOCAL":
+        print(f"    {_YELLOW}⚠ Local timeout ({timeout}s) — execution may still be running{_RESET}")
+    else:
+        print(f"    {_RED}✗ {status}{_RESET}")
+
+    return status
+
+
+# ---------------------------------------------------------------------------
+# Modes
+# ---------------------------------------------------------------------------
+
+
+def cmd_list(args):
+    """List all novae with reference counts."""
+    _init_clients()
+    print(f"\n{_BOLD}Scanning novae and counting references...{_RESET}\n")
+
+    results = _list_novae_with_ref_counts()
+
+    # Table header
+    print(f"  {'Nova':<30} {'Refs':>6}   {'nova_id'}")
+    print(f"  {'─' * 30} {'─' * 6}   {'─' * 36}")
+
+    for r in results:
+        ref_str = str(r["ref_count"])
+        color = _RED if r["ref_count"] == 0 else (_YELLOW if r["ref_count"] < 5 else "")
+        reset = _RESET if color else ""
+        print(
+            f"  {r['primary_name']:<30} {color}{ref_str:>6}{reset}   {_DIM}{r['nova_id']}{_RESET}"
+        )
+
+    total = len(results)
+    zero = sum(1 for r in results if r["ref_count"] == 0)
+    print(f"\n  {_DIM}{total} novae total, {zero} with zero references{_RESET}\n")
+
+
+def cmd_single(args):
+    """Run refresh_references for a single nova."""
+    _init_clients()
+
+    if args.nova_id:
+        nova_id = args.nova_id
+        name = f"(uuid: {nova_id[:12]}…)"
+        # Try to find the name
+        novae = _scan_active_novae()
+        for n in novae:
+            if n["nova_id"] == nova_id:
+                name = n.get("primary_name", name)
+                break
+    else:
+        nova_id = _resolve_name_to_nova_id(args.name)
+        if not nova_id:
+            print(f"\n  {_RED}✗ Could not resolve name: {args.name!r}{_RESET}\n")
+            sys.exit(1)
+        name = args.name
+
+    ref_count = _count_references(nova_id)
+    print(f"\n  {_DIM}Current references: {ref_count}{_RESET}")
+
+    status = _run_single(
+        nova_id,
+        name,
+        wait=not args.no_wait,
+        timeout=args.timeout,
+    )
+
+    if status == "SUCCEEDED" and not args.no_wait:
+        new_count = _count_references(nova_id)
+        delta = new_count - ref_count
+        delta_str = f"+{delta}" if delta >= 0 else str(delta)
+        print(f"\n  References: {ref_count} → {new_count} ({delta_str})")
+
+    print()
+
+
+def cmd_batch(args):
+    """Run refresh_references for all novae below a reference threshold."""
+    _init_clients()
+
+    threshold = args.below
+    print(f"\n{_BOLD}Scanning novae with fewer than {threshold} references...{_RESET}\n")
+
+    all_novae = _list_novae_with_ref_counts()
+    targets = [r for r in all_novae if r["ref_count"] < threshold]
+
+    if not targets:
+        print(f"  {_DIM}No novae found with fewer than {threshold} references.{_RESET}\n")
+        return
+
+    print(f"  Found {len(targets)} novae:\n")
+    for r in targets:
+        print(f"    {r['primary_name']:<30} ({r['ref_count']} refs)")
+
+    if args.dry_run:
+        print(f"\n  {_YELLOW}[DRY RUN]{_RESET} Would launch {len(targets)} executions.\n")
+        return
+
+    # Confirm
+    print()
+    confirm = (
+        input(f"  Launch {len(targets)} refresh_references executions? [y/N] ").strip().lower()
+    )
+    if confirm != "y":
+        print(f"\n  {_DIM}Aborted.{_RESET}\n")
+        return
+
+    # Run sequentially with wait
+    print()
+    results = {"SUCCEEDED": 0, "FAILED": 0, "OTHER": 0}
+
+    for i, r in enumerate(targets, 1):
+        print(f"  {_DIM}[{i}/{len(targets)}]{_RESET}")
+        status = _run_single(
+            r["nova_id"],
+            r["primary_name"],
+            wait=not args.no_wait,
+            timeout=args.timeout,
+        )
+
+        if status == "SUCCEEDED":
+            results["SUCCEEDED"] += 1
+        elif status in ("FAILED", "TIMED_OUT", "ABORTED", "LAUNCH_FAILED"):
+            results["FAILED"] += 1
+        else:
+            results["OTHER"] += 1
+
+        # Brief pause between launches to avoid throttling
+        if i < len(targets):
+            time.sleep(2)
+
+    # Summary
+    print(f"\n{_BOLD}Batch complete:{_RESET}")
+    print(f"  {_GREEN}✓ Succeeded: {results['SUCCEEDED']}{_RESET}")
+    if results["FAILED"]:
+        print(f"  {_RED}✗ Failed:    {results['FAILED']}{_RESET}")
+    if results["OTHER"]:
+        print(f"  {_YELLOW}? Other:     {results['OTHER']}{_RESET}")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run refresh_references on individual or batched novae.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    # -- list --
+    list_parser = subparsers.add_parser("list", help="List all novae with reference counts")
+    list_parser.set_defaults(func=cmd_list)
+
+    # -- run (single) --
+    run_parser = subparsers.add_parser("run", help="Run refresh_references for a single nova")
+    id_group = run_parser.add_mutually_exclusive_group(required=True)
+    id_group.add_argument("--nova-id", help="Nova UUID")
+    id_group.add_argument("--name", help="Nova name (resolved via NameMapping)")
+    run_parser.add_argument("--no-wait", action="store_true", help="Don't wait for completion")
+    run_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=_DEFAULT_TIMEOUT_S,
+        help=f"Max seconds to wait (default: {_DEFAULT_TIMEOUT_S})",
+    )
+    run_parser.set_defaults(func=cmd_single)
+
+    # -- batch --
+    batch_parser = subparsers.add_parser("batch", help="Run for novae below a reference threshold")
+    batch_parser.add_argument(
+        "--below", type=int, required=True, help="Reference count threshold (exclusive)"
+    )
+    batch_parser.add_argument(
+        "--dry-run", action="store_true", help="Show targets without launching"
+    )
+    batch_parser.add_argument(
+        "--no-wait", action="store_true", help="Don't wait for each execution"
+    )
+    batch_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=_DEFAULT_TIMEOUT_S,
+        help=f"Max seconds per execution (default: {_DEFAULT_TIMEOUT_S})",
+    )
+    batch_parser.set_defaults(func=cmd_batch)
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
+
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Fixed ADS query tokenization bug caused by SIMBAD's fixed-width alias formatting
- Collapsed internal multi-space runs in `_quote()` so ADS treats aliases as proper phrase searches
- Added operator notebook (`run_refresh_references.py`) for single-nova and batch refresh with sync execution tracking
- Added parametrized tests for whitespace normalization edge cases
- Updated master tasks, bug worklog, and recurrent novae reference list

## Why
- SIMBAD returns catalog identifiers with internal padding (e.g. `"HD  21629"`, `"AN    3.1901"`, `"HR  1057"`)
- ADS breaks phrase matching on multi-space runs, tokenizing `"HD  21629"` into separate terms `"HD"` and `"21629"`
- `"HD"` alone matches ~19,000 results; `"HR"` alone matches ~9,000 — flooding novae like GK Per with irrelevant references including Victorian geological surveys and unrelated variable star observations
- Every SIMBAD alias with internal whitespace padding was silently degrading query precision

## Testing
- Binary-searched the GK Per alias list against ADS to isolate `"HD  21629"` and `"HR  1057"` as the culprits
- Confirmed `"HD 21629"` (single space) returns expected results while `"HD  21629"` (double space) returns 19,000
- Rebuilt the full GK Per query with normalized whitespace and verified a reasonable reference count
- Parametrized unit tests cover multi-space collapse, tabs, mixed whitespace, leading/trailing strip, single-space passthrough, empty string, and None

## Notes
- Novae that already ingested garbage references need manual cleanup: `purge_references.py` → `clear_idempotency_locks.py` → re-run `refresh_references` → sweep
- GK Per has been cleaned up; other novae with 2000+ references likely have the same root cause and need the same cycle
- The operator notebook supports both individual and batch refresh to facilitate this

## Next Steps
- Purge and re-run remaining novae with inflated reference counts
- Investigate catalog prefix blocklist to filter SIMBAD catalog identifiers (HD, HR, BD, 2MASS, etc.) from ADS queries entirely — these are never used to refer to novae in papers
- Evaluate `object:` field qualifier for the primary name query — lets ADS handle name resolution via SIMBAD/NED tagging instead of our alias list
- Evaluate `full:` field qualifier for novae returning zero references despite having papers that mention them in the body