### PR TITLE
feat(frontend): redirect / to /catalog and promote stats bar to catalog pages

### DIFF
--- a/docs/adr/ADR-011-Amendment-homepage-redirect.md
+++ b/docs/adr/ADR-011-Amendment-homepage-redirect.md
@@ -1,0 +1,94 @@
+# ADR-011 Amendment — Homepage Redirect
+
+**Amends:** ADR-011 (Frontend Architecture and Design Specification)
+**Status:** Accepted
+**Date:** 2026-04-17
+**Relates to:** ADR-010 (Catalog Navigation Model), ADR-030 (ADR Amendment
+  Policy Revision)
+
+---
+
+## Decision
+
+The root route (`/`) redirects to `/catalog`. No dedicated homepage is rendered.
+
+The aggregate catalog statistics block (formerly on the homepage) now renders at
+the top of every catalog-flavor page — `/catalog` and `/search` — via the
+extracted `StatsBar` component.
+
+This revises ADR-011 §"Page Specifications → Homepage (`/`)" and reinstates
+ADR-010 §"Site Entry Point" as written.
+
+---
+
+## Rationale
+
+**Jump directly into the catalog.** ADR-011 specified a dedicated splash page
+with a hero explainer, stats bar, and top-10 preview table above a "View Full
+Catalog →" link. In practice this introduced an interstitial between the user
+and the catalog — the primary reason the site exists. A researcher typing the
+root URL, or clicking the logo in the nav, should land in the full catalog
+without an additional click.
+
+**The preview table had a sorting defect.** The splash page pre-sorted the full
+catalog by spectra count descending, sliced to the top 10, and handed those 10
+rows to `CatalogTable`. Clicking a different column header re-sorted only those
+10 rows, not the full catalog — users saw a correctly-sorted sample rather than
+the top 10 under their chosen sort. Redirecting to `/catalog` eliminates this
+class of defect entirely: `CatalogTable` always receives the full catalog.
+
+**Stats bar promoted from splash-only to catalog-flavor pages.** Aggregate
+totals are useful context anywhere the catalog table is visible, not only on
+the landing page. Hoisting the stats bar onto `/catalog` and `/search`
+preserves the information while eliminating the splash page that previously
+hosted it. The stats bar is not rendered on nova detail pages, `/docs`, or
+`/about` — those surfaces have their own contextual framing and do not need
+catalog totals.
+
+**Hero explainer is absorbed elsewhere or deleted.** The 2–4 sentence explainer
+copy from the splash page is superseded by the `/about` page, which already
+serves that role. No prose content is lost.
+
+---
+
+## Amendment Classification
+
+The decisions in ADR-011 §"Homepage" have been reflected in deployed
+infrastructure (the splash page is live at the public Vercel deployment).
+Per ADR-030 Decision 1, this makes direct body amendment of ADR-011
+inappropriate. This separate amendment file records the revised decision while
+preserving ADR-011's original text unchanged.
+
+ADR-011's other sections — tech stack, catalog page spec, nova page layout,
+visual design direction, typography, accessibility guidance — are unaffected by
+this amendment.
+
+---
+
+## Implementation
+
+| Source | Change |
+|---|---|
+| `frontend/src/components/catalog/StatsBar.tsx` | New component. Extracted `StatsBar` + private `StatCard` helper from the former `app/page.tsx`. |
+| `frontend/src/app/page.tsx` | Collapsed to a three-line server-component redirect to `/catalog`. Former splash layout removed. |
+| `frontend/src/app/catalog/page.tsx` | Pulls `stats` from `getCatalogData()` and renders `<StatsBar>` above the page heading. |
+| `frontend/src/app/search/page.tsx` | Same addition as `/catalog`. |
+| `docs/adr/ADR-011-frontend-architecture-and-design-spec.md` | Unchanged. A top-level annotation pointing to this amendment may be added in a subsequent pass if ADR-011 is revisited for other reasons; not required by this amendment. |
+
+No changes to `NavBar` are required. The logo already links to `/` and rides
+the new redirect correctly.
+
+---
+
+## Forward Compatibility
+
+The `StatsBar` component is the surface on which two queued frontend tasks will
+extend the stats display:
+
+- **F7** — Total unique spectral visits in the stats display. Adds a fourth
+  card or replaces one of the existing three.
+- **F8** — Stats broken out by spectral regime. Likely introduces a variant
+  layout (per-regime breakdown), rendered in place of or below the current
+  aggregate cards on `/catalog` and `/search`.
+
+Both tasks operate on the extracted component rather than per-page duplication.

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/app/catalog/page.tsx
+++ b/frontend/src/app/catalog/page.tsx
@@ -1,11 +1,13 @@
 /**
  * Catalog page — /catalog
  *
- * Primary browsing interface (ADR-010, ADR-011).
- * Renders the full catalog as a paginated, sortable, searchable table.
+ * Primary browsing interface and the canonical entry point for the site
+ * (ADR-010; reinstated by ADR-011 Amendment: Homepage Redirect).
  *
- * CatalogTable owns the search bar and pagination controls internally —
- * this page only needs to supply the novae array and a heading.
+ * Renders the full catalog as a paginated, sortable, searchable table,
+ * preceded by the aggregate stats bar. CatalogTable owns the search bar
+ * and pagination controls internally — this page supplies the novae
+ * array, the stats block, and the heading.
  *
  * Server Component: catalog data is read at build time. No client-side
  * fetch is needed; the component tree is interactive via CatalogTable's
@@ -13,6 +15,7 @@
  */
 
 import { CatalogTable } from '@/components/catalog/CatalogTable';
+import { StatsBar } from '@/components/catalog/StatsBar';
 import { getCatalogData } from '@/lib/catalog';
 import { resolveRelease } from '@/lib/dataClient';
 
@@ -23,13 +26,20 @@ export const metadata = {
 };
 
 export default async function CatalogPage() {
-  const [{ novae }, releaseId] = await Promise.all([
+  const [{ stats, novae }, releaseId] = await Promise.all([
     getCatalogData(),
     resolveRelease().catch(() => 'local'),
   ]);
 
   return (
     <div className="py-10 flex flex-col gap-8">
+
+      {/* ── Stats bar ────────────────────────────────────────────────── */}
+      {/*
+       * ADR-011 Amendment: stats render at the top of every catalog-flavor
+       * page. Numbers reflect the release currently being served.
+       */}
+      <StatsBar stats={stats} />
 
       {/* ── Page heading ─────────────────────────────────────────────── */}
       {/*

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,158 +1,23 @@
 /**
- * Homepage — /
+ * Root — /
  *
- * Layout (ADR-011):
- *   1. Hero / explainer section
- *   2. Stats bar  (stats block from catalog.json — ADR-014)
- *   3. Catalog preview table (top 10 novae, preview mode — ADR-011)
+ * Redirects to /catalog, which is the primary entry point for the site
+ * (ADR-010 §"Site Entry Point", reinstated by ADR-011 Amendment:
+ * Homepage Redirect).
  *
- * This is a Server Component. Catalog data is read at build time via the
- * shared getCatalogData() helper. No client-side fetch is required.
+ * The dedicated splash page formerly at this route — hero explainer,
+ * stats bar, top-10 preview table — has been removed so users land
+ * directly in the catalog without an intermediate page. The stats bar
+ * now lives on /catalog and /search via the extracted StatsBar
+ * component (src/components/catalog/StatsBar.tsx).
+ *
+ * 307 (temporary) is used for simplicity. If this routing decision
+ * becomes settled long-term, swap in `permanentRedirect` from
+ * next/navigation for a 308.
  */
 
-import Link from 'next/link';
-import { CatalogTable } from '@/components/catalog/CatalogTable';
-import { getCatalogData } from '@/lib/catalog';
-import { resolveRelease } from '@/lib/dataClient';
-import type { CatalogStats } from '@/types/catalog';
+import { redirect } from 'next/navigation';
 
-// ── Stats bar ────────────────────────────────────────────────────────────────
-
-interface StatCardProps {
-  value: number;
-  label: string;
-}
-
-/**
- * Individual stats bar card.
- * ADR-012 card pattern: bg-surface-secondary, border border-border-subtle,
- * rounded-lg, p-6. Numeral: text-4xl semibold. Label: text-sm normal.
- */
-function StatCard({ value, label }: StatCardProps) {
-  return (
-    <div className="bg-surface-secondary border border-border-subtle rounded-lg p-6">
-      {/*
-       * toLocaleString() formats large numbers with locale-appropriate
-       * thousands separators (e.g. 8,940 rather than 8940).
-       */}
-      <div className="text-4xl font-semibold leading-tight text-text-primary">
-        {value.toLocaleString()}
-      </div>
-      <div className="text-sm text-text-secondary mt-2">{label}</div>
-    </div>
-  );
-}
-
-function StatsBar({ stats }: { stats: CatalogStats }) {
-  return (
-    <section aria-label="Catalog statistics">
-      <div className="grid grid-cols-3 gap-6">
-        <StatCard value={stats.nova_count} label="Novae in catalog" />
-        <StatCard value={stats.spectra_count} label="Validated spectra" />
-        <StatCard
-          value={stats.photometry_count}
-          label="Photometric observations"
-        />
-      </div>
-    </section>
-  );
-}
-
-// ── Page ─────────────────────────────────────────────────────────────────────
-
-export default async function HomePage() {
-  const [{ stats, novae }, releaseId] = await Promise.all([
-    getCatalogData(),
-    resolveRelease().catch(() => 'local'),
-  ]);
-
-  /*
-   * The homepage preview table shows the top 10 novae by spectra count —
-   * the same default sort CatalogTable applies internally. Sorting here on
-   * the server ensures the preview matches what the full catalog page shows
-   * at the top of its first page.
-   */
-  const previewNovae = [...novae]
-    .sort((a, b) => b.spectra_count - a.spectra_count)
-    .slice(0, 10);
-
-  return (
-    <div className="py-12 flex flex-col gap-16">
-
-      {/* ── Hero ─────────────────────────────────────────────────────── */}
-      {/*
-       * ADR-011: "2–4 sentences. Aimed at a researcher encountering the site
-       * for the first time. No large decorative imagery."
-       * ADR-012: page heading text-3xl semibold; body text-base leading-relaxed.
-       */}
-      <section>
-        <h1 className="text-3xl font-semibold leading-tight text-text-primary mb-6">
-          Open Nova Catalog
-        </h1>
-        <p className="text-base leading-relaxed text-text-secondary max-w-2xl">
-          The Open Nova Catalog is a curated, publicly accessible repository of
-          observational data for classical novae. It collects spectroscopic and
-          photometric records drawn from published literature and public archives,
-          structured for direct browsing and programmatic access. The catalog is
-          designed to support reproducible nova research and to serve as a shared
-          reference resource for the community.
-        </p>
-      </section>
-
-      {/* ── Stats bar ────────────────────────────────────────────────── */}
-      <StatsBar stats={stats} />
-
-      {/* ── Catalog preview ──────────────────────────────────────────── */}
-      {/*
-       * ADR-011: "A non-paginated sample of the full catalog (e.g. the top
-       * 10 entries by default sort order). Uses the same component and column
-       * configuration as the full catalog page."
-       * The `preview` prop suppresses the search bar and pagination controls
-       * inside CatalogTable. We slice to 10 rows above; the component renders
-       * all rows it receives when preview=true.
-       */}
-      <section>
-        <div className="flex items-baseline justify-between mb-6">
-          <h2 className="text-2xl font-semibold text-text-primary">
-            Catalog preview
-          </h2>
-          {novae.length > 0 && (
-            <Link
-              href="/catalog"
-              className="text-sm font-medium text-interactive no-underline hover:underline"
-            >
-              View full catalog →
-            </Link>
-          )}
-        </div>
-
-        {previewNovae.length > 0 ? (
-          <>
-            <CatalogTable novae={previewNovae} releaseId={releaseId} preview />
-            {/*
-             * "View Full Catalog" link below the table as well, per ADR-011.
-             * The one in the heading is the primary affordance; this one is
-             * a convenience for users who read to the bottom of the preview.
-             */}
-            <div className="mt-6 flex justify-end">
-              <Link
-                href="/catalog"
-                className="text-sm font-medium text-interactive no-underline hover:underline"
-              >
-                View full catalog →
-              </Link>
-            </div>
-          </>
-        ) : (
-          // Empty state: catalog.json not yet populated during development.
-          <p className="py-8 text-sm text-text-tertiary">
-            Catalog data is not yet available. Run the generation pipeline to
-            populate{' '}
-            <code className="font-mono text-xs">public/data/catalog.json</code>.
-          </p>
-        )}
-      </section>
-
-    </div>
-  );
+export default function HomePage(): never {
+  redirect('/catalog');
 }

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -9,6 +9,9 @@
  *   1. The heading and copy are oriented around search rather than browsing.
  *   2. The search input is auto-focused on mount (autoFocusSearch prop).
  *
+ * Like /catalog, this page renders the aggregate stats bar at the top
+ * (ADR-011 Amendment: Homepage Redirect).
+ *
  * PREREQUISITE — one prop addition needed on CatalogTable before deploying:
  * ─────────────────────────────────────────────────────────────────────────
  * In CatalogTableProps (src/components/catalog/CatalogTable.tsx), add:
@@ -33,6 +36,7 @@
  */
 
 import { CatalogTable } from '@/components/catalog/CatalogTable';
+import { StatsBar } from '@/components/catalog/StatsBar';
 import { getCatalogData } from '@/lib/catalog';
 
 export const metadata = {
@@ -42,10 +46,17 @@ export const metadata = {
 };
 
 export default async function SearchPage() {
-  const { novae } = await getCatalogData();
+  const { stats, novae } = await getCatalogData();
 
   return (
     <div className="py-10 flex flex-col gap-8">
+
+      {/* ── Stats bar ────────────────────────────────────────────────── */}
+      {/*
+       * ADR-011 Amendment: stats render at the top of every catalog-flavor
+       * page. Consistent with /catalog.
+       */}
+      <StatsBar stats={stats} />
 
       {/* ── Page heading ─────────────────────────────────────────────── */}
       {/*

--- a/frontend/src/components/catalog/StatsBar.tsx
+++ b/frontend/src/components/catalog/StatsBar.tsx
@@ -1,0 +1,73 @@
+/**
+ * Stats bar — aggregate catalog statistics.
+ *
+ * Renders a three-card horizontal strip summarizing the catalog at a glance:
+ * nova count, validated spectra count, photometric observation count.
+ *
+ * Used at the top of every "catalog-flavor" page — /catalog and /search
+ * (ADR-011 Amendment: Homepage Redirect). Not rendered on nova detail pages,
+ * the documentation page, or the about page.
+ *
+ * Values are drawn from catalog.json's stats block (ADR-014) and are therefore
+ * always current for the release being rendered.
+ *
+ * Design tokens (ADR-012):
+ *   - Card: bg-surface-secondary, border border-border-subtle, rounded-lg, p-6
+ *   - Numeral: text-4xl semibold, leading-tight, text-text-primary
+ *   - Label: text-sm text-text-secondary
+ */
+
+import type { CatalogStats } from '@/types/catalog';
+
+// ── Individual card ──────────────────────────────────────────────────────────
+
+interface StatCardProps {
+  value: number;
+  label: string;
+}
+
+/**
+ * Single stats card. Private to this file — StatsBar is the only consumer,
+ * and the card composition isn't meaningful on its own.
+ */
+function StatCard({ value, label }: StatCardProps) {
+  return (
+    <div className="bg-surface-secondary border border-border-subtle rounded-lg p-6">
+      {/*
+       * toLocaleString() formats large numbers with locale-appropriate
+       * thousands separators (e.g. 8,940 rather than 8940).
+       */}
+      <div className="text-4xl font-semibold leading-tight text-text-primary">
+        {value.toLocaleString()}
+      </div>
+      <div className="text-sm text-text-secondary mt-2">{label}</div>
+    </div>
+  );
+}
+
+// ── Stats bar ────────────────────────────────────────────────────────────────
+
+interface StatsBarProps {
+  stats: CatalogStats;
+}
+
+/**
+ * Three-card horizontal stats strip. Drops in above a page's primary content.
+ *
+ * The `aria-label` on the containing section makes the block addressable by
+ * assistive technology as a single landmark rather than three orphan cards.
+ */
+export function StatsBar({ stats }: StatsBarProps) {
+  return (
+    <section aria-label="Catalog statistics">
+      <div className="grid grid-cols-3 gap-6">
+        <StatCard value={stats.nova_count} label="Novae in catalog" />
+        <StatCard value={stats.spectra_count} label="Validated spectra" />
+        <StatCard
+          value={stats.photometry_count}
+          label="Photometric observations"
+        />
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- `/` now redirects to `/catalog` (ADR-010 §"Site Entry Point" reinstated)
- Extracted `StatsBar` into `components/catalog/StatsBar.tsx` — reusable from any page
- Stats bar now renders at the top of `/catalog` and `/search`
- Added ADR-011 Amendment recording the revised decision

## Why
- The dedicated splash page put an interstitial between users and the catalog
- Stats are useful context anywhere the catalog is visible, not only on a landing page
- F7 (spectral visits in stats) and F8 (stats by regime) both build on an extracted
  `StatsBar` — doing F6 first sets up those tasks cleanly

## Testing
- `cd frontend && npx next build` — clean build, no new type errors
- Dev build verified locally:
  - Visiting `/` redirects to `/catalog`
  - Stats bar appears above the heading on `/catalog` and `/search`
  - Stats bar does NOT appear on `/nova/*`, `/docs`, `/about` (unchanged)
  - Column header sort operates on the full catalog (verification limited by
    the 2-fixture local dataset; behavior is structurally guaranteed now that
    no slicing path exists)

## Bugs Fixed
- `bugs_list_4_17_26.md` item 2 — "when you click to, e.g., sort by references,
  it only sorts by references on that page (likely an issue with the splash page
  not being the catalog)." The redirect eliminates the pre-sort-and-slice path
  that caused this, so it closes as a side effect of F6 rather than needing its
  own fix.

## Notes
- ADR-011's "Artifact Consumption Model" table still lists "Homepage preview" as
  a consumer of `catalog.json`. That reference is stale post-F6 but was left
  untouched on purpose — per ADR-030, ADR-011's body is immutable because its
  decisions were reflected in deployed infrastructure (the splash page was live
  on Vercel). The amendment file is the correct channel for the revision.
- `CatalogTable` still accepts a `preview` prop, which no caller uses after this
  change. Leaving the dead prop in place to keep the diff scoped; flagged for a
  follow-up cleanup task (see Next Steps).
- No changes to `NavBar` — the logo links to `/` and rides the new redirect.
- 307 (temporary) used on the redirect. If the routing decision feels settled
  long-term, swap `redirect` → `permanentRedirect` for a 308.

## Next Steps
- Mark F6 ✅ in `master-tasks.md`; increment scoreboard (done 106→107,
  features-remaining 37→36)
- Mark `bugs_list_4_17_26.md` item 2 as resolved
- Add a small `R`-series cleanup task: "Remove unused `preview` prop from
  `CatalogTable` (dead after F6)"
- F7 (spectral visits in stats) now has a clean surface to extend